### PR TITLE
Use canonical class name when importing as class.

### DIFF
--- a/src/main/java/com/squareup/javawriter/JavaWriter.java
+++ b/src/main/java/com/squareup/javawriter/JavaWriter.java
@@ -95,7 +95,7 @@ public class JavaWriter implements Closeable {
   public JavaWriter emitImports(Class<?>... types) throws IOException {
     List<String> classNames = new ArrayList<String>(types.length);
     for (Class<?> classToImport : types) {
-      classNames.add(classToImport.getName());
+      classNames.add(classToImport.getCanonicalName());
     }
     return emitImports(classNames);
   }

--- a/src/test/java/com/squareup/javawriter/JavaWriterTest.java
+++ b/src/test/java/com/squareup/javawriter/JavaWriterTest.java
@@ -458,6 +458,25 @@ public final class JavaWriterTest {
         + "}\n");
   }
 
+  @Test
+  public void addNestedClassImportAsClass() throws IOException {
+    javaWriter.emitPackage("com.squareup");
+    javaWriter.emitImports(NestedClass.class);
+    javaWriter.beginType("com.squareup.Foo", "class", EnumSet.of(PUBLIC, FINAL));
+    javaWriter.emitField("com.squareup.javawriter.JavaWriterTest.NestedClass", "nestedClass",
+        EnumSet.noneOf(Modifier.class), "new NestedClass()");
+    javaWriter.endType();
+    assertCode(""
+        + "package com.squareup;\n"
+        + "\n"
+        + "import com.squareup.javawriter.JavaWriterTest.NestedClass;\n"
+        + "public final class Foo {\n"
+        + "  NestedClass nestedClass = new NestedClass();\n"
+        + "}\n");
+  }
+
+  public static class NestedClass {}
+
   @Test public void addStaticWildcardImport() throws IOException {
     javaWriter.emitPackage("com.squareup");
     javaWriter.emitStaticImports("java.lang.System.*");


### PR DESCRIPTION
`emitImports(Parent.Nested.class)` would write `import some.pkg.Parent$Nested;`. Even though it's valid import, having `.` instead of `$` is more natural and keeps compressing `some.pkg.Parent.Nested` occurrences correctly.
