### PR TITLE
API ergonomics redux.

### DIFF
--- a/src/main/java/com/squareup/javapoet/AnnotationSpec.java
+++ b/src/main/java/com/squareup/javapoet/AnnotationSpec.java
@@ -98,10 +98,6 @@ public final class AnnotationSpec {
     codeWriter.emit(whitespace + "}");
   }
 
-  public static AnnotationSpec of(Type annotation) {
-    return builder(annotation).build();
-  }
-
   public static Builder builder(Type type) {
     return new Builder(type);
   }
@@ -126,7 +122,7 @@ public final class AnnotationSpec {
     }
 
     public Builder addMember(String name, String format, Object... args) {
-      members.put(name, CodeBlock.of(format, args));
+      members.put(name, CodeBlock.builder().add(format, args).build());
       return this;
     }
 

--- a/src/main/java/com/squareup/javapoet/ClassName.java
+++ b/src/main/java/com/squareup/javapoet/ClassName.java
@@ -75,7 +75,7 @@ public final class ClassName implements Type, Comparable<ClassName> {
    * Returns a new {@link ClassName} instance for the specified {@code name} as nested inside this
    * class.
    */
-  public ClassName nestedClassNamed(String name) {
+  public ClassName nestedClass(String name) {
     checkNotNull(name, "name == null");
     return new ClassName(new ImmutableList.Builder<String>()
         .addAll(names)
@@ -85,6 +85,18 @@ public final class ClassName implements Type, Comparable<ClassName> {
 
   public ImmutableList<String> simpleNames() {
     return names.subList(1, names.size());
+  }
+
+  /**
+   * Returns a class that shares the same enclosing package or class. If this class is enclosed by
+   * another class, this is equivalent to {@code enclosingClassName().nestedClass(name)}. Otherwise
+   * it is equivalent to {@code get(packageName(), name)}.
+   */
+  public ClassName peerClass(String name) {
+    return new ClassName(new ImmutableList.Builder<String>()
+        .addAll(names.subList(0, names.size() - 1))
+        .add(name)
+        .build());
   }
 
   /** Returns the simple name of this class, like {@code "Entry"} for {@link Map.Entry}. */

--- a/src/main/java/com/squareup/javapoet/CodeBlock.java
+++ b/src/main/java/com/squareup/javapoet/CodeBlock.java
@@ -57,17 +57,20 @@ public final class CodeBlock {
     this.args = builder.args.build();
   }
 
-  public static CodeBlock of(String format, Object... args) {
-    return new Builder().add(format, args).build();
-  }
-
   public boolean isEmpty() {
     return formatParts.isEmpty();
+  }
+
+  public static Builder builder() {
+    return new Builder();
   }
 
   public static final class Builder {
     final ImmutableList.Builder<String> formatParts = ImmutableList.builder();
     final ImmutableList.Builder<Object> args = ImmutableList.builder();
+
+    private Builder() {
+    }
 
     public Builder add(String format, Object... args) {
       int expectedArgsLength = 0;
@@ -144,7 +147,7 @@ public final class CodeBlock {
       return this;
     }
 
-    public Builder statement(String format, Object... args) {
+    public Builder addStatement(String format, Object... args) {
       return add(format + ";\n", args);
     }
 

--- a/src/main/java/com/squareup/javapoet/CodeWriter.java
+++ b/src/main/java/com/squareup/javapoet/CodeWriter.java
@@ -190,7 +190,7 @@ final class CodeWriter {
   }
 
   public CodeWriter emit(String format, Object... args) throws IOException {
-    return emit(CodeBlock.of(format, args));
+    return emit(CodeBlock.builder().add(format, args).build());
   }
 
   public CodeWriter emit(CodeBlock codeBlock) throws IOException {

--- a/src/main/java/com/squareup/javapoet/FieldSpec.java
+++ b/src/main/java/com/squareup/javapoet/FieldSpec.java
@@ -67,18 +67,14 @@ public final class FieldSpec {
         .addModifiers(modifiers);
   }
 
-  public static FieldSpec of(Type type, String name, Modifier... modifiers) {
-    return builder(type, name, modifiers).build();
-  }
-
   public static final class Builder {
     private final Type type;
     private final String name;
 
-    private final CodeBlock.Builder javadoc = new CodeBlock.Builder();
+    private final CodeBlock.Builder javadoc = CodeBlock.builder();
     private final List<AnnotationSpec> annotations = new ArrayList<>();
     private final List<Modifier> modifiers = new ArrayList<>();
-    private CodeBlock.Builder initializer = new CodeBlock.Builder();
+    private CodeBlock.Builder initializer = CodeBlock.builder();
 
     private Builder(Type type, String name) {
       checkArgument(SourceVersion.isName(name), "not a valid name: %s", name);
@@ -97,7 +93,7 @@ public final class FieldSpec {
     }
 
     public Builder addAnnotation(Type annotation) {
-      this.annotations.add(AnnotationSpec.of(annotation));
+      this.annotations.add(AnnotationSpec.builder(annotation).build());
       return this;
     }
 

--- a/src/main/java/com/squareup/javapoet/JavaFile.java
+++ b/src/main/java/com/squareup/javapoet/JavaFile.java
@@ -89,23 +89,22 @@ public final class JavaFile {
     }
   }
 
+  public static Builder builder(String packageName, TypeSpec typeSpec) {
+    return new Builder(packageName, typeSpec);
+  }
+
   public static final class Builder {
-    private CodeBlock.Builder fileComment = new CodeBlock.Builder();
-    private String packageName = "";
-    private TypeSpec typeSpec;
+    private final String packageName;
+    private final TypeSpec typeSpec;
+    private CodeBlock.Builder fileComment = CodeBlock.builder();
 
-    public Builder fileComment(String format, Object... args) {
+    private Builder(String packageName, TypeSpec typeSpec) {
+      this.packageName = checkNotNull(packageName, "packageName == null");
+      this.typeSpec = checkNotNull(typeSpec, "typeSpec == null");
+    }
+
+    public Builder addFileComment(String format, Object... args) {
       this.fileComment.add(format, args);
-      return this;
-    }
-
-    public Builder packageName(String packageName) {
-      this.packageName = checkNotNull(packageName);
-      return this;
-    }
-
-    public Builder typeSpec(TypeSpec typeSpec) {
-      this.typeSpec = typeSpec;
       return this;
     }
 

--- a/src/main/java/com/squareup/javapoet/JavaPoet.java
+++ b/src/main/java/com/squareup/javapoet/JavaPoet.java
@@ -40,10 +40,7 @@ public final class JavaPoet {
   }
 
   public JavaPoet add(String packageName, TypeSpec type) {
-    return add(new JavaFile.Builder()
-        .packageName(packageName)
-        .typeSpec(type)
-        .build());
+    return add(JavaFile.builder(packageName, type).build());
   }
 
   public void writeTo(Path directory) throws IOException {

--- a/src/main/java/com/squareup/javapoet/MethodSpec.java
+++ b/src/main/java/com/squareup/javapoet/MethodSpec.java
@@ -134,14 +134,14 @@ public final class MethodSpec {
   public static final class Builder {
     private final String name;
 
-    private final CodeBlock.Builder javadoc = new CodeBlock.Builder();
+    private final CodeBlock.Builder javadoc = CodeBlock.builder();
     private final List<AnnotationSpec> annotations = new ArrayList<>();
     private final List<Modifier> modifiers = new ArrayList<>();
     private List<TypeVariable<?>> typeVariables = new ArrayList<>();
     private Type returnType;
     private final List<ParameterSpec> parameters = new ArrayList<>();
     private final List<Type> exceptions = new ArrayList<>();
-    private final CodeBlock.Builder code = new CodeBlock.Builder();
+    private final CodeBlock.Builder code = CodeBlock.builder();
     private boolean varargs;
 
     private Builder(String name) {
@@ -162,7 +162,7 @@ public final class MethodSpec {
     }
 
     public Builder addAnnotation(Type annotation) {
-      this.annotations.add(AnnotationSpec.of(annotation));
+      this.annotations.add(AnnotationSpec.builder(annotation).build());
       return this;
     }
 
@@ -188,7 +188,7 @@ public final class MethodSpec {
     }
 
     public Builder addParameter(Type type, String name, Modifier... modifiers) {
-      return addParameter(ParameterSpec.of(type, name, modifiers));
+      return addParameter(ParameterSpec.builder(type, name, modifiers).build());
     }
 
     public Builder varargs() {
@@ -208,6 +208,43 @@ public final class MethodSpec {
 
     public Builder addCode(CodeBlock codeBlock) {
       code.add(codeBlock);
+      return this;
+    }
+
+    /**
+     * @param controlFlow the control flow construct and its code, such as "if (foo == 5)".
+     * Shouldn't contain braces or newline characters.
+     */
+    public Builder beginControlFlow(String controlFlow, Object... args) {
+      code.beginControlFlow(controlFlow, args);
+      return this;
+    }
+
+    /**
+     * @param controlFlow the control flow construct and its code, such as "else if (foo == 10)".
+     *     Shouldn't contain braces or newline characters.
+     */
+    public Builder nextControlFlow(String controlFlow, Object... args) {
+      code.nextControlFlow(controlFlow, args);
+      return this;
+    }
+
+    public Builder endControlFlow() {
+      code.endControlFlow();
+      return this;
+    }
+
+    /**
+     * @param controlFlow the optional control flow construct and its code, such as
+     *     "while(foo == 20)". Only used for "do/while" control flows.
+     */
+    public Builder endControlFlow(String controlFlow, Object... args) {
+      code.endControlFlow(controlFlow, args);
+      return this;
+    }
+
+    public Builder addStatement(String format, Object... args) {
+      code.addStatement(format, args);
       return this;
     }
 

--- a/src/main/java/com/squareup/javapoet/ParameterSpec.java
+++ b/src/main/java/com/squareup/javapoet/ParameterSpec.java
@@ -61,10 +61,6 @@ public final class ParameterSpec {
         .addModifiers(modifiers);
   }
 
-  public static ParameterSpec of(Type type, String name, Modifier... modifiers) {
-    return builder(type, name, modifiers).build();
-  }
-
   public static final class Builder {
     private final Type type;
     private final String name;
@@ -84,7 +80,7 @@ public final class ParameterSpec {
     }
 
     public Builder addAnnotation(Type annotation) {
-      this.annotations.add(AnnotationSpec.of(annotation));
+      this.annotations.add(AnnotationSpec.builder(annotation).build());
       return this;
     }
 

--- a/src/main/java/com/squareup/javapoet/TypeSpec.java
+++ b/src/main/java/com/squareup/javapoet/TypeSpec.java
@@ -121,7 +121,9 @@ public final class TypeSpec {
   }
 
   public static Builder anonymousClassBuilder(String typeArgumentsFormat, Object... args) {
-    return new Builder(DeclarationType.CLASS, null, CodeBlock.of(typeArgumentsFormat, args));
+    return new Builder(DeclarationType.CLASS, null, CodeBlock.builder()
+        .add(typeArgumentsFormat, args)
+        .build());
   }
 
   void emit(CodeWriter codeWriter, String enumName) throws IOException {
@@ -244,7 +246,7 @@ public final class TypeSpec {
     private final String name;
     private final CodeBlock anonymousTypeArguments;
 
-    private final CodeBlock.Builder javadoc = new CodeBlock.Builder();
+    private final CodeBlock.Builder javadoc = CodeBlock.builder();
     private final List<AnnotationSpec> annotations = new ArrayList<>();
     private final List<Modifier> modifiers = new ArrayList<>();
     private final List<TypeVariable<?>> typeVariables = new ArrayList<>();
@@ -277,7 +279,7 @@ public final class TypeSpec {
     }
 
     public Builder addAnnotation(Type annotation) {
-      return addAnnotation(AnnotationSpec.of(annotation));
+      return addAnnotation(AnnotationSpec.builder(annotation).build());
     }
 
     public Builder addModifiers(Modifier... modifiers) {
@@ -321,7 +323,7 @@ public final class TypeSpec {
     }
 
     public Builder addField(Type type, String name, Modifier... modifiers) {
-      return addField(FieldSpec.of(type, name, modifiers));
+      return addField(FieldSpec.builder(type, name, modifiers).build());
     }
 
     public Builder addMethod(MethodSpec methodSpec) {

--- a/src/test/java/com/squareup/javapoet/ClassNameTest.java
+++ b/src/test/java/com/squareup/javapoet/ClassNameTest.java
@@ -79,9 +79,9 @@ public final class ClassNameTest {
 
   @Test public void createNestedClass() {
     ClassName foo = ClassName.get("com.example", "Foo");
-    ClassName bar = foo.nestedClassNamed("Bar");
+    ClassName bar = foo.nestedClass("Bar");
     assertThat(bar).isEqualTo(ClassName.get("com.example", "Foo", "Bar"));
-    ClassName baz = bar.nestedClassNamed("Baz");
+    ClassName baz = bar.nestedClass("Baz");
     assertThat(baz).isEqualTo(ClassName.get("com.example", "Foo", "Bar", "Baz"));
   }
 
@@ -96,6 +96,15 @@ public final class ClassNameTest {
         .isEqualTo("java.lang.Object");
     assertThat(ClassName.get(OuterClass.InnerClass.class).toString())
         .isEqualTo("com.squareup.javapoet.ClassNameTest.OuterClass.InnerClass");
+  }
+
+  @Test public void peerClass() {
+    assertThat(ClassName.get(Double.class).peerClass("Short"))
+        .isEqualTo(ClassName.get(Short.class));
+    assertThat(ClassName.get("", "Double").peerClass("Short"))
+        .isEqualTo(ClassName.get("", "Short"));
+    assertThat(ClassName.get("a.b", "Combo", "Taco").peerClass("Burrito"))
+        .isEqualTo(ClassName.get("a.b", "Combo", "Burrito"));
   }
 
   @Test public void fromClassRejectionTypes() {

--- a/src/test/java/com/squareup/javapoet/JavaFileTest.java
+++ b/src/test/java/com/squareup/javapoet/JavaFileTest.java
@@ -23,10 +23,8 @@ import static com.google.common.truth.Truth.assertThat;
 
 public final class JavaFileTest {
   @Test public void noImports() throws Exception {
-    String source = new JavaFile.Builder()
-        .packageName("com.squareup.tacos")
-        .typeSpec(TypeSpec.classBuilder("Taco")
-            .build())
+    String source = JavaFile.builder("com.squareup.tacos",
+        TypeSpec.classBuilder("Taco").build())
         .build()
         .toString();
     assertThat(source).isEqualTo(""
@@ -37,10 +35,9 @@ public final class JavaFileTest {
   }
 
   @Test public void singleImport() throws Exception {
-    String source = new JavaFile.Builder()
-        .packageName("com.squareup.tacos")
-        .typeSpec(TypeSpec.classBuilder("Taco")
-            .addField(FieldSpec.of(Date.class, "madeFreshDate"))
+    String source = JavaFile.builder("com.squareup.tacos",
+        TypeSpec.classBuilder("Taco")
+            .addField(Date.class, "madeFreshDate")
             .build())
         .build()
         .toString();
@@ -55,11 +52,10 @@ public final class JavaFileTest {
   }
 
   @Test public void conflictingImports() throws Exception {
-    String source = new JavaFile.Builder()
-        .packageName("com.squareup.tacos")
-        .typeSpec(TypeSpec.classBuilder("Taco")
-            .addField(FieldSpec.of(Date.class, "madeFreshDate"))
-            .addField(FieldSpec.of(java.sql.Date.class, "madeFreshDatabaseDate"))
+    String source = JavaFile.builder("com.squareup.tacos",
+        TypeSpec.classBuilder("Taco")
+            .addField(Date.class, "madeFreshDate")
+            .addField(java.sql.Date.class, "madeFreshDatabaseDate")
             .build())
         .build()
         .toString();
@@ -76,8 +72,8 @@ public final class JavaFileTest {
   }
 
   @Test public void defaultPackage() throws Exception {
-    String source = new JavaFile.Builder()
-        .typeSpec(TypeSpec.classBuilder("HelloWorld")
+    String source = JavaFile.builder("",
+        TypeSpec.classBuilder("HelloWorld")
             .addMethod(MethodSpec.methodBuilder("main")
                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
                 .addParameter(String[].class, "args")
@@ -98,10 +94,9 @@ public final class JavaFileTest {
   }
 
   @Test public void topOfFileComment() throws Exception {
-    String source = new JavaFile.Builder()
-        .fileComment("Generated $L by JavaWriter. DO NOT EDIT!", "2015-01-13")
-        .packageName("com.squareup.tacos")
-        .typeSpec(TypeSpec.classBuilder("Taco").build())
+    String source = JavaFile.builder("com.squareup.tacos",
+        TypeSpec.classBuilder("Taco").build())
+        .addFileComment("Generated $L by JavaWriter. DO NOT EDIT!", "2015-01-13")
         .build()
         .toString();
     assertThat(source).isEqualTo(""
@@ -113,11 +108,9 @@ public final class JavaFileTest {
   }
 
   @Test public void emptyLinesInTopOfFileComment() throws Exception {
-    String source = new JavaFile.Builder()
-        .fileComment("\nGENERATED FILE:\n\nDO NOT EDIT!\n")
-        .packageName("com.squareup.tacos")
-        .typeSpec(TypeSpec.classBuilder("Taco")
-            .build())
+    String source = JavaFile.builder("com.squareup.tacos",
+        TypeSpec.classBuilder("Taco").build())
+        .addFileComment("\nGENERATED FILE:\n\nDO NOT EDIT!\n")
         .build()
         .toString();
     assertThat(source).isEqualTo(""

--- a/src/test/java/com/squareup/javapoet/TypeSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/TypeSpecTest.java
@@ -67,9 +67,9 @@ public final class TypeSpecTest {
     ParameterizedType listOfSuper = Types.parameterizedType(
         List.class, Types.supertypeOf(String.class));
     TypeSpec taco = TypeSpec.classBuilder("Taco")
-        .addField(FieldSpec.of(listOfAny, "extendsObject"))
-        .addField(FieldSpec.of(listOfExtends, "extendsSerializable"))
-        .addField(FieldSpec.of(listOfSuper, "superString"))
+        .addField(listOfAny, "extendsObject")
+        .addField(listOfExtends, "extendsSerializable")
+        .addField(listOfSuper, "superString")
         .build();
     assertThat(toString(taco)).isEqualTo(""
         + "package com.squareup.tacos;\n"
@@ -101,7 +101,9 @@ public final class TypeSpecTest {
         = Types.parameterizedType(thung, Types.supertypeOf(foo));
     ParameterizedType simpleThungOfBar = Types.parameterizedType(simpleThung, bar);
 
-    ParameterSpec thungParameter = ParameterSpec.of(thungOfSuperFoo, "thung", Modifier.FINAL);
+    ParameterSpec thungParameter = ParameterSpec.builder(thungOfSuperFoo, "thung")
+        .addModifiers(Modifier.FINAL)
+        .build();
     TypeSpec aSimpleThung = TypeSpec.anonymousClassBuilder("$N", thungParameter)
         .superclass(simpleThungOfBar)
         .addMethod(MethodSpec.methodBuilder("doSomething")
@@ -283,7 +285,7 @@ public final class TypeSpecTest {
   }
 
   @Test public void enumWithSubclassing() throws Exception {
-      TypeSpec roshambo = TypeSpec.enumBuilder("Roshambo")
+    TypeSpec roshambo = TypeSpec.enumBuilder("Roshambo")
         .addModifiers(Modifier.PUBLIC)
         .addEnumConstant("ROCK")
         .addEnumConstant("PAPER", TypeSpec.anonymousClassBuilder("$S", "flat")
@@ -296,7 +298,7 @@ public final class TypeSpecTest {
             .build())
         .addEnumConstant("SCISSORS", TypeSpec.anonymousClassBuilder("$S", "peace sign")
             .build())
-        .addField(FieldSpec.of(String.class, "handPosition", Modifier.PRIVATE, Modifier.FINAL))
+        .addField(String.class, "handPosition", Modifier.PRIVATE, Modifier.FINAL)
         .addMethod(MethodSpec.constructorBuilder()
             .addParameter(String.class, "handPosition")
             .addCode("this.handPosition = handPosition;\n")
@@ -413,9 +415,9 @@ public final class TypeSpecTest {
         .addTypeVariable(t)
         .addTypeVariable(p)
         .addSuperinterface(Types.parameterizedType(Comparable.class, p))
-        .addField(FieldSpec.of(t, "label"))
-        .addField(FieldSpec.of(p, "x"))
-        .addField(FieldSpec.of(p, "y"))
+        .addField(t, "label")
+        .addField(p, "x")
+        .addField(p, "y")
         .addMethod(MethodSpec.methodBuilder("compareTo")
             .addAnnotation(Override.class)
             .addModifiers(Modifier.PUBLIC)
@@ -523,12 +525,12 @@ public final class TypeSpecTest {
     ClassName chips = ClassName.get(tacosPackage, "Combo", "Chips");
     ClassName sauce = ClassName.get(tacosPackage, "Combo", "Sauce");
     TypeSpec typeSpec = TypeSpec.classBuilder("Combo")
-        .addField(FieldSpec.of(taco, "taco"))
-        .addField(FieldSpec.of(chips, "chips"))
+        .addField(taco, "taco")
+        .addField(chips, "chips")
         .addType(TypeSpec.classBuilder(taco.simpleName())
             .addModifiers(Modifier.STATIC)
-            .addField(FieldSpec.of(Types.parameterizedType(List.class, topping), "toppings"))
-            .addField(FieldSpec.of(sauce, "sauce"))
+            .addField(Types.parameterizedType(List.class, topping), "toppings")
+            .addField(sauce, "sauce")
             .addType(TypeSpec.enumBuilder(topping.simpleName())
                 .addEnumConstant("SHREDDED_CHEESE")
                 .addEnumConstant("LEAN_GROUND_BEEF")
@@ -536,8 +538,8 @@ public final class TypeSpecTest {
             .build())
         .addType(TypeSpec.classBuilder(chips.simpleName())
             .addModifiers(Modifier.STATIC)
-            .addField(FieldSpec.of(topping, "topping"))
-            .addField(FieldSpec.of(sauce, "dippingSauce"))
+            .addField(topping, "topping")
+            .addField(sauce, "dippingSauce")
             .build())
         .addType(TypeSpec.enumBuilder(sauce.simpleName())
             .addEnumConstant("SOUR_CREAM")
@@ -591,13 +593,14 @@ public final class TypeSpecTest {
   }
 
   @Test public void referencedAndDeclaredSimpleNamesConflict() throws Exception {
-    FieldSpec internalTop = FieldSpec.of(ClassName.get(tacosPackage, "Top"), "internalTop");
-    FieldSpec internalBottom = FieldSpec.of(ClassName.get(tacosPackage,
-        "Top", "Middle", "Bottom"), "internalBottom");
-    FieldSpec externalTop = FieldSpec.of(
-        ClassName.get(donutsPackage, "Top"), "externalTop");
-    FieldSpec externalBottom = FieldSpec.of(
-        ClassName.get(donutsPackage, "Bottom"), "externalBottom");
+    FieldSpec internalTop = FieldSpec.builder(
+        ClassName.get(tacosPackage, "Top"), "internalTop").build();
+    FieldSpec internalBottom = FieldSpec.builder(
+        ClassName.get(tacosPackage, "Top", "Middle", "Bottom"), "internalBottom").build();
+    FieldSpec externalTop = FieldSpec.builder(
+        ClassName.get(donutsPackage, "Top"), "externalTop").build();
+    FieldSpec externalBottom = FieldSpec.builder(
+        ClassName.get(donutsPackage, "Bottom"), "externalBottom").build();
     TypeSpec top = TypeSpec.classBuilder("Top")
         .addField(internalTop)
         .addField(internalBottom)
@@ -688,7 +691,7 @@ public final class TypeSpecTest {
 
   @Test public void arrayType() {
     TypeSpec taco = TypeSpec.classBuilder("Taco")
-        .addField(FieldSpec.of(int[].class, "ints"))
+        .addField(int[].class, "ints")
         .build();
     assertThat(toString(taco)).isEqualTo(""
         + "package com.squareup.tacos;\n"
@@ -791,19 +794,19 @@ public final class TypeSpecTest {
   }
 
   @Test public void codeBlocks() throws Exception {
-    CodeBlock ifBlock = new CodeBlock.Builder()
+    CodeBlock ifBlock = CodeBlock.builder()
         .beginControlFlow("if (!a.equals(b))")
-        .statement("return i")
+        .addStatement("return i")
         .endControlFlow()
         .build();
-    CodeBlock methodBody = new CodeBlock.Builder()
-        .statement("$T size = $T.min(listA.size(), listB.size())", int.class, Math.class)
+    CodeBlock methodBody = CodeBlock.builder()
+        .addStatement("$T size = $T.min(listA.size(), listB.size())", int.class, Math.class)
         .beginControlFlow("for ($T i = 0; i < size; i++)", int.class)
-        .statement("$T $N = $N.get(i)", String.class, "a", "listA")
-        .statement("$T $N = $N.get(i)", String.class, "b", "listB")
+        .addStatement("$T $N = $N.get(i)", String.class, "a", "listA")
+        .addStatement("$T $N = $N.get(i)", String.class, "b", "listB")
         .add("$L", ifBlock)
         .endControlFlow()
-        .statement("return size")
+        .addStatement("return size")
         .build();
     TypeSpec util = TypeSpec.classBuilder("Util")
         .addMethod(MethodSpec.methodBuilder("commonPrefixLength")
@@ -838,13 +841,11 @@ public final class TypeSpecTest {
   @Test public void elseIf() throws Exception {
     TypeSpec taco = TypeSpec.classBuilder("Taco")
         .addMethod(MethodSpec.methodBuilder("choices")
-            .addCode(new CodeBlock.Builder()
-                .beginControlFlow("if (5 < 4) ")
-                .statement("$T.out.println($S)", System.class, "wat")
-                .nextControlFlow("else if (5 < 6)")
-                .statement("$T.out.println($S)", System.class, "hello")
-                .endControlFlow()
-                .build())
+            .beginControlFlow("if (5 < 4) ")
+            .addStatement("$T.out.println($S)", System.class, "wat")
+            .nextControlFlow("else if (5 < 6)")
+            .addStatement("$T.out.println($S)", System.class, "hello")
+            .endControlFlow()
             .build())
         .build();
     assertThat(toString(taco)).isEqualTo(""
@@ -866,11 +867,9 @@ public final class TypeSpecTest {
   @Test public void doWhile() throws Exception {
     TypeSpec taco = TypeSpec.classBuilder("Taco")
         .addMethod(MethodSpec.methodBuilder("loopForever")
-            .addCode(new CodeBlock.Builder()
-                .beginControlFlow("do")
-                .statement("$T.out.println($S)", System.class, "hello")
-                .endControlFlow("while (5 < 6)")
-                .build())
+            .beginControlFlow("do")
+            .addStatement("$T.out.println($S)", System.class, "hello")
+            .endControlFlow("while (5 < 6)")
             .build())
         .build();
     assertThat(toString(taco)).isEqualTo(""
@@ -908,10 +907,6 @@ public final class TypeSpecTest {
   }
 
   private String toString(TypeSpec typeSpec) {
-    return new JavaFile.Builder()
-        .packageName(tacosPackage)
-        .typeSpec(typeSpec)
-        .build()
-        .toString();
+    return JavaFile.builder(tacosPackage, typeSpec).build().toString();
   }
 }


### PR DESCRIPTION
Drop a convenience overload for addParameter that was inconsistent;
we don't have similar shortcuts for fields.

Also restore peerNamed() needed by Dagger 2.