### PR TITLE
Configurable indent

### DIFF
--- a/src/main/java/com/squareup/javawriter/JavaWriter.java
+++ b/src/main/java/com/squareup/javawriter/JavaWriter.java
@@ -61,12 +61,12 @@ public class JavaWriter implements Closeable {
     return isCompressingTypes;
   }
 
-  public void setIndent(int indent) {
-    this.indent = new String(new char[indent]).replace("\0", " ");
+  public void setIndent(String indent) {
+    this.indent = indent;
   }
 
-  public int getIndent() {
-    return indent.length();
+  public String getIndent() {
+    return indent;
   }
 
   /** Emit a package declaration and empty line. */

--- a/src/test/java/com/squareup/javawriter/JavaWriterTest.java
+++ b/src/test/java/com/squareup/javawriter/JavaWriterTest.java
@@ -645,7 +645,7 @@ public final class JavaWriterTest {
   }
 
   @Test public void configurableIndent() throws IOException {
-    javaWriter.setIndent(4);
+    javaWriter.setIndent("    ");
     javaWriter.emitPackage("com.squareup");
     javaWriter.beginType("com.squareup.Foo", "class");
     javaWriter.emitField("String", "bar");


### PR DESCRIPTION
The current implementation uses a fixed indent of two spaces. This pull request made that configurable by using

``` java
writer.setIndent("    ");
// or
writer.setIndent("\t");
```

Default is still 2 spaces, to ensure backwards compatibility. Unit test is included.
