### PR TITLE
Rely on inheritance for building referenced classes.

### DIFF
--- a/src/main/java/com/squareup/javawriter/ClassWriter.java
+++ b/src/main/java/com/squareup/javawriter/ClassWriter.java
@@ -118,10 +118,9 @@ public final class ClassWriter extends TypeWriter {
 
   @Override
   public Set<ClassName> referencedClasses() {
-    @SuppressWarnings("unchecked")
     Iterable<? extends HasClassReferences> concat =
-        Iterables.concat(nestedTypeWriters, fieldWriters.values(), constructorWriters,
-            methodWriters, implementedTypes, supertype.asSet(), typeVariables, annotations);
+        Iterables.concat(super.referencedClasses(), constructorWriters, supertype.asSet(),
+            typeVariables);
     return FluentIterable.from(concat)
         .transformAndConcat(GET_REFERENCED_CLASSES)
         .toSet();

--- a/src/main/java/com/squareup/javawriter/ConstructorWriter.java
+++ b/src/main/java/com/squareup/javawriter/ConstructorWriter.java
@@ -28,7 +28,7 @@ import javax.lang.model.element.TypeElement;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-public final class ConstructorWriter extends Modifiable implements Writable, HasClassReferences {
+public final class ConstructorWriter extends Modifiable implements Writable {
   private final List<TypeVariableName> typeVariables;
   private final String name;
   private final Map<String, VariableWriter> parameterWriters;
@@ -76,8 +76,10 @@ public final class ConstructorWriter extends Modifiable implements Writable, Has
 
   @Override
   public Set<ClassName> referencedClasses() {
-    return FluentIterable.from(
-        Iterables.concat(typeVariables, parameterWriters.values(), ImmutableList.of(body)))
+    Iterable<? extends HasClassReferences> concat =
+        Iterables.concat(super.referencedClasses(), typeVariables, parameterWriters.values(),
+            ImmutableList.of(body));
+    return FluentIterable.from(concat)
             .transformAndConcat(GET_REFERENCED_CLASSES)
             .toSet();
   }

--- a/src/main/java/com/squareup/javawriter/EnumWriter.java
+++ b/src/main/java/com/squareup/javawriter/EnumWriter.java
@@ -107,10 +107,8 @@ public final class EnumWriter extends TypeWriter {
 
   @Override
   public Set<ClassName> referencedClasses() {
-    @SuppressWarnings("unchecked")
     Iterable<? extends HasClassReferences> concat =
-        Iterables.concat(nestedTypeWriters, constantWriters.values(), fieldWriters.values(),
-            constructorWriters, methodWriters, implementedTypes, annotations);
+        Iterables.concat(super.referencedClasses(), constantWriters.values(), constructorWriters);
     return FluentIterable.from(concat)
         .transformAndConcat(GET_REFERENCED_CLASSES)
         .toSet();

--- a/src/main/java/com/squareup/javawriter/FieldWriter.java
+++ b/src/main/java/com/squareup/javawriter/FieldWriter.java
@@ -17,7 +17,6 @@ package com.squareup.javawriter;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.FluentIterable;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import java.io.IOException;
 import java.util.Set;
@@ -52,7 +51,7 @@ public final class FieldWriter extends VariableWriter {
   @Override
   public Set<ClassName> referencedClasses() {
     Iterable<? extends HasClassReferences> concat =
-        Iterables.concat(ImmutableList.of(type()), initializer.asSet(), annotations);
+        Iterables.concat(super.referencedClasses(), initializer.asSet());
     return FluentIterable.from(concat)
         .transformAndConcat(GET_REFERENCED_CLASSES)
         .toSet();

--- a/src/main/java/com/squareup/javawriter/InterfaceWriter.java
+++ b/src/main/java/com/squareup/javawriter/InterfaceWriter.java
@@ -31,6 +31,7 @@ public final class InterfaceWriter extends TypeWriter {
   }
 
   private final List<TypeVariableName> typeVariables;
+
   InterfaceWriter(ClassName name) {
     super(name);
     this.typeVariables = Lists.newArrayList();
@@ -62,10 +63,8 @@ public final class InterfaceWriter extends TypeWriter {
 
   @Override
   public Set<ClassName> referencedClasses() {
-    @SuppressWarnings("unchecked")
     Iterable<? extends HasClassReferences> concat =
-        Iterables.concat(nestedTypeWriters, methodWriters, implementedTypes, typeVariables,
-            annotations);
+        Iterables.concat(super.referencedClasses(), typeVariables);
     return FluentIterable.from(concat)
         .transformAndConcat(GET_REFERENCED_CLASSES)
         .toSet();

--- a/src/main/java/com/squareup/javawriter/MethodWriter.java
+++ b/src/main/java/com/squareup/javawriter/MethodWriter.java
@@ -29,7 +29,7 @@ import javax.lang.model.element.TypeElement;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-public final class MethodWriter extends Modifiable implements HasClassReferences, Writable {
+public final class MethodWriter extends Modifiable implements Writable {
   private final List<TypeVariableName> typeVariables;
   private final TypeName returnType;
   private final String name;
@@ -109,9 +109,10 @@ public final class MethodWriter extends Modifiable implements HasClassReferences
 
   @Override
   public Set<ClassName> referencedClasses() {
+    @SuppressWarnings("unchecked")
     Iterable<? extends HasClassReferences> concat =
-        Iterables.concat(typeVariables, ImmutableList.of(returnType, body),
-            parameterWriters.values(), throwsTypes);
+        Iterables.concat(super.referencedClasses(), typeVariables,
+            ImmutableList.of(returnType, body), parameterWriters.values(), throwsTypes);
     return FluentIterable.from(concat)
         .transformAndConcat(GET_REFERENCED_CLASSES)
         .toSet();

--- a/src/main/java/com/squareup/javawriter/Modifiable.java
+++ b/src/main/java/com/squareup/javawriter/Modifiable.java
@@ -15,6 +15,7 @@
  */
 package com.squareup.javawriter;
 
+import com.google.common.collect.FluentIterable;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.squareup.javawriter.Writable.Context;
@@ -25,7 +26,7 @@ import java.util.List;
 import java.util.Set;
 import javax.lang.model.element.Modifier;
 
-public abstract class Modifiable {
+public abstract class Modifiable implements HasClassReferences {
   final Set<Modifier> modifiers;
   final List<AnnotationWriter> annotations;
 
@@ -64,5 +65,11 @@ public abstract class Modifiable {
       annotationWriter.write(appendable, context).append('\n');
     }
     return appendable;
+  }
+
+  @Override public Set<ClassName> referencedClasses() {
+    return FluentIterable.from(annotations)
+        .transformAndConcat(GET_REFERENCED_CLASSES)
+        .toSet();
   }
 }

--- a/src/main/java/com/squareup/javawriter/TypeWriter.java
+++ b/src/main/java/com/squareup/javawriter/TypeWriter.java
@@ -22,6 +22,7 @@ import com.google.common.collect.FluentIterable;
 import com.google.common.collect.HashBiMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Ordering;
@@ -39,7 +40,7 @@ import javax.lang.model.type.TypeMirror;
  * Only named types. Doesn't cover anonymous inner classes.
  */
 public abstract class TypeWriter /* ha ha */ extends Modifiable
-    implements Writable, HasTypeName, HasClassReferences {
+    implements Writable, HasTypeName {
   final ClassName name;
   final List<TypeName> implementedTypes;
   final List<MethodWriter> methodWriters;
@@ -147,6 +148,16 @@ public abstract class TypeWriter /* ha ha */ extends Modifiable
     } catch (IOException e) {
       throw new AssertionError(e);
     }
+  }
+
+  @Override public Set<ClassName> referencedClasses() {
+    @SuppressWarnings("unchecked")
+    Iterable<? extends HasClassReferences> concat =
+        Iterables.concat(super.referencedClasses(), implementedTypes, methodWriters,
+            nestedTypeWriters, fieldWriters.values(), explicitImports);
+    return FluentIterable.from(concat)
+        .transformAndConcat(GET_REFERENCED_CLASSES)
+        .toSet();
   }
 
   Appendable writeTypeToAppendable(Appendable appendable) throws IOException {

--- a/src/main/java/com/squareup/javawriter/VariableWriter.java
+++ b/src/main/java/com/squareup/javawriter/VariableWriter.java
@@ -15,12 +15,15 @@
  */
 package com.squareup.javawriter;
 
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 import java.io.IOException;
 import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-public class VariableWriter extends Modifiable implements Writable, HasClassReferences {
+public class VariableWriter extends Modifiable implements Writable {
   private final TypeName type;
   private final String name;
 
@@ -46,6 +49,10 @@ public class VariableWriter extends Modifiable implements Writable, HasClassRefe
 
   @Override
   public Set<ClassName> referencedClasses() {
-    return type.referencedClasses();
+    Iterable<? extends HasClassReferences> concat =
+        Iterables.concat(super.referencedClasses(), ImmutableSet.of(type));
+    return FluentIterable.from(concat)
+        .transformAndConcat(GET_REFERENCED_CLASSES)
+        .toSet();
   }
 }


### PR DESCRIPTION
This is better than forcing all subclasses to update when new types are referenced in super classes.
