### PR TITLE
Eliminate extra newlines.

### DIFF
--- a/src/main/java/com/squareup/javawriter/JavaWriter.java
+++ b/src/main/java/com/squareup/javawriter/JavaWriter.java
@@ -152,14 +152,19 @@ public final class JavaWriter {
       }
     }
 
-    appendable.append('\n');
+    if (importedClassIndex.isEmpty()) {
+      appendable.append('\n');
+    }
 
     CompilationUnitContext context =
         new CompilationUnitContext(packageName, ImmutableSet.copyOf(importedClassIndex.values()));
 
     // write types
+    String sep = "";
     for (TypeWriter typeWriter : typeWriters) {
-      typeWriter.write(appendable, context.createSubcontext(typeNames)).append('\n');
+      appendable.append(sep);
+      typeWriter.write(appendable, context.createSubcontext(typeNames));
+      sep = "\n";
     }
     return appendable;
   }

--- a/src/test/java/com/squareup/javawriter/JavaWriterTest.java
+++ b/src/test/java/com/squareup/javawriter/JavaWriterTest.java
@@ -15,6 +15,7 @@
  */
 package com.squareup.javawriter;
 
+import java.util.concurrent.Executor;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -29,5 +30,50 @@ public class JavaWriterTest {
     topClass.addNestedClass("Middle").addNestedClass("Bottom");
     topClass.addField(ClassName.create("some.other.pkg", "Bottom"), "field");
     assertThat(topClass.toString()).doesNotContain("import some.other.pkg.Bottom;");
+  }
+
+  @Test public void zeroImportsSingleNewline() {
+    JavaWriter javaWriter = JavaWriter.inPackage("test");
+    javaWriter.addClass("Top");
+
+    String expected = ""
+        + "package test;\n"
+        + "\n"
+        + "class Top {";
+
+    assertThat(javaWriter.toString()).startsWith(expected);
+  }
+
+  @Test public void newlineBetweenImports() {
+    JavaWriter javaWriter = JavaWriter.inPackage("test");
+    ClassWriter topClass = javaWriter.addClass("Top");
+    topClass.addField(Executor.class, "executor");
+
+    String expected = ""
+        + "package test;\n"
+        + "\n"
+        + "import java.util.concurrent.Executor;\n"
+        + "\n"
+        + "class Top {";
+
+    assertThat(javaWriter.toString()).startsWith(expected);
+  }
+
+  @Test public void newlinesBetweenTypes() {
+    JavaWriter javaWriter = JavaWriter.inPackage("test");
+    javaWriter.addClass("Top");
+    javaWriter.addClass("Middle");
+    javaWriter.addClass("Bottom");
+
+    String expected = ""
+        + "package test;\n"
+        + "\n"
+        + "class Top {}\n"
+        + "\n"
+        + "class Middle {}\n"
+        + "\n"
+        + "class Bottom {}\n";
+
+    assertThat(javaWriter.toString()).isEqualTo(expected);
   }
 }


### PR DESCRIPTION
- No additional trailing newline after the last type in a file.
- No additional newline between package and types when there are no imports.
