### PR TITLE
Type writer subclasses are now top level. JavaWriter is for multiple types.

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -89,7 +89,6 @@
     <!-- See http://checkstyle.sf.net/config_coding.html -->
     <!--module name="AvoidInlineConditionals"/-->
     <module name="CovariantEquals"/>
-    <module name="DoubleCheckedLocking"/>
     <module name="EmptyStatement"/>
     <!--<module name="EqualsAvoidNull"/>-->
     <module name="EqualsHashCode"/>

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,12 @@
       <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.jimfs</groupId>
+      <artifactId>jimfs</artifactId>
+      <version>1.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -92,7 +98,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>2.13</version>
         <configuration>
           <failsOnError>true</failsOnError>
           <configLocation>checkstyle.xml</configLocation>

--- a/src/main/java/com/squareup/javawriter/ClassWriter.java
+++ b/src/main/java/com/squareup/javawriter/ClassWriter.java
@@ -28,12 +28,18 @@ import java.util.Set;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.squareup.javawriter.Writables.writeToString;
 import static javax.lang.model.element.Modifier.PRIVATE;
 import static javax.lang.model.element.Modifier.PROTECTED;
 import static javax.lang.model.element.Modifier.PUBLIC;
 
 public final class ClassWriter extends TypeWriter {
+  public static ClassWriter forClassName(ClassName name) {
+    checkArgument(name.enclosingSimpleNames().isEmpty(), "%s must be top-level type.", name);
+    return new ClassWriter(name);
+  }
+
   private Optional<TypeName> supertype;
   private final List<ConstructorWriter> constructorWriters;
   private final List<TypeVariableName> typeVariables;

--- a/src/main/java/com/squareup/javawriter/EnumWriter.java
+++ b/src/main/java/com/squareup/javawriter/EnumWriter.java
@@ -29,12 +29,18 @@ import java.util.Map;
 import java.util.Set;
 import javax.lang.model.element.Modifier;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static javax.lang.model.element.Modifier.PRIVATE;
 import static javax.lang.model.element.Modifier.PROTECTED;
 import static javax.lang.model.element.Modifier.PUBLIC;
 
 public final class EnumWriter extends TypeWriter {
+  public static EnumWriter forClassName(ClassName name) {
+    checkArgument(name.enclosingSimpleNames().isEmpty(), "%s must be top-level type.", name);
+    return new EnumWriter(name);
+  }
+
   private final Map<String, ConstantWriter> constantWriters = Maps.newLinkedHashMap();
   private final List<ConstructorWriter> constructorWriters = Lists.newArrayList();
 

--- a/src/main/java/com/squareup/javawriter/InterfaceWriter.java
+++ b/src/main/java/com/squareup/javawriter/InterfaceWriter.java
@@ -24,7 +24,14 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 public final class InterfaceWriter extends TypeWriter {
+  public static InterfaceWriter forClassName(ClassName name) {
+    checkArgument(name.enclosingSimpleNames().isEmpty(), "%s must be top-level type.", name);
+    return new InterfaceWriter(name);
+  }
+
   private final List<TypeVariableName> typeVariables;
   InterfaceWriter(ClassName name) {
     super(name);

--- a/src/test/java/com/squareup/javawriter/ClassWriterTest.java
+++ b/src/test/java/com/squareup/javawriter/ClassWriterTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2014 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.javawriter;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import static com.google.common.truth.Truth.assertThat;
+
+@RunWith(JUnit4.class)
+public final class ClassWriterTest {
+  @Test public void onlyTopLevelClassNames() {
+    ClassName name = ClassName.bestGuessFromString("test.Foo.Bar");
+    try {
+      ClassWriter.forClassName(name);
+    } catch (IllegalArgumentException e) {
+      assertThat(e.getMessage()).isEqualTo("test.Foo.Bar must be top-level type.");
+    }
+  }
+}

--- a/src/test/java/com/squareup/javawriter/EnumWriterTest.java
+++ b/src/test/java/com/squareup/javawriter/EnumWriterTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2014 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.javawriter;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import static com.google.common.truth.Truth.assertThat;
+
+@RunWith(JUnit4.class)
+public final class EnumWriterTest {
+  @Test public void onlyTopLevelClassNames() {
+    ClassName name = ClassName.bestGuessFromString("test.Foo.Bar");
+    try {
+      EnumWriter.forClassName(name);
+    } catch (IllegalArgumentException e) {
+      assertThat(e.getMessage()).isEqualTo("test.Foo.Bar must be top-level type.");
+    }
+  }
+}

--- a/src/test/java/com/squareup/javawriter/InterfaceWriterTest.java
+++ b/src/test/java/com/squareup/javawriter/InterfaceWriterTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2014 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.javawriter;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import static com.google.common.truth.Truth.assertThat;
+
+@RunWith(JUnit4.class)
+public final class InterfaceWriterTest {
+  @Test public void onlyTopLevelClassNames() {
+    ClassName name = ClassName.bestGuessFromString("test.Foo.Bar");
+    try {
+      InterfaceWriter.forClassName(name);
+    } catch (IllegalArgumentException e) {
+      assertThat(e.getMessage()).isEqualTo("test.Foo.Bar must be top-level type.");
+    }
+  }
+}

--- a/src/test/java/com/squareup/javawriter/TypeWriterTest.java
+++ b/src/test/java/com/squareup/javawriter/TypeWriterTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2014 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.javawriter;
+
+import java.util.concurrent.Executor;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import static com.google.common.truth.Truth.assertThat;
+
+@RunWith(JUnit4.class)
+public class TypeWriterTest {
+  @Test public void referencedAndDeclaredSimpleName() {
+    ClassName name = ClassName.create("test", "Top");
+    ClassWriter topClass = ClassWriter.forClassName(name);
+    topClass.addNestedClass("Middle").addNestedClass("Bottom");
+    topClass.addField(ClassName.create("some.other.pkg", "Bottom"), "field");
+    assertThat(topClass.toString()).doesNotContain("import some.other.pkg.Bottom;");
+  }
+
+  @Test public void zeroImportsSingleNewline() {
+    ClassName name = ClassName.create("test", "Top");
+    ClassWriter classWriter = ClassWriter.forClassName(name);
+
+    String expected = ""
+        + "package test;\n"
+        + "\n"
+        + "class Top {}\n";
+    assertThat(classWriter.toString()).isEqualTo(expected);
+  }
+
+  @Test public void newlineBetweenImports() {
+    ClassName name = ClassName.create("test", "Top");
+    ClassWriter topClass = ClassWriter.forClassName(name);
+    topClass.addField(Executor.class, "executor");
+
+    String expected = ""
+        + "package test;\n"
+        + "\n"
+        + "import java.util.concurrent.Executor;\n"
+        + "\n"
+        + "class Top {\n"
+        + "  Executor executor;\n"
+        + "}\n";
+    assertThat(topClass.toString()).isEqualTo(expected);
+  }
+}


### PR DESCRIPTION
This changes JavaWriter from having parity with a single Java file containing multiple types to each TypeWriter subclass being representative of a single Java file (thus eliminating multiple types in a file). JavaWriter instead becomes an aggregator of top-level types and supports emitting them as a tree of files to a Path, File, or Filer.

Closes #84.

@gk5885 @swankjesse 
