### PR TITLE
Do not emit trailing white-space for empty javadoc lines.

### DIFF
--- a/src/main/java/com/squareup/javawriter/JavaWriter.java
+++ b/src/main/java/com/squareup/javawriter/JavaWriter.java
@@ -448,8 +448,11 @@ public class JavaWriter implements Closeable {
     out.write("/**\n");
     for (String line : formatted.split("\n")) {
       indent();
-      out.write(" * ");
-      out.write(line);
+      out.write(" *");
+      if (!line.isEmpty()) {
+        out.write(" ");
+        out.write(line);
+      }
       out.write("\n");
     }
     indent();

--- a/src/test/java/com/squareup/javawriter/JavaWriterTest.java
+++ b/src/test/java/com/squareup/javawriter/JavaWriterTest.java
@@ -552,6 +552,17 @@ public final class JavaWriterTest {
         + " */\n");
   }
 
+  @Test public void multilineJavadocDoesNotEmitTrailingSpaceForEmptyLines() throws IOException {
+    javaWriter.emitJavadoc("Foo\n\nBar");
+    assertCode(""
+        + "/**\n"
+        + " * Foo\n"
+        + " *\n"
+        + " * Bar\n"
+        + " */\n"
+    );
+  }
+
   @Test public void testStringLiteral() {
     assertThat(JavaWriter.stringLiteral("")).isEqualTo("\"\"");
     assertThat(JavaWriter.stringLiteral("JavaWriter")).isEqualTo("\"JavaWriter\"");


### PR DESCRIPTION
This occurs when multiple newlines are present. While the HTML-rendered Javadoc will collapse these, we preserve them for the sake of continuity with input.

@swankjesse @danrice-square
