### PR TITLE
Cache the contents of .m2 on Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,7 @@ notifications:
   email: false
 
 sudo: false
+
+cache:
+  directories:
+    - $HOME/.m2


### PR DESCRIPTION
This doesn't seem to prevent snapshot resolution from happening every time (as far as I can tell).
