### PR TITLE
Skip work when modifier set is empty.

### DIFF
--- a/src/main/java/com/squareup/javawriter/JavaWriter.java
+++ b/src/main/java/com/squareup/javawriter/JavaWriter.java
@@ -798,6 +798,9 @@ public class JavaWriter implements Closeable {
 
   /** Emits the modifiers to the writer. */
   private void emitModifiers(Set<Modifier> modifiers) throws IOException {
+    if (modifiers.isEmpty()) {
+      return;
+    }
     // Use an EnumSet to ensure the proper ordering
     if (!(modifiers instanceof EnumSet)) {
       modifiers = EnumSet.copyOf(modifiers);

--- a/src/test/java/com/squareup/javawriter/JavaWriterTest.java
+++ b/src/test/java/com/squareup/javawriter/JavaWriterTest.java
@@ -849,6 +849,17 @@ public final class JavaWriterTest {
         + "}\n");
   }
 
+  @Test public void emptyNonEnumModifierSet() throws IOException {
+    javaWriter.emitPackage("com.squareup");
+    javaWriter.beginType("com.squareup.Foo", "class", new LinkedHashSet<Modifier>());
+    javaWriter.endType();
+    assertCode(""
+        + "package com.squareup;\n"
+        + "\n"
+        + "class Foo {\n"
+        + "}\n");
+  }
+
   private void assertCode(String expected) {
     assertThat(stringWriter.toString()).isEqualTo(expected);
   }


### PR DESCRIPTION
This both avoids an exception from EnumSet.copyOf when empty and avoids wasting an iterator on looping over an empty set.

Closes #52.
