### PR TITLE
Prefer TypeNames.forClass for input of potentially primitive or array types.

### DIFF
--- a/src/main/java/com/squareup/javawriter/ConstructorWriter.java
+++ b/src/main/java/com/squareup/javawriter/ConstructorWriter.java
@@ -48,7 +48,7 @@ public final class ConstructorWriter extends Modifiable implements Writable, Has
   }
 
   public VariableWriter addParameter(Class<?> type, String name) {
-    return addParameter(ClassName.fromClass(type), name);
+    return addParameter(TypeNames.forClass(type), name);
   }
 
   public VariableWriter addParameter(TypeElement type, String name) {

--- a/src/main/java/com/squareup/javawriter/MethodWriter.java
+++ b/src/main/java/com/squareup/javawriter/MethodWriter.java
@@ -55,7 +55,7 @@ public final class MethodWriter extends Modifiable implements HasClassReferences
   }
 
   public VariableWriter addParameter(Class<?> type, String name) {
-    return addParameter(ClassName.fromClass(type), name);
+    return addParameter(TypeNames.forClass(type), name);
   }
 
   public VariableWriter addParameter(TypeElement type, String name) {

--- a/src/main/java/com/squareup/javawriter/TypeWriter.java
+++ b/src/main/java/com/squareup/javawriter/TypeWriter.java
@@ -70,7 +70,7 @@ public abstract class TypeWriter /* ha ha */ extends Modifiable
 
   public MethodWriter addMethod(Class<?> returnType, String name) {
     MethodWriter methodWriter =
-        new MethodWriter(ClassName.fromClass(returnType), name);
+        new MethodWriter(TypeNames.forClass(returnType), name);
     methodWriters.add(methodWriter);
     return methodWriter;
   }
@@ -90,7 +90,7 @@ public abstract class TypeWriter /* ha ha */ extends Modifiable
   }
 
   public FieldWriter addField(Class<?> type, String name) {
-    return addField(ClassName.fromClass(type), name);
+    return addField(TypeNames.forClass(type), name);
   }
 
   public FieldWriter addField(TypeElement type, String name) {


### PR DESCRIPTION
Closes #79.
