### PR TITLE
Do not apply indent on empty lines.

### DIFF
--- a/src/main/java/com/squareup/javawriter/BlockWriter.java
+++ b/src/main/java/com/squareup/javawriter/BlockWriter.java
@@ -44,11 +44,7 @@ public final class BlockWriter implements Writable, HasClassReferences {
 
   @Override
   public Appendable write(Appendable appendable, Context context) throws IOException {
-    for (Snippet snippet : snippets) {
-      appendable.append('\n');
-      snippet.write(appendable, context);
-    }
-    return appendable.append('\n');
+    return Writables.Joiner.on('\n').appendTo(appendable, context, snippets);
   }
 
   @Override

--- a/src/main/java/com/squareup/javawriter/ConstructorWriter.java
+++ b/src/main/java/com/squareup/javawriter/ConstructorWriter.java
@@ -32,13 +32,13 @@ public final class ConstructorWriter extends Modifiable implements Writable, Has
   private final List<TypeVariableName> typeVariables;
   private final String name;
   private final Map<String, VariableWriter> parameterWriters;
-  private final BlockWriter blockWriter;
+  private final BlockWriter body;
 
   ConstructorWriter(String name) {
     this.typeVariables = Lists.newArrayList();
     this.name = name;
     this.parameterWriters = Maps.newLinkedHashMap();
-    this.blockWriter = new BlockWriter();
+    this.body = new BlockWriter();
   }
 
   public void addTypeVariable(TypeVariableName typeVariable) {
@@ -64,7 +64,7 @@ public final class ConstructorWriter extends Modifiable implements Writable, Has
   }
 
   public BlockWriter body() {
-    return blockWriter;
+    return body;
   }
 
   private VariableWriter addParameter(ClassName type, String name) {
@@ -77,7 +77,7 @@ public final class ConstructorWriter extends Modifiable implements Writable, Has
   @Override
   public Set<ClassName> referencedClasses() {
     return FluentIterable.from(
-        Iterables.concat(typeVariables, parameterWriters.values(), ImmutableList.of(blockWriter)))
+        Iterables.concat(typeVariables, parameterWriters.values(), ImmutableList.of(body)))
             .transformAndConcat(GET_REFERENCED_CLASSES)
             .toSet();
   }
@@ -89,7 +89,11 @@ public final class ConstructorWriter extends Modifiable implements Writable, Has
     appendable.append(name).append('(');
     Writables.Joiner.on(", ").appendTo(appendable, context, parameterWriters.values());
     appendable.append(") {");
-    blockWriter.write(new IndentingAppendable(appendable), context);
+    if (!body.isEmpty()) {
+      appendable.append('\n');
+      body.write(new IndentingAppendable(appendable), context);
+      appendable.append('\n');
+    }
     return appendable.append("}\n");
   }
 }

--- a/src/main/java/com/squareup/javawriter/IndentingAppendable.java
+++ b/src/main/java/com/squareup/javawriter/IndentingAppendable.java
@@ -43,22 +43,25 @@ final class IndentingAppendable implements Appendable {
     Iterator<CharSequence> lines = lines(csq, start, end);
     while (lines.hasNext()) {
       CharSequence line = lines.next();
-      maybeIndent();
-      delegate.append(line);
+      if (line.length() > 1 || line.charAt(0) != '\n') {
+        maybeIndent();
+      }
       if (line.charAt(line.length() - 1) == '\n') {
         requiresIndent = true;
       }
+      delegate.append(line);
     }
     return this;
   }
 
   @Override
   public Appendable append(char c) throws IOException {
-    maybeIndent();
-    delegate.append(c);
     if (c == '\n') {
       requiresIndent = true;
+    } else {
+      maybeIndent();
     }
+    delegate.append(c);
     return this;
   }
 

--- a/src/test/java/com/squareup/javawriter/ConstructorWriterTest.java
+++ b/src/test/java/com/squareup/javawriter/ConstructorWriterTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2014 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.javawriter;
+
+import com.google.common.base.Joiner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import static com.google.common.truth.Truth.assertThat;
+
+@RunWith(JUnit4.class)
+public final class ConstructorWriterTest {
+  @Test public void empty() {
+    ConstructorWriter test = new ConstructorWriter("Test");
+    String actual = Writables.writeToString(test);
+    assertThat(actual).isEqualTo("Test() {}\n");
+  }
+
+  @Test public void multilineBody() {
+    ConstructorWriter test = new ConstructorWriter("Test");
+    test.body().addSnippet("String firstName;\nString lastName;");
+    String actual = Writables.writeToString(test);
+    assertThat(actual).isEqualTo(Joiner.on('\n').join(
+        "Test() {",
+        "  String firstName;",
+        "  String lastName;",
+        "}\n"
+    ));
+  }
+}

--- a/src/test/java/com/squareup/javawriter/IndentingAppendableTest.java
+++ b/src/test/java/com/squareup/javawriter/IndentingAppendableTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2014 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.javawriter;
+
+import com.google.common.base.Joiner;
+import java.io.IOException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import static com.google.common.truth.Truth.assertThat;
+
+@RunWith(JUnit4.class)
+public final class IndentingAppendableTest {
+  private final StringBuilder data = new StringBuilder();
+  private final Appendable appendable = new IndentingAppendable(data);
+
+  @Test public void newlineCharacterNeverTriggerPendingIndent() throws IOException {
+    appendable.append("Hello\n").append('\n').append("World!");
+    assertThat(data.toString()).isEqualTo(Joiner.on('\n').join(
+        "  Hello",
+        "",
+        "  World!"
+    ));
+  }
+
+  @Test public void newlineStringNeverTriggerPendingIndent() throws IOException {
+    appendable.append("Hello\n").append("\n").append("World!");
+    assertThat(data.toString()).isEqualTo(Joiner.on('\n').join("  Hello", "", "  World!"));
+  }
+
+  @Test public void nestingAppendables() throws IOException {
+    appendable.append("Hello\n");
+    new IndentingAppendable(appendable).append("World\n");
+    appendable.append("This Is\n");
+    new IndentingAppendable(appendable).append("A Test\n");
+
+    assertThat(data.toString()).isEqualTo(Joiner.on('\n').join(
+        "  Hello",
+        "    World",
+        "  This Is",
+        "    A Test",
+        ""
+    ));
+  }
+
+  @Test public void nestingInsideContent() throws IOException {
+    appendable.append(Joiner.on('\n').join(
+        "def fib(num):",
+        "  if num == 1 or num == 2:",
+        "    return 1",
+        "  return fib(num - 1) + fib(num - 2)"
+    ));
+    assertThat(data.toString()).isEqualTo(Joiner.on('\n').join(
+        "  def fib(num):",
+        "    if num == 1 or num == 2:",
+        "      return 1",
+        "    return fib(num - 1) + fib(num - 2)"
+    ));
+  }
+}

--- a/src/test/java/com/squareup/javawriter/MethodWriterTest.java
+++ b/src/test/java/com/squareup/javawriter/MethodWriterTest.java
@@ -25,12 +25,30 @@ import static com.google.common.truth.Truth.assertThat;
 
 @RunWith(JUnit4.class)
 public final class MethodWriterTest {
+  @Test public void empty() {
+    MethodWriter test = new MethodWriter(VoidName.VOID, "test");
+    String actual = Writables.writeToString(test);
+    assertThat(actual).isEqualTo("void test() {}\n");
+  }
+
+  @Test public void multilineBody() {
+    MethodWriter test = new MethodWriter(VoidName.VOID, "test");
+    test.body().addSnippet("String firstName;\nString lastName;");
+    String actual = Writables.writeToString(test);
+    assertThat(actual).isEqualTo(Joiner.on('\n').join(
+        "void test() {",
+        "  String firstName;",
+        "  String lastName;",
+        "}\n"
+    ));
+  }
+
   @Test public void singleThrowsTypeName() {
     MethodWriter method = new MethodWriter(VoidName.VOID, "test");
     method.addThrowsType(ClassName.fromClass(IOException.class));
 
     assertThat(Writables.writeToString(method)) //
-        .isEqualTo("void test() throws java.io.IOException;\n");
+        .isEqualTo("void test() throws java.io.IOException {}\n");
   }
 
   @Test public void singleThrowsClass() {
@@ -38,7 +56,7 @@ public final class MethodWriterTest {
     method.addThrowsType(ClassName.fromClass(IOException.class));
 
     assertThat(Writables.writeToString(method)) //
-        .isEqualTo("void test() throws java.io.IOException;\n");
+        .isEqualTo("void test() throws java.io.IOException {}\n");
   }
 
   @Test public void throwsWithBody() {
@@ -47,7 +65,7 @@ public final class MethodWriterTest {
     method.body().addSnippet("return 0;");
 
     assertThat(Writables.writeToString(method)).isEqualTo(Joiner.on('\n').join(
-        "int test() throws java.io.IOException {  ",
+        "int test() throws java.io.IOException {",
         "  return 0;",
         "}\n"
     ));
@@ -59,6 +77,6 @@ public final class MethodWriterTest {
     method.addThrowsType(ClassName.create("example", "ExampleException"));
 
     assertThat(Writables.writeToString(method)) //
-        .isEqualTo("void test() throws java.io.IOException, example.ExampleException;\n");
+        .isEqualTo("void test() throws java.io.IOException, example.ExampleException {}\n");
   }
 }


### PR DESCRIPTION
This manifested when `BlockWriter` had no `Snippet`s to contribute but appended a trailing newline. The resulting code had trailing indent whitespace on after the open curly brace.

``` java
public Foo() { // <-- trailing whitespace was here
}
```
