### PR TITLE
Add a StringLiteral class as a replacement for JavaWriter.StringLiteral

### DIFF
--- a/src/main/java/com/squareup/javawriter/JavaWriter.java
+++ b/src/main/java/com/squareup/javawriter/JavaWriter.java
@@ -735,44 +735,14 @@ public class JavaWriter implements Closeable {
     return this;
   }
 
-  /** Returns the string literal representing {@code data}, including wrapping quotes. */
+  /**
+   * Returns the string literal representing {@code data}, including wrapping quotes.
+   *
+   * @deprecated use {@link StringLiteral} and its {@link StringLiteral#literal()} method instead.
+   */
+  @Deprecated
   public static String stringLiteral(String data) {
-    StringBuilder result = new StringBuilder();
-    result.append('"');
-    for (int i = 0; i < data.length(); i++) {
-      char c = data.charAt(i);
-      switch (c) {
-        case '"':
-          result.append("\\\"");
-          break;
-        case '\\':
-          result.append("\\\\");
-          break;
-        case '\b':
-          result.append("\\b");
-          break;
-        case '\t':
-          result.append("\\t");
-          break;
-        case '\n':
-          result.append("\\n");
-          break;
-        case '\f':
-          result.append("\\f");
-          break;
-        case '\r':
-          result.append("\\r");
-          break;
-        default:
-          if (Character.isISOControl(c)) {
-            result.append(String.format("\\u%04x", (int) c));
-          } else {
-            result.append(c);
-          }
-      }
-    }
-    result.append('"');
-    return result.toString();
+    return StringLiteral.forValue(data).literal();
   }
 
   /** Build a string representation of a type and optionally its generic type arguments. */

--- a/src/main/java/com/squareup/javawriter/StringLiteral.java
+++ b/src/main/java/com/squareup/javawriter/StringLiteral.java
@@ -1,0 +1,91 @@
+// Copyright 2014 Square, Inc.
+package com.squareup.javawriter;
+
+import java.util.Formatter;
+
+/**
+ * Represents a string literal as found in Java source code.
+ */
+public final class StringLiteral {
+  /** Returns a new {@link StringLiteral} instance for the intended value of the literal. */
+  public static StringLiteral forValue(String value) {
+    return new StringLiteral(value, stringLiteral(value));
+  }
+
+  /** Returns the string literal representing {@code data}, including wrapping quotes. */
+  private static String stringLiteral(String value) {
+    StringBuilder result = new StringBuilder();
+    result.append('"');
+    for (int i = 0; i < value.length(); i++) {
+      char c = value.charAt(i);
+      switch (c) {
+        case '"':
+          result.append("\\\"");
+          break;
+        case '\\':
+          result.append("\\\\");
+          break;
+        case '\b':
+          result.append("\\b");
+          break;
+        case '\t':
+          result.append("\\t");
+          break;
+        case '\n':
+          result.append("\\n");
+          break;
+        case '\f':
+          result.append("\\f");
+          break;
+        case '\r':
+          result.append("\\r");
+          break;
+        default:
+          if (Character.isISOControl(c)) {
+            new Formatter(result).format("\\u%04x", (int) c);
+          } else {
+            result.append(c);
+          }
+      }
+    }
+    result.append('"');
+    return result.toString();
+  }
+
+  private final String value;
+  private final String literal;
+
+  private StringLiteral(String value, String literal) {
+    this.value = value;
+    this.literal = literal;
+  }
+
+  public String value() {
+    return value;
+  }
+
+  public String literal() {
+    return literal;
+  }
+
+  @Override
+  public String toString() {
+    return literal;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == this) {
+      return true;
+    } else if (obj instanceof StringLiteral) {
+      return this.value.equals(((StringLiteral) obj).value);
+    } else {
+      return false;
+    }
+  }
+
+  @Override
+  public int hashCode() {
+    return value.hashCode();
+  }
+}

--- a/src/test/java/com/squareup/javawriter/JavaWriterTest.java
+++ b/src/test/java/com/squareup/javawriter/JavaWriterTest.java
@@ -17,7 +17,6 @@ import java.util.Set;
 import javax.lang.model.element.Modifier;
 import org.junit.Test;
 
-import static com.squareup.javawriter.JavaWriter.stringLiteral;
 import static javax.lang.model.element.Modifier.ABSTRACT;
 import static javax.lang.model.element.Modifier.FINAL;
 import static javax.lang.model.element.Modifier.PRIVATE;
@@ -605,7 +604,7 @@ public final class JavaWriterTest {
     javaWriter.emitImports("javax.inject.Singleton");
     javaWriter.emitAnnotation("javax.inject.Singleton");
     javaWriter.emitAnnotation(SuppressWarnings.class,
-        JavaWriter.stringLiteral("unchecked"));
+        StringLiteral.forValue("unchecked"));
     javaWriter.beginType("com.squareup.Foo", "class");
     javaWriter.endType();
     assertCode(""
@@ -651,7 +650,7 @@ public final class JavaWriterTest {
 
   @Test public void annotatedWithSingleValueAttribute() throws IOException {
     Map<String, Object> attributes = new LinkedHashMap<String, Object>();
-    attributes.put("value", stringLiteral("blah.Generator"));
+    attributes.put("value", StringLiteral.forValue("blah.Generator"));
 
     javaWriter.emitPackage("com.squareup");
     javaWriter.emitAnnotation("Generated", attributes);
@@ -775,40 +774,6 @@ public final class JavaWriterTest {
         + " * Bar\n"
         + " */\n"
     );
-  }
-
-  @Test public void testStringLiteral() {
-    assertThat(JavaWriter.stringLiteral("")).isEqualTo("\"\"");
-    assertThat(JavaWriter.stringLiteral("JavaWriter")).isEqualTo("\"JavaWriter\"");
-    assertThat(JavaWriter.stringLiteral("\\")).isEqualTo("\"\\\\\"");
-    assertThat(JavaWriter.stringLiteral("\"")).isEqualTo("\"\\\"\"");
-    assertThat(JavaWriter.stringLiteral("\b")).isEqualTo("\"\\b\"");
-    assertThat(JavaWriter.stringLiteral("\t")).isEqualTo("\"\\t\"");
-    assertThat(JavaWriter.stringLiteral("\n")).isEqualTo("\"\\n\"");
-    assertThat(JavaWriter.stringLiteral("\f")).isEqualTo("\"\\f\"");
-    assertThat(JavaWriter.stringLiteral("\r")).isEqualTo("\"\\r\"");
-
-    // Control characters
-    for (char i = 0x1; i <= 0x1f; i++) {
-      checkCharEscape(i);
-    }
-    for (char i = 0x7f; i <= 0x9f; i++) {
-      checkCharEscape(i);
-    }
-  }
-
-  private void checkCharEscape(char codePoint) {
-    String test = "" + codePoint;
-    String expected;
-    switch (codePoint) {
-      case 8: expected = "\"\\b\""; break;
-      case 9: expected = "\"\\t\""; break;
-      case 10: expected = "\"\\n\""; break;
-      case 12: expected = "\"\\f\""; break;
-      case 13: expected = "\"\\r\""; break;
-      default: expected = "\"\\u" + String.format("%04x", (int) codePoint) + "\"";
-    }
-    assertThat(JavaWriter.stringLiteral(test)).isEqualTo(expected);
   }
 
   @Test public void testType() {

--- a/src/test/java/com/squareup/javawriter/StringLiteralTest.java
+++ b/src/test/java/com/squareup/javawriter/StringLiteralTest.java
@@ -1,0 +1,46 @@
+// Copyright 2014 Square, Inc.
+package com.squareup.javawriter;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+
+@RunWith(JUnit4.class)
+public final class StringLiteralTest {
+  @Test public void stringLiteral() {
+    assertThat(StringLiteral.forValue("").toString()).isEqualTo("\"\"");
+    assertThat(StringLiteral.forValue("JavaWriter").toString()).isEqualTo("\"JavaWriter\"");
+    assertThat(StringLiteral.forValue("\\").toString()).isEqualTo("\"\\\\\"");
+    assertThat(StringLiteral.forValue("\"").toString()).isEqualTo("\"\\\"\"");
+    assertThat(StringLiteral.forValue("\b").toString()).isEqualTo("\"\\b\"");
+    assertThat(StringLiteral.forValue("\t").toString()).isEqualTo("\"\\t\"");
+    assertThat(StringLiteral.forValue("\n").toString()).isEqualTo("\"\\n\"");
+    assertThat(StringLiteral.forValue("\f").toString()).isEqualTo("\"\\f\"");
+    assertThat(StringLiteral.forValue("\r").toString()).isEqualTo("\"\\r\"");
+
+    // Control characters
+    for (char i = 0x1; i <= 0x1f; i++) {
+      checkCharEscape(i);
+    }
+    for (char i = 0x7f; i <= 0x9f; i++) {
+      checkCharEscape(i);
+    }
+  }
+
+  private void checkCharEscape(char codePoint) {
+    String test = "" + codePoint;
+    String expected;
+    switch (codePoint) {
+      case 8: expected = "\"\\b\""; break;
+      case 9: expected = "\"\\t\""; break;
+      case 10: expected = "\"\\n\""; break;
+      case 12: expected = "\"\\f\""; break;
+      case 13: expected = "\"\\r\""; break;
+      default: expected = "\"\\u" + String.format("%04x", (int) codePoint) + "\"";
+    }
+    assertThat(StringLiteral.forValue(test).toString()).isEqualTo(expected);
+  }
+
+}


### PR DESCRIPTION
Advantages include:
- References differentiate between String and StringLiteral
- StringLiteral.toString() still allows to be directly passed to String.format, et. al.
- You can get the value back after the literal has been passed around.
