### PR TITLE
Make type compression optional.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .classpath
 .project
 .settings
+.checkstyle
 eclipsebin
 
 bin


### PR DESCRIPTION
This pull request is really small but it solves the problem of conflicting imports. 

I think this mechanism should be kept even if the branch of lazy import management is merged. It makes bigger java files of course, but I am pretty sure I am not the only one not to care about it. :)

This merge is needed for BoundBox to work properly : https://github.com/stephanenicolas/boundbox/issues/4

I could respect checkstyle of the project, but couldn't run the tests. So I didn't add one for this feature. I would be pleased to if someone wants to take some time to help me running the tests. 

BTW, I signed the licence agreement.
