### PR TITLE
Emit members in an order more consistent with hand-written classes and c...

### DIFF
--- a/src/main/java/com/squareup/javawriter/ClassWriter.java
+++ b/src/main/java/com/squareup/javawriter/ClassWriter.java
@@ -107,26 +107,17 @@ public final class ClassWriter extends TypeWriter {
       }
     }
     appendable.append(" {");
-    if (!fieldWriters.isEmpty()) {
-      appendable.append('\n');
-    }
-    for (VariableWriter fieldWriter : fieldWriters.values()) {
-      fieldWriter.write(new IndentingAppendable(appendable), context).append("\n");
-    }
+    writeFields(appendable, context, STATICS);
+    writeMethods(appendable, context, STATICS);
+    writeFields(appendable, context, INSTANCE);
     for (ConstructorWriter constructorWriter : constructorWriters) {
       appendable.append('\n');
       if (!isDefaultConstructor(constructorWriter)) {
         constructorWriter.write(new IndentingAppendable(appendable), context);
       }
     }
-    for (MethodWriter methodWriter : methodWriters) {
-      appendable.append('\n');
-      methodWriter.write(new IndentingAppendable(appendable), context);
-    }
-    for (TypeWriter nestedTypeWriter : nestedTypeWriters) {
-      appendable.append('\n');
-      nestedTypeWriter.write(new IndentingAppendable(appendable), context);
-    }
+    writeMethods(appendable, context, INSTANCE);
+    writeNestedTypes(appendable, context);
     appendable.append("}\n");
     return appendable;
   }

--- a/src/main/java/com/squareup/javawriter/EnumWriter.java
+++ b/src/main/java/com/squareup/javawriter/EnumWriter.java
@@ -94,26 +94,17 @@ public final class EnumWriter extends TypeWriter {
     constantWriterList.get(constantWriterList.size() - 1).write(appendable, context);
     appendable.append(";\n");
 
-    if (!fieldWriters.isEmpty()) {
-      appendable.append('\n');
-    }
-    for (VariableWriter fieldWriter : fieldWriters.values()) {
-      fieldWriter.write(new IndentingAppendable(appendable), context).append("\n");
-    }
+    writeFields(appendable, context, STATICS);
+    writeMethods(appendable, context, STATICS);
+    writeFields(appendable, context, INSTANCE);
     for (ConstructorWriter constructorWriter : constructorWriters) {
       appendable.append('\n');
       if (!isDefaultConstructor(constructorWriter)) {
         constructorWriter.write(new IndentingAppendable(appendable), context);
       }
     }
-    for (MethodWriter methodWriter : methodWriters) {
-      appendable.append('\n');
-      methodWriter.write(new IndentingAppendable(appendable), context);
-    }
-    for (TypeWriter nestedTypeWriter : nestedTypeWriters) {
-      appendable.append('\n');
-      nestedTypeWriter.write(new IndentingAppendable(appendable), context);
-    }
+    writeMethods(appendable, context, INSTANCE);
+    writeNestedTypes(appendable, context);
     appendable.append("}\n");
     return appendable;
   }

--- a/src/main/java/com/squareup/javawriter/InterfaceWriter.java
+++ b/src/main/java/com/squareup/javawriter/InterfaceWriter.java
@@ -73,14 +73,10 @@ public final class InterfaceWriter extends TypeWriter {
       }
     }
     appendable.append(" {");
-    for (MethodWriter methodWriter : methodWriters) {
-      appendable.append('\n');
-      methodWriter.write(new IndentingAppendable(appendable), context);
-    }
-    for (TypeWriter nestedTypeWriter : nestedTypeWriters) {
-      appendable.append('\n');
-      nestedTypeWriter.write(new IndentingAppendable(appendable), context);
-    }
+    writeFields(appendable, context, ALL);
+    writeMethods(appendable, context, STATICS);
+    writeMethods(appendable, context, INSTANCE);
+    writeNestedTypes(appendable, context);
     appendable.append("}\n");
     return appendable;
   }

--- a/src/main/java/com/squareup/javawriter/Modifiable.java
+++ b/src/main/java/com/squareup/javawriter/Modifiable.java
@@ -15,6 +15,8 @@
  */
 package com.squareup.javawriter;
 
+import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.squareup.javawriter.Writable.Context;
@@ -26,6 +28,14 @@ import java.util.Set;
 import javax.lang.model.element.Modifier;
 
 public abstract class Modifiable {
+  static final Predicate<Modifiable> STATICS = new Predicate<Modifiable>() {
+    @Override public boolean apply(Modifiable input) {
+      return input.modifiers.contains(Modifier.STATIC);
+    }
+  };
+  static final Predicate<Modifiable> INSTANCE = Predicates.not(STATICS);
+  static final Predicate<Modifiable> ALL = Predicates.alwaysTrue();
+
   final Set<Modifier> modifiers;
   final List<AnnotationWriter> annotations;
 

--- a/src/main/java/com/squareup/javawriter/TypeWriter.java
+++ b/src/main/java/com/squareup/javawriter/TypeWriter.java
@@ -17,7 +17,9 @@ package com.squareup.javawriter;
 
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
+import com.google.common.base.Predicate;
 import com.google.common.collect.BiMap;
+import com.google.common.collect.Collections2;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.HashBiMap;
 import com.google.common.collect.ImmutableSet;
@@ -28,6 +30,7 @@ import com.google.common.collect.Ordering;
 import com.google.common.collect.Queues;
 import com.google.common.collect.Sets;
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Deque;
 import java.util.List;
 import java.util.Map;
@@ -187,6 +190,33 @@ public abstract class TypeWriter /* ha ha */ extends Modifiable
     write(appendable, context.createSubcontext(ImmutableSet.of(name())));
 
     return appendable;
+  }
+
+  void writeFields(Appendable appendable, Context context, Predicate<Modifiable> filter)
+      throws IOException {
+    Collection<FieldWriter> fields = Collections2.filter(fieldWriters.values(), filter);
+    if (!fields.isEmpty()) {
+      appendable.append('\n');
+      for (VariableWriter fieldWriter : fields) {
+        fieldWriter.write(new IndentingAppendable(appendable), context).append('\n');
+      }
+    }
+  }
+
+  void writeMethods(Appendable appendable, Context context, Predicate<Modifiable> filter)
+      throws IOException {
+    Collection<MethodWriter> methods = Collections2.filter(methodWriters, filter);
+    for (MethodWriter methodWriter : methods) {
+      appendable.append('\n');
+      methodWriter.write(new IndentingAppendable(appendable), context);
+    }
+  }
+
+  void writeNestedTypes(Appendable appendable, Context context) throws IOException {
+    for (TypeWriter nestedTypeWriter : nestedTypeWriters) {
+      appendable.append('\n');
+      nestedTypeWriter.write(new IndentingAppendable(appendable), context);
+    }
   }
 
   static final class CompilationUnitContext implements Context {

--- a/src/test/java/com/squareup/javawriter/ClassWriterTest.java
+++ b/src/test/java/com/squareup/javawriter/ClassWriterTest.java
@@ -15,11 +15,14 @@
  */
 package com.squareup.javawriter;
 
+import com.google.common.base.Joiner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 import static com.google.common.truth.Truth.assertThat;
+import static javax.lang.model.element.Modifier.PRIVATE;
+import static javax.lang.model.element.Modifier.STATIC;
 
 @RunWith(JUnit4.class)
 public final class ClassWriterTest {
@@ -30,5 +33,33 @@ public final class ClassWriterTest {
     } catch (IllegalArgumentException e) {
       assertThat(e.getMessage()).isEqualTo("test.Foo.Bar must be top-level type.");
     }
+  }
+
+  @Test public void memberOrdering() {
+    ClassName name = ClassName.create("example", "Test");
+    ClassWriter writer = ClassWriter.forClassName(name);
+
+    writer.addConstructor().addModifiers(PRIVATE);
+    writer.addField(String.class, "ONE").addModifiers(STATIC);
+    writer.addField(String.class, "three");
+    writer.addMethod(VoidName.VOID, "two").addModifiers(STATIC);
+    writer.addMethod(VoidName.VOID, "four");
+
+    String expected = Joiner.on('\n').join(
+        "package example;",
+        "",
+        "class Test {",
+        "  static String ONE;",
+        "",
+        "  static void two() {}",
+        "",
+        "  String three;",
+        "",
+        "  private Test() {}",
+        "",
+        "  void four() {}",
+        "}"
+    );
+    assertThat(writer.toString()).isEqualTo(expected);
   }
 }

--- a/src/test/java/com/squareup/javawriter/EnumWriterTest.java
+++ b/src/test/java/com/squareup/javawriter/EnumWriterTest.java
@@ -15,11 +15,14 @@
  */
 package com.squareup.javawriter;
 
+import com.google.common.base.Joiner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 import static com.google.common.truth.Truth.assertThat;
+import static javax.lang.model.element.Modifier.PRIVATE;
+import static javax.lang.model.element.Modifier.STATIC;
 
 @RunWith(JUnit4.class)
 public final class EnumWriterTest {
@@ -30,5 +33,36 @@ public final class EnumWriterTest {
     } catch (IllegalArgumentException e) {
       assertThat(e.getMessage()).isEqualTo("test.Foo.Bar must be top-level type.");
     }
+  }
+
+  @Test public void memberOrdering() {
+    ClassName name = ClassName.create("example", "Test");
+    EnumWriter writer = EnumWriter.forClassName(name);
+
+    writer.addConstant("TEST");
+    writer.addConstructor().addModifiers(PRIVATE);
+    writer.addField(String.class, "ONE").addModifiers(STATIC);
+    writer.addField(String.class, "three");
+    writer.addMethod(VoidName.VOID, "two").addModifiers(STATIC);
+    writer.addMethod(VoidName.VOID, "four");
+
+    String expected = Joiner.on('\n').join(
+        "package example;",
+        "",
+        "enum Test {",
+        "  TEST;",
+        "",
+        "  static String ONE;",
+        "",
+        "  static void two() {}",
+        "",
+        "  String three;",
+        "",
+        "  private Test() {}",
+        "",
+        "  void four() {}",
+        "}"
+    );
+    assertThat(writer.toString()).isEqualTo(expected);
   }
 }

--- a/src/test/java/com/squareup/javawriter/InterfaceWriterTest.java
+++ b/src/test/java/com/squareup/javawriter/InterfaceWriterTest.java
@@ -15,11 +15,14 @@
  */
 package com.squareup.javawriter;
 
+import com.google.common.base.Joiner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 import static com.google.common.truth.Truth.assertThat;
+import static javax.lang.model.element.Modifier.ABSTRACT;
+import static javax.lang.model.element.Modifier.STATIC;
 
 @RunWith(JUnit4.class)
 public final class InterfaceWriterTest {
@@ -30,5 +33,27 @@ public final class InterfaceWriterTest {
     } catch (IllegalArgumentException e) {
       assertThat(e.getMessage()).isEqualTo("test.Foo.Bar must be top-level type.");
     }
+  }
+
+  @Test public void memberOrdering() {
+    ClassName name = ClassName.create("example", "Test");
+    InterfaceWriter writer = InterfaceWriter.forClassName(name);
+
+    writer.addField(String.class, "ONE").addModifiers(STATIC);
+    writer.addMethod(VoidName.VOID, "two").addModifiers(STATIC);
+    writer.addMethod(VoidName.VOID, "four").addModifiers(ABSTRACT);
+
+    String expected = Joiner.on('\n').join(
+        "package example;",
+        "",
+        "class Test {",
+        "  static String ONE;",
+        "",
+        "  static void two() {}",
+        "",
+        "  void four();",
+        "}"
+    );
+    assertThat(writer.toString()).isEqualTo(expected);
   }
 }


### PR DESCRIPTION
...ommon style guides.

Order is:
1. enum constants (enums only)
2. static fields
3. static methods
4. instance fields (non-interface)
5. constructors (non-interface)
6. instance methods
7. nested types
# DO NOT MERGE

Review only. This is pending other PRs fixes get merged.
