### PR TITLE
Small API ergonomics.

### DIFF
--- a/src/main/java/com/squareup/javapoet/ClassName.java
+++ b/src/main/java/com/squareup/javapoet/ClassName.java
@@ -75,6 +75,19 @@ public final class ClassName implements Type, Comparable<ClassName> {
     return names.subList(1, names.size());
   }
 
+  /** Returns a class enclosed by this class. */
+  public ClassName nestedClass(String name) {
+    return new ClassName(new ImmutableList.Builder<String>().addAll(names).add(name).build());
+  }
+
+  /** Returns a class enclosed by the same package or class as this class. */
+  public ClassName peerClass(String name) {
+    return new ClassName(new ImmutableList.Builder<String>()
+        .addAll(names.subList(0, names.size() - 1))
+        .add(name)
+        .build());
+  }
+
   /** Returns the simple name of this class, like {@code "Entry"} for {@link Map.Entry}. */
   public String simpleName() {
     return Iterables.getLast(names);

--- a/src/main/java/com/squareup/javapoet/CodeBlock.java
+++ b/src/main/java/com/squareup/javapoet/CodeBlock.java
@@ -144,7 +144,7 @@ public final class CodeBlock {
       return this;
     }
 
-    public Builder statement(String format, Object... args) {
+    public Builder addStatement(String format, Object... args) {
       return add(format + ";\n", args);
     }
 

--- a/src/main/java/com/squareup/javapoet/FieldSpec.java
+++ b/src/main/java/com/squareup/javapoet/FieldSpec.java
@@ -64,7 +64,7 @@ public final class FieldSpec {
 
   public static Builder builder(Type type, String name, Modifier... modifiers) {
     return new Builder(type, name)
-        .addModifiers(modifiers);
+        .add(modifiers);
   }
 
   public static FieldSpec of(Type type, String name, Modifier... modifiers) {
@@ -91,7 +91,7 @@ public final class FieldSpec {
       return this;
     }
 
-    public Builder addAnnotation(AnnotationSpec annotationSpec) {
+    public Builder add(AnnotationSpec annotationSpec) {
       this.annotations.add(annotationSpec);
       return this;
     }
@@ -101,7 +101,7 @@ public final class FieldSpec {
       return this;
     }
 
-    public Builder addModifiers(Modifier... modifiers) {
+    public Builder add(Modifier... modifiers) {
       Collections.addAll(this.modifiers, modifiers);
       return this;
     }

--- a/src/main/java/com/squareup/javapoet/MethodSpec.java
+++ b/src/main/java/com/squareup/javapoet/MethodSpec.java
@@ -156,7 +156,7 @@ public final class MethodSpec {
       return this;
     }
 
-    public Builder addAnnotation(AnnotationSpec annotationSpec) {
+    public Builder add(AnnotationSpec annotationSpec) {
       this.annotations.add(annotationSpec);
       return this;
     }
@@ -166,12 +166,12 @@ public final class MethodSpec {
       return this;
     }
 
-    public Builder addModifiers(Modifier... modifiers) {
+    public Builder add(Modifier... modifiers) {
       Collections.addAll(this.modifiers, modifiers);
       return this;
     }
 
-    public Builder addTypeVariable(TypeVariable typeVariable) {
+    public Builder add(TypeVariable typeVariable) {
       typeVariables.add(typeVariable);
       return this;
     }
@@ -182,13 +182,9 @@ public final class MethodSpec {
       return this;
     }
 
-    public Builder addParameter(ParameterSpec parameterSpec) {
+    public Builder add(ParameterSpec parameterSpec) {
       this.parameters.add(parameterSpec);
       return this;
-    }
-
-    public Builder addParameter(Type type, String name, Modifier... modifiers) {
-      return addParameter(ParameterSpec.of(type, name, modifiers));
     }
 
     public Builder varargs() {
@@ -208,6 +204,43 @@ public final class MethodSpec {
 
     public Builder addCode(CodeBlock codeBlock) {
       code.add(codeBlock);
+      return this;
+    }
+
+    /**
+     * @param controlFlow the control flow construct and its code, such as "if (foo == 5)".
+     * Shouldn't contain braces or newline characters.
+     */
+    public Builder beginControlFlow(String controlFlow, Object... args) {
+      code.beginControlFlow(controlFlow, args);
+      return this;
+    }
+
+    /**
+     * @param controlFlow the control flow construct and its code, such as "else if (foo == 10)".
+     *     Shouldn't contain braces or newline characters.
+     */
+    public Builder nextControlFlow(String controlFlow, Object... args) {
+      code.nextControlFlow(controlFlow, args);
+      return this;
+    }
+
+    public Builder endControlFlow() {
+      code.endControlFlow();
+      return this;
+    }
+
+    /**
+     * @param controlFlow the optional control flow construct and its code, such as
+     *     "while(foo == 20)". Only used for "do/while" control flows.
+     */
+    public Builder endControlFlow(String controlFlow, Object... args) {
+      code.endControlFlow(controlFlow, args);
+      return this;
+    }
+
+    public Builder addStatement(String format, Object... args) {
+      code.addStatement(format, args);
       return this;
     }
 

--- a/src/main/java/com/squareup/javapoet/ParameterSpec.java
+++ b/src/main/java/com/squareup/javapoet/ParameterSpec.java
@@ -58,7 +58,7 @@ public final class ParameterSpec {
 
   public static Builder builder(Type type, String name, Modifier... modifiers) {
     return new Builder(type, name)
-        .addModifiers(modifiers);
+        .add(modifiers);
   }
 
   public static ParameterSpec of(Type type, String name, Modifier... modifiers) {
@@ -78,7 +78,7 @@ public final class ParameterSpec {
       this.name = name;
     }
 
-    public Builder addAnnotation(AnnotationSpec annotationSpec) {
+    public Builder add(AnnotationSpec annotationSpec) {
       this.annotations.add(annotationSpec);
       return this;
     }
@@ -88,7 +88,7 @@ public final class ParameterSpec {
       return this;
     }
 
-    public Builder addModifiers(Modifier... modifiers) {
+    public Builder add(Modifier... modifiers) {
       Collections.addAll(this.modifiers, modifiers);
       return this;
     }

--- a/src/main/java/com/squareup/javapoet/TypeSpec.java
+++ b/src/main/java/com/squareup/javapoet/TypeSpec.java
@@ -270,23 +270,23 @@ public final class TypeSpec {
       return this;
     }
 
-    public Builder addAnnotation(AnnotationSpec annotationSpec) {
+    public Builder add(AnnotationSpec annotationSpec) {
       checkState(anonymousTypeArguments == null);
       this.annotations.add(annotationSpec);
       return this;
     }
 
     public Builder addAnnotation(Type annotation) {
-      return addAnnotation(AnnotationSpec.of(annotation));
+      return add(AnnotationSpec.of(annotation));
     }
 
-    public Builder addModifiers(Modifier... modifiers) {
+    public Builder add(Modifier... modifiers) {
       checkState(anonymousTypeArguments == null);
       Collections.addAll(this.modifiers, modifiers);
       return this;
     }
 
-    public Builder addTypeVariable(TypeVariable<?> typeVariable) {
+    public Builder add(TypeVariable<?> typeVariable) {
       checkState(anonymousTypeArguments == null);
       typeVariables.add(typeVariable);
       return this;
@@ -315,21 +315,17 @@ public final class TypeSpec {
       return this;
     }
 
-    public Builder addField(FieldSpec fieldSpec) {
+    public Builder add(FieldSpec fieldSpec) {
       fieldSpecs.add(fieldSpec);
       return this;
     }
 
-    public Builder addField(Type type, String name, Modifier... modifiers) {
-      return addField(FieldSpec.of(type, name, modifiers));
-    }
-
-    public Builder addMethod(MethodSpec methodSpec) {
+    public Builder add(MethodSpec methodSpec) {
       methodSpecs.add(methodSpec);
       return this;
     }
 
-    public Builder addType(TypeSpec typeSpec) {
+    public Builder add(TypeSpec typeSpec) {
       typeSpecs.add(typeSpec);
       return this;
     }

--- a/src/test/java/com/squareup/javapoet/ClassNameTest.java
+++ b/src/test/java/com/squareup/javapoet/ClassNameTest.java
@@ -90,6 +90,22 @@ public final class ClassNameTest {
         .isEqualTo("com.squareup.javapoet.ClassNameTest.OuterClass.InnerClass");
   }
 
+  @Test public void peerClass() {
+    assertThat(ClassName.get(Double.class).peerClass("Short"))
+        .isEqualTo(ClassName.get(Short.class));
+    assertThat(ClassName.get("", "Double").peerClass("Short"))
+        .isEqualTo(ClassName.get("", "Short"));
+    assertThat(ClassName.get("a.b", "Combo", "Taco").peerClass("Burrito"))
+        .isEqualTo(ClassName.get("a.b", "Combo", "Burrito"));
+  }
+
+  @Test public void nestedClass() {
+    assertThat(ClassName.get(Map.class).nestedClass("Entry"))
+        .isEqualTo(ClassName.get(Map.Entry.class));
+    assertThat(ClassName.get("a.b", "Combo").nestedClass("Taco"))
+        .isEqualTo(ClassName.get("a.b", "Combo", "Taco"));
+  }
+
   @Test public void fromClassRejectionTypes() {
     try {
       ClassName.get(int.class);

--- a/src/test/java/com/squareup/javapoet/JavaFileTest.java
+++ b/src/test/java/com/squareup/javapoet/JavaFileTest.java
@@ -40,7 +40,7 @@ public final class JavaFileTest {
     String source = new JavaFile.Builder()
         .packageName("com.squareup.tacos")
         .typeSpec(TypeSpec.classBuilder("Taco")
-            .addField(FieldSpec.of(Date.class, "madeFreshDate"))
+            .add(FieldSpec.of(Date.class, "madeFreshDate"))
             .build())
         .build()
         .toString();
@@ -58,8 +58,8 @@ public final class JavaFileTest {
     String source = new JavaFile.Builder()
         .packageName("com.squareup.tacos")
         .typeSpec(TypeSpec.classBuilder("Taco")
-            .addField(FieldSpec.of(Date.class, "madeFreshDate"))
-            .addField(FieldSpec.of(java.sql.Date.class, "madeFreshDatabaseDate"))
+            .add(FieldSpec.of(Date.class, "madeFreshDate"))
+            .add(FieldSpec.of(java.sql.Date.class, "madeFreshDatabaseDate"))
             .build())
         .build()
         .toString();
@@ -78,9 +78,8 @@ public final class JavaFileTest {
   @Test public void defaultPackage() throws Exception {
     String source = new JavaFile.Builder()
         .typeSpec(TypeSpec.classBuilder("HelloWorld")
-            .addMethod(MethodSpec.methodBuilder("main")
-                .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-                .addParameter(String[].class, "args")
+            .add(MethodSpec.methodBuilder("main")
+                .add(Modifier.PUBLIC, Modifier.STATIC).add(ParameterSpec.of(String[].class, "args"))
                 .addCode("$T.out.println($S);\n", System.class, "Hello World!")
                 .build())
             .build())

--- a/src/test/java/com/squareup/javapoet/TypeSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/TypeSpecTest.java
@@ -38,9 +38,9 @@ public final class TypeSpecTest {
 
   @Test public void basic() throws Exception {
     TypeSpec taco = TypeSpec.classBuilder("Taco")
-        .addMethod(MethodSpec.methodBuilder("toString")
+        .add(MethodSpec.methodBuilder("toString")
             .addAnnotation(Override.class)
-            .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+            .add(Modifier.PUBLIC, Modifier.FINAL)
             .returns(String.class)
             .addCode("return $S;\n", "taco")
             .build())
@@ -67,9 +67,9 @@ public final class TypeSpecTest {
     ParameterizedType listOfSuper = Types.parameterizedType(
         List.class, Types.supertypeOf(String.class));
     TypeSpec taco = TypeSpec.classBuilder("Taco")
-        .addField(FieldSpec.of(listOfAny, "extendsObject"))
-        .addField(FieldSpec.of(listOfExtends, "extendsSerializable"))
-        .addField(FieldSpec.of(listOfSuper, "superString"))
+        .add(FieldSpec.of(listOfAny, "extendsObject"))
+        .add(FieldSpec.of(listOfExtends, "extendsSerializable"))
+        .add(FieldSpec.of(listOfSuper, "superString"))
         .build();
     assertThat(toString(taco)).isEqualTo(""
         + "package com.squareup.tacos;\n"
@@ -104,26 +104,26 @@ public final class TypeSpecTest {
     ParameterSpec thungParameter = ParameterSpec.of(thungOfSuperFoo, "thung", Modifier.FINAL);
     TypeSpec aSimpleThung = TypeSpec.anonymousClassBuilder("$N", thungParameter)
         .superclass(simpleThungOfBar)
-        .addMethod(MethodSpec.methodBuilder("doSomething")
+        .add(MethodSpec.methodBuilder("doSomething")
             .addAnnotation(Override.class)
-            .addModifiers(Modifier.PUBLIC)
-            .addParameter(bar, "bar")
+            .add(Modifier.PUBLIC)
+            .add(ParameterSpec.of(bar, "bar"))
             .addCode("/* code snippets */\n")
             .build())
         .build();
     TypeSpec aThingThang = TypeSpec.anonymousClassBuilder("")
         .superclass(thingThangOfFooBar)
-        .addMethod(MethodSpec.methodBuilder("call")
+        .add(MethodSpec.methodBuilder("call")
             .addAnnotation(Override.class)
-            .addModifiers(Modifier.PUBLIC)
+            .add(Modifier.PUBLIC)
             .returns(thungOfSuperBar)
-            .addParameter(thungParameter)
+            .add(thungParameter)
             .addCode("return $L;\n", aSimpleThung)
             .build())
         .build();
     TypeSpec taco = TypeSpec.classBuilder("Taco")
-        .addField(FieldSpec.builder(thingThangOfFooBar, "NAME")
-            .addModifiers(Modifier.STATIC, Modifier.FINAL, Modifier.FINAL)
+        .add(FieldSpec.builder(thingThangOfFooBar, "NAME")
+            .add(Modifier.STATIC, Modifier.FINAL, Modifier.FINAL)
             .initializer("$L", aThingThang)
             .build())
         .build();
@@ -150,21 +150,21 @@ public final class TypeSpecTest {
 
   @Test public void annotatedParameters() throws Exception {
     TypeSpec service = TypeSpec.classBuilder("Foo")
-        .addMethod(MethodSpec.constructorBuilder()
-            .addModifiers(Modifier.PUBLIC)
-            .addParameter(long.class, "id")
-            .addParameter(ParameterSpec.builder(String.class, "one")
+        .add(MethodSpec.constructorBuilder()
+            .add(Modifier.PUBLIC)
+            .add(ParameterSpec.of(long.class, "id"))
+            .add(ParameterSpec.builder(String.class, "one")
                 .addAnnotation(ClassName.get(tacosPackage, "Ping"))
                 .build())
-            .addParameter(ParameterSpec.builder(String.class, "two")
+            .add(ParameterSpec.builder(String.class, "two")
                 .addAnnotation(ClassName.get(tacosPackage, "Ping"))
                 .build())
-            .addParameter(ParameterSpec.builder(String.class, "three")
-                .addAnnotation(AnnotationSpec.builder(ClassName.get(tacosPackage, "Pong"))
+            .add(ParameterSpec.builder(String.class, "three")
+                .add(AnnotationSpec.builder(ClassName.get(tacosPackage, "Pong"))
                     .addMember("value", "$S", "pong")
                     .build())
                 .build())
-            .addParameter(ParameterSpec.builder(String.class, "four")
+            .add(ParameterSpec.builder(String.class, "four")
                 .addAnnotation(ClassName.get(tacosPackage, "Ping"))
                 .build())
             .addCode("/* code snippets */\n")
@@ -197,27 +197,27 @@ public final class TypeSpecTest {
     ClassName queryMap = ClassName.get(tacosPackage, "QueryMap");
     ClassName header = ClassName.get(tacosPackage, "Header");
     TypeSpec service = TypeSpec.interfaceBuilder("Service")
-        .addMethod(MethodSpec.methodBuilder("fooBar")
-            .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
-            .addAnnotation(AnnotationSpec.builder(headers)
+        .add(MethodSpec.methodBuilder("fooBar")
+            .add(Modifier.PUBLIC, Modifier.ABSTRACT)
+            .add(AnnotationSpec.builder(headers)
                 .addMember("value", "$S", "Accept: application/json")
                 .addMember("value", "$S", "User-Agent: foobar")
                 .build())
-            .addAnnotation(AnnotationSpec.builder(post)
+            .add(AnnotationSpec.builder(post)
                 .addMember("value", "$S", "/foo/bar")
                 .build())
             .returns(Types.parameterizedType(observable, fooBar))
-            .addParameter(ParameterSpec.builder(Types.parameterizedType(things, thing), "things")
+            .add(ParameterSpec.builder(Types.parameterizedType(things, thing), "things")
                 .addAnnotation(body)
                 .build())
-            .addParameter(ParameterSpec.builder(
+            .add(ParameterSpec.builder(
                 Types.parameterizedType(map, string, string), "query")
-                .addAnnotation(AnnotationSpec.builder(queryMap)
+                .add(AnnotationSpec.builder(queryMap)
                     .addMember("encodeValues", "false")
                     .build())
                 .build())
-            .addParameter(ParameterSpec.builder(string, "authorization")
-                .addAnnotation(AnnotationSpec.builder(header)
+            .add(ParameterSpec.builder(string, "authorization")
+                .add(AnnotationSpec.builder(header)
                     .addMember("value", "$S", "Authorization")
                     .build())
                 .build())
@@ -243,8 +243,8 @@ public final class TypeSpecTest {
 
   @Test public void annotatedField() throws Exception {
     TypeSpec taco = TypeSpec.classBuilder("Taco")
-        .addField(FieldSpec.builder(String.class, "thing", Modifier.PRIVATE, Modifier.FINAL)
-            .addAnnotation(AnnotationSpec.builder(ClassName.get(tacosPackage, "JsonAdapter"))
+        .add(FieldSpec.builder(String.class, "thing", Modifier.PRIVATE, Modifier.FINAL)
+            .add(AnnotationSpec.builder(ClassName.get(tacosPackage, "JsonAdapter"))
                 .addMember("value", "$T.class", ClassName.get(tacosPackage, "Foo"))
                 .build())
             .build())
@@ -263,12 +263,12 @@ public final class TypeSpecTest {
   @Test public void annotatedClass() throws Exception {
     ClassName someType = ClassName.get(tacosPackage, "SomeType");
     TypeSpec taco = TypeSpec.classBuilder("Foo")
-        .addAnnotation(AnnotationSpec.builder(ClassName.get(tacosPackage, "Something"))
+        .add(AnnotationSpec.builder(ClassName.get(tacosPackage, "Something"))
             .addMember("hi", "$T.$N", someType, "FIELD")
             .addMember("hey", "$L", 12)
             .addMember("hello", "$S", "goodbye")
             .build())
-        .addModifiers(Modifier.PUBLIC)
+        .add(Modifier.PUBLIC)
         .build();
     assertThat(toString(taco)).isEqualTo(""
         + "package com.squareup.tacos;\n"
@@ -283,25 +283,25 @@ public final class TypeSpecTest {
   }
 
   @Test public void enumWithSubclassing() throws Exception {
-      TypeSpec roshambo = TypeSpec.enumBuilder("Roshambo")
-        .addModifiers(Modifier.PUBLIC)
+    TypeSpec roshambo = TypeSpec.enumBuilder("Roshambo")
+        .add(Modifier.PUBLIC)
         .addEnumConstant("ROCK")
         .addEnumConstant("PAPER", TypeSpec.anonymousClassBuilder("$S", "flat")
-            .addMethod(MethodSpec.methodBuilder("toString")
+            .add(MethodSpec.methodBuilder("toString")
                 .addAnnotation(Override.class)
-                .addModifiers(Modifier.PUBLIC)
+                .add(Modifier.PUBLIC)
                 .returns(String.class)
                 .addCode("return $S;\n", "paper airplane!")
                 .build())
             .build())
         .addEnumConstant("SCISSORS", TypeSpec.anonymousClassBuilder("$S", "peace sign")
             .build())
-        .addField(FieldSpec.of(String.class, "handPosition", Modifier.PRIVATE, Modifier.FINAL))
-        .addMethod(MethodSpec.constructorBuilder()
-            .addParameter(String.class, "handPosition")
-            .addCode("this.handPosition = handPosition;\n")
-            .build())
-        .addMethod(MethodSpec.constructorBuilder()
+        .add(FieldSpec.of(String.class, "handPosition", Modifier.PRIVATE, Modifier.FINAL))
+        .add(MethodSpec.constructorBuilder()
+            .add(ParameterSpec.of(String.class, "handPosition"))
+                .addCode("this.handPosition = handPosition;\n")
+                .build())
+        .add(MethodSpec.constructorBuilder()
             .addCode("this($S);\n", "fist")
             .build())
         .build();
@@ -357,9 +357,9 @@ public final class TypeSpecTest {
   @Test public void enumWithMembersButNoConstructorCall() throws Exception {
     TypeSpec roshambo = TypeSpec.enumBuilder("Roshambo")
         .addEnumConstant("SPOCK", TypeSpec.anonymousClassBuilder("")
-            .addMethod(MethodSpec.methodBuilder("toString")
+            .add(MethodSpec.methodBuilder("toString")
                 .addAnnotation(Override.class)
-                .addModifiers(Modifier.PUBLIC)
+                .add(Modifier.PUBLIC)
                 .returns(String.class)
                 .addCode("return $S;\n", "west side")
                 .build())
@@ -383,10 +383,10 @@ public final class TypeSpecTest {
 
   @Test public void methodThrows() throws Exception {
     TypeSpec taco = TypeSpec.classBuilder("Taco")
-        .addMethod(MethodSpec.methodBuilder("throwOne")
+        .add(MethodSpec.methodBuilder("throwOne")
             .addException(IOException.class)
             .build())
-        .addMethod(MethodSpec.methodBuilder("throwTwo")
+        .add(MethodSpec.methodBuilder("throwTwo")
             .addException(IOException.class)
             .addException(ClassName.get(tacosPackage, "SourCreamException"))
             .build())
@@ -410,27 +410,27 @@ public final class TypeSpecTest {
     TypeVariable<?> p = Types.typeVariable("P", Number.class);
     ClassName location = ClassName.get(tacosPackage, "Location");
     TypeSpec typeSpec = TypeSpec.classBuilder("Location")
-        .addTypeVariable(t)
-        .addTypeVariable(p)
+        .add(t)
+        .add(p)
         .addSuperinterface(Types.parameterizedType(Comparable.class, p))
-        .addField(FieldSpec.of(t, "label"))
-        .addField(FieldSpec.of(p, "x"))
-        .addField(FieldSpec.of(p, "y"))
-        .addMethod(MethodSpec.methodBuilder("compareTo")
+        .add(FieldSpec.of(t, "label"))
+        .add(FieldSpec.of(p, "x"))
+        .add(FieldSpec.of(p, "y"))
+        .add(MethodSpec.methodBuilder("compareTo")
             .addAnnotation(Override.class)
-            .addModifiers(Modifier.PUBLIC)
+            .add(Modifier.PUBLIC)
             .returns(int.class)
-            .addParameter(p, "p")
+            .add(ParameterSpec.of(p, "p"))
             .addCode("return 0;\n")
             .build())
-        .addMethod(MethodSpec.methodBuilder("of")
-            .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-            .addTypeVariable(t)
-            .addTypeVariable(p)
+        .add(MethodSpec.methodBuilder("of")
+            .add(Modifier.PUBLIC, Modifier.STATIC)
+            .add(t)
+            .add(p)
             .returns(Types.parameterizedType(location, t, p))
-            .addParameter(t, "label")
-            .addParameter(p, "x")
-            .addParameter(p, "y")
+            .add(ParameterSpec.of(t, "label"))
+            .add(ParameterSpec.of(p, "x"))
+            .add(ParameterSpec.of(p, "y"))
             .addCode("throw new $T($S);\n", UnsupportedOperationException.class, "TODO")
             .build())
         .build();
@@ -464,7 +464,7 @@ public final class TypeSpecTest {
     ClassName taco = ClassName.get(tacosPackage, "Taco");
     ClassName food = ClassName.get("com.squareup.tacos", "Food");
     TypeSpec typeSpec = TypeSpec.classBuilder("Taco")
-        .addModifiers(Modifier.ABSTRACT)
+        .add(Modifier.ABSTRACT)
         .superclass(Types.parameterizedType(AbstractSet.class, food))
         .addSuperinterface(Serializable.class)
         .addSuperinterface(Types.parameterizedType(Comparable.class, taco))
@@ -523,23 +523,23 @@ public final class TypeSpecTest {
     ClassName chips = ClassName.get(tacosPackage, "Combo", "Chips");
     ClassName sauce = ClassName.get(tacosPackage, "Combo", "Sauce");
     TypeSpec typeSpec = TypeSpec.classBuilder("Combo")
-        .addField(FieldSpec.of(taco, "taco"))
-        .addField(FieldSpec.of(chips, "chips"))
-        .addType(TypeSpec.classBuilder(taco.simpleName())
-            .addModifiers(Modifier.STATIC)
-            .addField(FieldSpec.of(Types.parameterizedType(List.class, topping), "toppings"))
-            .addField(FieldSpec.of(sauce, "sauce"))
-            .addType(TypeSpec.enumBuilder(topping.simpleName())
+        .add(FieldSpec.of(taco, "taco"))
+        .add(FieldSpec.of(chips, "chips"))
+        .add(TypeSpec.classBuilder(taco.simpleName())
+            .add(Modifier.STATIC)
+            .add(FieldSpec.of(Types.parameterizedType(List.class, topping), "toppings"))
+            .add(FieldSpec.of(sauce, "sauce"))
+            .add(TypeSpec.enumBuilder(topping.simpleName())
                 .addEnumConstant("SHREDDED_CHEESE")
                 .addEnumConstant("LEAN_GROUND_BEEF")
                 .build())
             .build())
-        .addType(TypeSpec.classBuilder(chips.simpleName())
-            .addModifiers(Modifier.STATIC)
-            .addField(FieldSpec.of(topping, "topping"))
-            .addField(FieldSpec.of(sauce, "dippingSauce"))
+        .add(TypeSpec.classBuilder(chips.simpleName())
+            .add(Modifier.STATIC)
+            .add(FieldSpec.of(topping, "topping"))
+            .add(FieldSpec.of(sauce, "dippingSauce"))
             .build())
-        .addType(TypeSpec.enumBuilder(sauce.simpleName())
+        .add(TypeSpec.enumBuilder(sauce.simpleName())
             .addEnumConstant("SOUR_CREAM")
             .addEnumConstant("SALSA")
             .addEnumConstant("QUESO")
@@ -599,20 +599,20 @@ public final class TypeSpecTest {
     FieldSpec externalBottom = FieldSpec.of(
         ClassName.get(donutsPackage, "Bottom"), "externalBottom");
     TypeSpec top = TypeSpec.classBuilder("Top")
-        .addField(internalTop)
-        .addField(internalBottom)
-        .addField(externalTop)
-        .addField(externalBottom)
-        .addType(TypeSpec.classBuilder("Middle")
-            .addField(internalTop)
-            .addField(internalBottom)
-            .addField(externalTop)
-            .addField(externalBottom)
-            .addType(TypeSpec.classBuilder("Bottom")
-                .addField(internalTop)
-                .addField(internalBottom)
-                .addField(externalTop)
-                .addField(externalBottom)
+        .add(internalTop)
+        .add(internalBottom)
+        .add(externalTop)
+        .add(externalBottom)
+        .add(TypeSpec.classBuilder("Middle")
+            .add(internalTop)
+            .add(internalBottom)
+            .add(externalTop)
+            .add(externalBottom)
+            .add(TypeSpec.classBuilder("Bottom")
+                .add(internalTop)
+                .add(internalBottom)
+                .add(externalTop)
+                .add(externalBottom)
                 .build())
             .build())
         .build();
@@ -657,7 +657,7 @@ public final class TypeSpecTest {
     Element innerElement = Mockito.mock(Element.class);
     TypeSpec outer = TypeSpec.classBuilder("Outer")
         .addOriginatingElement(outerElement)
-        .addType(TypeSpec.classBuilder("Inner")
+        .add(TypeSpec.classBuilder("Inner")
             .addOriginatingElement(innerElement)
             .build())
         .build();
@@ -667,8 +667,8 @@ public final class TypeSpecTest {
   @Test public void intersectionType() {
     TypeVariable<?> typeVariable = Types.typeVariable("T", Comparator.class, Serializable.class);
     TypeSpec taco = TypeSpec.classBuilder("Taco")
-        .addMethod(MethodSpec.methodBuilder("getComparator")
-            .addTypeVariable(typeVariable)
+        .add(MethodSpec.methodBuilder("getComparator")
+            .add(typeVariable)
             .returns(typeVariable)
             .addCode("return null;\n")
             .build())
@@ -688,7 +688,7 @@ public final class TypeSpecTest {
 
   @Test public void arrayType() {
     TypeSpec taco = TypeSpec.classBuilder("Taco")
-        .addField(FieldSpec.of(int[].class, "ints"))
+        .add(FieldSpec.of(int[].class, "ints"))
         .build();
     assertThat(toString(taco)).isEqualTo(""
         + "package com.squareup.tacos;\n"
@@ -702,14 +702,14 @@ public final class TypeSpecTest {
     TypeSpec taco = TypeSpec.classBuilder("Taco")
         .addJavadoc("A hard or soft tortilla, loosely folded and filled with whatever {@link \n")
         .addJavadoc("{@link $T random} tex-mex stuff we could find in the pantry.\n", Random.class)
-        .addField(FieldSpec.builder(boolean.class, "soft")
+        .add(FieldSpec.builder(boolean.class, "soft")
             .addJavadoc("True for a soft flour tortilla; false for a crunchy corn tortilla.\n")
             .build())
-        .addMethod(MethodSpec.methodBuilder("refold")
+        .add(MethodSpec.methodBuilder("refold")
             .addJavadoc("Folds the back of this taco to reduce sauce leakage.\n"
                 + "\n"
                 + "<p>For {@link $T#KOREAN}, the front may also be folded.\n", Locale.class)
-            .addParameter(Locale.class, "locale")
+            .add(ParameterSpec.of(Locale.class, "locale"))
             .build())
         .build();
     // Mentioning a type in Javadoc will not cause an import to be added (java.util.Random here),
@@ -745,7 +745,7 @@ public final class TypeSpecTest {
     ClassName option = ClassName.get(tacosPackage, "Option");
     ClassName mealDeal = ClassName.get(tacosPackage, "MealDeal");
     TypeSpec menu = TypeSpec.classBuilder("Menu")
-        .addAnnotation(AnnotationSpec.builder(mealDeal)
+        .add(AnnotationSpec.builder(mealDeal)
             .addMember("price", "$L", 500)
             .addMember("options", "$L", AnnotationSpec.builder(option)
                 .addMember("name", "$S", "taco")
@@ -773,9 +773,9 @@ public final class TypeSpecTest {
 
   @Test public void varargs() throws Exception {
     TypeSpec taqueria = TypeSpec.classBuilder("Taqueria")
-        .addMethod(MethodSpec.methodBuilder("prepare")
-            .addParameter(int.class, "workers")
-            .addParameter(Runnable[].class, "jobs")
+        .add(MethodSpec.methodBuilder("prepare")
+            .add(ParameterSpec.of(int.class, "workers"))
+            .add(ParameterSpec.of(Runnable[].class, "jobs"))
             .varargs()
             .build())
         .build();
@@ -793,23 +793,23 @@ public final class TypeSpecTest {
   @Test public void codeBlocks() throws Exception {
     CodeBlock ifBlock = new CodeBlock.Builder()
         .beginControlFlow("if (!a.equals(b))")
-        .statement("return i")
+        .addStatement("return i")
         .endControlFlow()
         .build();
     CodeBlock methodBody = new CodeBlock.Builder()
-        .statement("$T size = $T.min(listA.size(), listB.size())", int.class, Math.class)
+        .addStatement("$T size = $T.min(listA.size(), listB.size())", int.class, Math.class)
         .beginControlFlow("for ($T i = 0; i < size; i++)", int.class)
-        .statement("$T $N = $N.get(i)", String.class, "a", "listA")
-        .statement("$T $N = $N.get(i)", String.class, "b", "listB")
+        .addStatement("$T $N = $N.get(i)", String.class, "a", "listA")
+        .addStatement("$T $N = $N.get(i)", String.class, "b", "listB")
         .add("$L", ifBlock)
         .endControlFlow()
-        .statement("return size")
+        .addStatement("return size")
         .build();
     TypeSpec util = TypeSpec.classBuilder("Util")
-        .addMethod(MethodSpec.methodBuilder("commonPrefixLength")
+        .add(MethodSpec.methodBuilder("commonPrefixLength")
             .returns(int.class)
-            .addParameter(Types.parameterizedType(List.class, String.class), "listA")
-            .addParameter(Types.parameterizedType(List.class, String.class), "listB")
+            .add(ParameterSpec.of(Types.parameterizedType(List.class, String.class), "listA"))
+            .add(ParameterSpec.of(Types.parameterizedType(List.class, String.class), "listB"))
             .addCode(methodBody)
             .build())
         .build();
@@ -837,14 +837,12 @@ public final class TypeSpecTest {
 
   @Test public void elseIf() throws Exception {
     TypeSpec taco = TypeSpec.classBuilder("Taco")
-        .addMethod(MethodSpec.methodBuilder("choices")
-            .addCode(new CodeBlock.Builder()
-                .beginControlFlow("if (5 < 4) ")
-                .statement("$T.out.println($S)", System.class, "wat")
-                .nextControlFlow("else if (5 < 6)")
-                .statement("$T.out.println($S)", System.class, "hello")
-                .endControlFlow()
-                .build())
+        .add(MethodSpec.methodBuilder("choices")
+            .beginControlFlow("if (5 < 4) ")
+            .addStatement("$T.out.println($S)", System.class, "wat")
+            .nextControlFlow("else if (5 < 6)")
+            .addStatement("$T.out.println($S)", System.class, "hello")
+            .endControlFlow()
             .build())
         .build();
     assertThat(toString(taco)).isEqualTo(""
@@ -865,12 +863,10 @@ public final class TypeSpecTest {
 
   @Test public void doWhile() throws Exception {
     TypeSpec taco = TypeSpec.classBuilder("Taco")
-        .addMethod(MethodSpec.methodBuilder("loopForever")
-            .addCode(new CodeBlock.Builder()
-                .beginControlFlow("do")
-                .statement("$T.out.println($S)", System.class, "hello")
-                .endControlFlow("while (5 < 6)")
-                .build())
+        .add(MethodSpec.methodBuilder("loopForever")
+            .beginControlFlow("do")
+            .addStatement("$T.out.println($S)", System.class, "hello")
+            .endControlFlow("while (5 < 6)")
             .build())
         .build();
     assertThat(toString(taco)).isEqualTo(""
@@ -889,7 +885,7 @@ public final class TypeSpecTest {
 
   @Test public void inlineIndent() throws Exception {
     TypeSpec taco = TypeSpec.classBuilder("Taco")
-        .addMethod(MethodSpec.methodBuilder("inlineIndent")
+        .add(MethodSpec.methodBuilder("inlineIndent")
             .addCode("if (3 < 4) {\n$>$T.out.println($S);\n$<}\n", System.class, "hello")
             .build())
         .build();


### PR DESCRIPTION
Don't require the caller to repeat the type when that's redundant.
addField(FieldSpec.of()) is now just add(FieldSpec.of()). This gives
us the option later of introducing a member type, and interleaving
members with a single add() method.

Also make it possible to write basic control flow without creating
an explicit code block.