### PR TITLE
Fix WildcardTypeName.get(WildcardType)

### DIFF
--- a/src/main/java/com/squareup/javapoet/WildcardTypeName.java
+++ b/src/main/java/com/squareup/javapoet/WildcardTypeName.java
@@ -21,6 +21,7 @@ import java.lang.reflect.WildcardType;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import javax.lang.model.type.TypeMirror;
 
 import static com.squareup.javapoet.Util.checkArgument;
 
@@ -89,9 +90,17 @@ public final class WildcardTypeName extends TypeName {
   }
 
   public static TypeName get(javax.lang.model.type.WildcardType mirror) {
-    TypeName extendsBound = TypeName.get(mirror.getExtendsBound());
-    TypeName superBound = TypeName.get(mirror.getSuperBound());
-    return superBound != null ? supertypeOf(superBound) : subtypeOf(extendsBound);
+    TypeMirror extendsBound = mirror.getExtendsBound();
+    if (extendsBound == null) {
+      TypeMirror superBound = mirror.getSuperBound();
+      if (superBound == null) {
+        return subtypeOf(Object.class);
+      } else {
+        return supertypeOf(TypeName.get(superBound));
+      }
+    } else {
+      return subtypeOf(TypeName.get(extendsBound));
+    }
   }
 
   public static TypeName get(WildcardType wildcardName) {

--- a/src/test/java/com/squareup/javapoet/TypesTest.java
+++ b/src/test/java/com/squareup/javapoet/TypesTest.java
@@ -26,6 +26,9 @@ import javax.lang.model.element.TypeParameterElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
+import javax.lang.model.type.WildcardType;
+import javax.lang.model.util.Elements;
+import javax.lang.model.util.Types;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -154,6 +157,30 @@ public final class TypesTest {
 
   @Test public void wildcardSuperType() throws Exception {
     WildcardTypeName type = WildcardTypeName.supertypeOf(String.class);
+    assertThat(type.toString()).isEqualTo("? super java.lang.String");
+  }
+
+  @Test public void wildcardMirrorNoBounds() throws Exception {
+    WildcardType wildcard = compilation.getTypes().getWildcardType(null, null);
+    TypeName type = TypeName.get(wildcard);
+    assertThat(type.toString()).isEqualTo("?");
+  }
+
+  @Test public void wildcardMirrorExtendsType() throws Exception {
+    Types types = compilation.getTypes();
+    Elements elements = compilation.getElements();
+    TypeMirror charSequence = elements.getTypeElement(CharSequence.class.getName()).asType();
+    WildcardType wildcard = types.getWildcardType(charSequence, null);
+    TypeName type = TypeName.get(wildcard);
+    assertThat(type.toString()).isEqualTo("? extends java.lang.CharSequence");
+  }
+
+  @Test public void wildcardMirrorSuperType() throws Exception {
+    Types types = compilation.getTypes();
+    Elements elements = compilation.getElements();
+    TypeMirror string = elements.getTypeElement(String.class.getName()).asType();
+    WildcardType wildcard = types.getWildcardType(null, string);
+    TypeName type = TypeName.get(wildcard);
     assertThat(type.toString()).isEqualTo("? super java.lang.String");
   }
 


### PR DESCRIPTION
It would always fail with NulllPointerException since either the extends bound or the super bound or both will be null.