### PR TITLE
retain package when simple name ambiguous in compressType

### DIFF
--- a/src/main/java/com/squareup/java/JavaWriter.java
+++ b/src/main/java/com/squareup/java/JavaWriter.java
@@ -143,7 +143,12 @@ public final class JavaWriter implements Closeable {
       if (imported != null) {
         sb.append(imported);
       } else if (isClassInPackage(name)) {
-        sb.append(name.substring(packagePrefix.length()));
+        String compressed = name.substring(packagePrefix.length());
+        if (isAmbiguous(compressed)) {
+          sb.append(name);
+        } else {
+          sb.append(compressed);
+        }
       } else if (name.startsWith("java.lang.")) {
         sb.append(name.substring("java.lang.".length()));
       } else {
@@ -165,6 +170,15 @@ public final class JavaWriter implements Closeable {
       }
     }
     return false;
+  }
+
+  /**
+   * Returns true if the imports contain a class with same simple name as {@code compressed}.
+   *
+   * @param compressed simple name of the type
+   */
+  private boolean isAmbiguous(String compressed) {
+    return importedTypes.values().contains(compressed);
   }
 
   /**

--- a/src/test/java/com/squareup/java/JavaWriterTest.java
+++ b/src/test/java/com/squareup/java/JavaWriterTest.java
@@ -461,6 +461,13 @@ public final class JavaWriterTest {
     assertThat(actual).isEqualTo("Binding<? extends Foo.Blah>");
   }
 
+  @Test public void compressSimpleNameCollisionInSamePackage() throws IOException {
+    javaWriter.emitPackage("denominator");
+    javaWriter.emitImports("javax.inject.Provider", "dagger.internal.Binding");
+    String actual = javaWriter.compressType("dagger.internal.Binding<denominator.Provider>");
+    assertThat(actual).isEqualTo("Binding<denominator.Provider>");
+  }
+
   private void assertCode(String expected) {
     assertThat(stringWriter.toString()).isEqualTo(expected);
   }


### PR DESCRIPTION
fix issue #8: retain package when simple name ambiguous in compressType
