### PR TITLE
Add @RunWith boilerplate to tests

### DIFF
--- a/src/test/java/com/squareup/javapoet/ClassNameTest.java
+++ b/src/test/java/com/squareup/javapoet/ClassNameTest.java
@@ -21,11 +21,14 @@ import javax.lang.model.element.TypeElement;
 import javax.lang.model.util.Elements;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
+@RunWith(JUnit4.class)
 public final class ClassNameTest {
   @Rule public CompilationRule compilationRule = new CompilationRule();
 

--- a/src/test/java/com/squareup/javapoet/FileWritingTest.java
+++ b/src/test/java/com/squareup/javapoet/FileWritingTest.java
@@ -27,11 +27,14 @@ import javax.lang.model.element.Modifier;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 import org.mockito.Mockito;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 
+@RunWith(JUnit4.class)
 public final class FileWritingTest {
   // Used for testing java.io File behavior.
   @Rule public final TemporaryFolder tmp = new TemporaryFolder();

--- a/src/test/java/com/squareup/javapoet/JavaFileTest.java
+++ b/src/test/java/com/squareup/javapoet/JavaFileTest.java
@@ -18,9 +18,12 @@ package com.squareup.javapoet;
 import java.util.Date;
 import javax.lang.model.element.Modifier;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 import static com.google.common.truth.Truth.assertThat;
 
+@RunWith(JUnit4.class)
 public final class JavaFileTest {
   @Test public void noImports() throws Exception {
     String source = JavaFile.builder("com.squareup.tacos",

--- a/src/test/java/com/squareup/javapoet/TypeSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/TypeSpecTest.java
@@ -27,6 +27,8 @@ import java.util.Random;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.Modifier;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 import org.mockito.Mockito;
 
 import com.google.common.collect.ImmutableMap;
@@ -34,6 +36,7 @@ import com.google.common.collect.ImmutableMap;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 
+@RunWith(JUnit4.class)
 public final class TypeSpecTest {
   private final String tacosPackage = "com.squareup.tacos";
   private static final String donutsPackage = "com.squareup.donuts";

--- a/src/test/java/com/squareup/javapoet/TypesTest.java
+++ b/src/test/java/com/squareup/javapoet/TypesTest.java
@@ -28,10 +28,13 @@ import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 
+@RunWith(JUnit4.class)
 public final class TypesTest {
   @Rule public final CompilationRule compilation = new CompilationRule();
 


### PR DESCRIPTION
Add @RunWith boilerplate to tests - lets alternative test runners in other build systems pick the correct runner.