### PR TITLE
Move supertype into class, expose setter, fix interface implements.

### DIFF
--- a/src/main/java/com/squareup/javawriter/ClassWriter.java
+++ b/src/main/java/com/squareup/javawriter/ClassWriter.java
@@ -16,6 +16,7 @@
 package com.squareup.javawriter;
 
 import com.google.common.base.Function;
+import com.google.common.base.Optional;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -25,19 +26,34 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import javax.lang.model.element.Modifier;
+import javax.lang.model.element.TypeElement;
 
+import static com.squareup.javawriter.Writables.writeToString;
 import static javax.lang.model.element.Modifier.PRIVATE;
 import static javax.lang.model.element.Modifier.PROTECTED;
 import static javax.lang.model.element.Modifier.PUBLIC;
 
 public final class ClassWriter extends TypeWriter {
+  private Optional<TypeName> supertype;
   private final List<ConstructorWriter> constructorWriters;
   private final List<TypeVariableName> typeVariables;
 
   ClassWriter(ClassName className) {
     super(className);
+    this.supertype = Optional.absent();
     this.constructorWriters = Lists.newArrayList();
     this.typeVariables = Lists.newArrayList();
+  }
+
+  public void setSupertype(TypeName typeName) {
+    if (supertype.isPresent()) {
+      throw new IllegalStateException("Supertype already set to " + writeToString(supertype.get()));
+    }
+    supertype = Optional.of(typeName);
+  }
+
+  public void setSupertype(TypeElement typeElement) {
+    setSupertype(ClassName.fromTypeElement(typeElement));
   }
 
   public ConstructorWriter addConstructor() {

--- a/src/main/java/com/squareup/javawriter/EnumWriter.java
+++ b/src/main/java/com/squareup/javawriter/EnumWriter.java
@@ -126,8 +126,7 @@ public final class EnumWriter extends TypeWriter {
     @SuppressWarnings("unchecked")
     Iterable<? extends HasClassReferences> concat =
         Iterables.concat(nestedTypeWriters, constantWriters.values(), fieldWriters.values(),
-            constructorWriters,
-            methodWriters, implementedTypes, supertype.asSet(), annotations);
+            constructorWriters, methodWriters, implementedTypes, annotations);
     return FluentIterable.from(concat)
         .transformAndConcat(new Function<HasClassReferences, Set<ClassName>>() {
           @Override

--- a/src/main/java/com/squareup/javawriter/InterfaceWriter.java
+++ b/src/main/java/com/squareup/javawriter/InterfaceWriter.java
@@ -56,13 +56,9 @@ public final class InterfaceWriter extends TypeWriter {
       }
       appendable.append("> ");
     }
-    if (supertype.isPresent()) {
-      appendable.append(" extends ");
-      supertype.get().write(appendable, context);
-    }
     Iterator<TypeName> implementedTypesIterator = implementedTypes.iterator();
     if (implementedTypesIterator.hasNext()) {
-      appendable.append(" implements ");
+      appendable.append(" extends ");
       implementedTypesIterator.next().write(appendable, context);
       while (implementedTypesIterator.hasNext()) {
         appendable.append(", ");
@@ -86,8 +82,8 @@ public final class InterfaceWriter extends TypeWriter {
   public Set<ClassName> referencedClasses() {
     @SuppressWarnings("unchecked")
     Iterable<? extends HasClassReferences> concat =
-        Iterables.concat(nestedTypeWriters, methodWriters, implementedTypes, supertype.asSet(),
-            typeVariables, annotations);
+        Iterables.concat(nestedTypeWriters, methodWriters, implementedTypes, typeVariables,
+            annotations);
     return FluentIterable.from(concat)
         .transformAndConcat(new Function<HasClassReferences, Set<ClassName>>() {
           @Override

--- a/src/main/java/com/squareup/javawriter/TypeWriter.java
+++ b/src/main/java/com/squareup/javawriter/TypeWriter.java
@@ -15,7 +15,6 @@
  */
 package com.squareup.javawriter;
 
-import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import java.util.List;
@@ -29,7 +28,6 @@ import javax.lang.model.type.TypeMirror;
 public abstract class TypeWriter /* ha ha */ extends Modifiable
     implements Writable, HasTypeName, HasClassReferences {
   final ClassName name;
-  Optional<TypeName> supertype;
   final List<TypeName> implementedTypes;
   final List<MethodWriter> methodWriters;
   final List<TypeWriter> nestedTypeWriters;
@@ -37,7 +35,6 @@ public abstract class TypeWriter /* ha ha */ extends Modifiable
 
   TypeWriter(ClassName name) {
     this.name = name;
-    this.supertype = Optional.absent();
     this.implementedTypes = Lists.newArrayList();
     this.methodWriters = Lists.newArrayList();
     this.nestedTypeWriters = Lists.newArrayList();


### PR DESCRIPTION
- Supertypes are only applicable to classes. Additionally, expose a single-use setter for providing a value.
- Interfaces use 'extends' instead of 'implements' for their implemented types.

Closes #74.
