### PR TITLE
adding configurable indent

### DIFF
--- a/src/main/java/com/squareup/javapoet/CodeWriter.java
+++ b/src/main/java/com/squareup/javapoet/CodeWriter.java
@@ -49,7 +49,7 @@ import static com.google.common.base.Preconditions.checkState;
  * honors imports, indentation, and deferred variable names.
  */
 final class CodeWriter {
-  private final String indent = "  ";
+  private final String indent;
   private final Appendable out;
   private int indentLevel;
 
@@ -68,12 +68,13 @@ final class CodeWriter {
    */
   int statementLine = -1;
 
-  public CodeWriter(Appendable out) {
-    this(out, ImmutableMap.<ClassName, String>of());
+  public CodeWriter(Appendable out, String indent) {
+    this(out, indent, ImmutableMap.<ClassName, String>of());
   }
 
-  public CodeWriter(Appendable out, ImmutableMap<ClassName, String> importedTypes) {
+  public CodeWriter(Appendable out, String indent, ImmutableMap<ClassName, String> importedTypes) {
     this.out = checkNotNull(out);
+    this.indent = checkNotNull(indent);
     this.importedTypes = checkNotNull(importedTypes);
   }
 

--- a/src/main/java/com/squareup/javapoet/JavaFile.java
+++ b/src/main/java/com/squareup/javapoet/JavaFile.java
@@ -46,14 +46,14 @@ public final class JavaFile {
     this.typeSpec = builder.typeSpec;
   }
 
-  public void emit(Appendable out) throws IOException {
+  public void emit(Appendable out, String indent) throws IOException {
     // First pass: emit the entire class, just to collect the types we'll need to import.
-    CodeWriter importsCollector = new CodeWriter(NULL_APPENDABLE);
+    CodeWriter importsCollector = new CodeWriter(NULL_APPENDABLE, indent);
     emit(importsCollector);
     ImmutableMap<ClassName, String> suggestedImports = importsCollector.suggestedImports();
 
     // Second pass: write the code, taking advantage of the imports.
-    CodeWriter codeWriter = new CodeWriter(out, suggestedImports);
+    CodeWriter codeWriter = new CodeWriter(out, indent, suggestedImports);
     emit(codeWriter);
   }
 
@@ -84,7 +84,7 @@ public final class JavaFile {
   public String toString() {
     try {
       StringBuilder result = new StringBuilder();
-      emit(result);
+      emit(result, "  ");
       return result.toString();
     } catch (IOException e) {
       throw new AssertionError();

--- a/src/main/java/com/squareup/javapoet/JavaPoet.java
+++ b/src/main/java/com/squareup/javapoet/JavaPoet.java
@@ -33,6 +33,12 @@ import static com.google.common.base.Preconditions.checkArgument;
 /** Writes generated types to a filesystem using the standard directory structure. */
 public final class JavaPoet {
   private final List<JavaFile> javaFiles = new ArrayList<>();
+  private String indent = "  ";
+
+  public JavaPoet setIndent(String indent) {
+    this.indent = indent;
+    return this;
+  }
 
   public JavaPoet add(JavaFile javaFile) {
     javaFiles.add(javaFile);
@@ -59,7 +65,7 @@ public final class JavaPoet {
 
       Path outputPath = outputDirectory.resolve(javaFile.typeSpec.name + ".java");
       try (Writer writer = new OutputStreamWriter(Files.newOutputStream(outputPath))) {
-        javaFile.emit(writer);
+        javaFile.emit(writer, indent);
       }
     }
   }
@@ -76,7 +82,7 @@ public final class JavaPoet {
       JavaFileObject filerSourceFile = filer.createSourceFile(fileName,
           Iterables.toArray(javaFile.typeSpec.originatingElements, Element.class));
       try (Writer writer = filerSourceFile.openWriter()) {
-        javaFile.emit(writer);
+        javaFile.emit(writer, indent);
       } catch (Exception e) {
         try {
           filerSourceFile.delete();

--- a/src/main/java/com/squareup/javapoet/Types.java
+++ b/src/main/java/com/squareup/javapoet/Types.java
@@ -347,7 +347,7 @@ public final class Types {
   private static String typeToString(Type type) {
     try {
       StringBuilder result = new StringBuilder();
-      new CodeWriter(result).emit("$T", type);
+      new CodeWriter(result, "  ").emit("$T", type);
       return result.toString();
     } catch (IOException e) {
       throw new AssertionError();

--- a/src/test/java/com/squareup/javapoet/JavaFileTest.java
+++ b/src/test/java/com/squareup/javapoet/JavaFileTest.java
@@ -96,11 +96,11 @@ public final class JavaFileTest {
   @Test public void topOfFileComment() throws Exception {
     String source = JavaFile.builder("com.squareup.tacos",
         TypeSpec.classBuilder("Taco").build())
-        .addFileComment("Generated $L by JavaWriter. DO NOT EDIT!", "2015-01-13")
+        .addFileComment("Generated $L by JavaPoet. DO NOT EDIT!", "2015-01-13")
         .build()
         .toString();
     assertThat(source).isEqualTo(""
-        + "// Generated 2015-01-13 by JavaWriter. DO NOT EDIT!\n"
+        + "// Generated 2015-01-13 by JavaPoet. DO NOT EDIT!\n"
         + "package com.squareup.tacos;\n"
         + "\n"
         + "class Taco {\n"

--- a/src/test/java/com/squareup/javapoet/JavaPoetTest.java
+++ b/src/test/java/com/squareup/javapoet/JavaPoetTest.java
@@ -22,7 +22,9 @@ import java.io.IOException;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Date;
 import javax.lang.model.element.Element;
+import javax.lang.model.element.Modifier;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -192,5 +194,36 @@ public final class JavaPoetTest {
     assertThat(filer.getOriginatingElements(testPath1)).containsExactly(element1_1);
     Path testPath2 = fsRoot.resolve(fs.getPath("example", "Test2.java"));
     assertThat(filer.getOriginatingElements(testPath2)).containsExactly(element2_1, element2_2);
+  }
+
+  @Test public void filerClassesWithTabIndent() throws IOException {
+    TypeSpec test = TypeSpec.classBuilder("Test")
+        .addField(Date.class, "madeFreshDate")
+        .addMethod(MethodSpec.methodBuilder("main")
+            .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+            .addParameter(String[].class, "args")
+            .addCode("$T.out.println($S);\n", System.class, "Hello World!")
+            .build())
+        .build();
+    javaPoet.add("foo", test).setIndent("\t").writeTo(filer);
+
+    Path fooPath = fsRoot.resolve(fs.getPath("foo", "Test.java"));
+    assertThat(Files.exists(fooPath)).isTrue();
+    String source = new String(Files.readAllBytes(fooPath));
+
+    assertThat(source).isEqualTo(""
+        + "package foo;\n"
+        + "\n"
+        + "import java.lang.String;\n"
+        + "import java.lang.System;\n"
+        + "import java.util.Date;\n"
+        + "\n"
+        + "class Test {\n"
+        + "\tDate madeFreshDate;\n"
+        + "\n"
+        + "\tpublic static void main(String[] args) {\n"
+        + "\t\tSystem.out.println(\"Hello World!\");\n"
+        + "\t}\n"
+        + "}\n");
   }
 }


### PR DESCRIPTION
Hi,

I have added configurable indent. It solves issue #106 . Indent can be configured in `JavaPoet` class (old `JavaWriter` class). Exemplary usage of the configurable indent is presented in the following code snippet:
```java
new JavaPoet(new Indent().level(4));
```

In addition, I've added appropriate Unit Tests verifying behavior of the library with new functionality.
I wanted to make code clean and as abstract as possible.

I hope it would be useful for you.

Regards,
Piotr 