### PR TITLE
Properly handle subpackages of java.lang in compressType.

### DIFF
--- a/src/main/java/com/squareup/javawriter/JavaWriter.java
+++ b/src/main/java/com/squareup/javawriter/JavaWriter.java
@@ -187,14 +187,14 @@ public class JavaWriter implements Closeable {
       String imported = importedTypes.get(name);
       if (imported != null) {
         sb.append(imported);
-      } else if (isClassInPackage(name)) {
+      } else if (isClassInPackage(name, packagePrefix)) {
         String compressed = name.substring(packagePrefix.length());
         if (isAmbiguous(compressed)) {
           sb.append(name);
         } else {
           sb.append(compressed);
         }
-      } else if (name.startsWith("java.lang.")) {
+      } else if (isClassInPackage(name, "java.lang.")) {
         sb.append(name.substring("java.lang.".length()));
       } else {
         sb.append(name);
@@ -204,7 +204,7 @@ public class JavaWriter implements Closeable {
     return sb.toString();
   }
 
-  private boolean isClassInPackage(String name) {
+  private static boolean isClassInPackage(String name, String packagePrefix) {
     if (name.startsWith(packagePrefix)) {
       if (name.indexOf('.', packagePrefix.length()) == -1) {
         return true;

--- a/src/test/java/com/squareup/javawriter/JavaWriterTest.java
+++ b/src/test/java/com/squareup/javawriter/JavaWriterTest.java
@@ -737,6 +737,18 @@ public final class JavaWriterTest {
     assertThat(actual).isEqualTo("Binding<denominator.Provider>");
   }
 
+  @Test public void compressJavaLangClass() throws IOException {
+    javaWriter.emitPackage("com.blah");
+    String actual = javaWriter.compressType("java.lang.Class");
+    assertThat(actual).isEqualTo("Class");
+  }
+
+  @Test public void compressJavaLangSubPackageClass() throws IOException {
+    javaWriter.emitPackage("com.blah");
+    String actual = javaWriter.compressType("java.lang.annotation.Annotation");
+    assertThat(actual).isEqualTo("java.lang.annotation.Annotation");
+  }
+
   @Test public void configurableIndent() throws IOException {
     javaWriter.setIndent("    ");
     javaWriter.emitPackage("com.squareup");


### PR DESCRIPTION
Previously, all types prefixed by java.lang would have the java.lang prefix
removed even if they weren't in that package leading to invalid types in
the written source.

This fixes issue #39
