### PR TITLE
Change CodeBlock.nextControlFlow to be consistent with beginControlFlow.

### DIFF
--- a/src/main/java/com/squareup/javapoet/CodeBlock.java
+++ b/src/main/java/com/squareup/javapoet/CodeBlock.java
@@ -145,7 +145,7 @@ public final class CodeBlock {
       unindent();
       add("} ", args);
       add(controlFlow, args);
-      add("{\n", args);
+      add(" {\n", args);
       indent();
       return this;
     }

--- a/src/test/java/com/squareup/javapoet/TypeSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/TypeSpecTest.java
@@ -924,7 +924,7 @@ public final class TypeSpecTest {
         + "  void choices() {\n"
         + "    if (5 < 4)  {\n"
         + "      System.out.println(\"wat\");\n"
-        + "    } else if (5 < 6){\n"
+        + "    } else if (5 < 6) {\n"
         + "      System.out.println(\"hello\");\n"
         + "    }\n"
         + "  }\n"


### PR DESCRIPTION
It should include a space before {. Bizarrely, a test checks the current behaviour, but I don't see how it can be desirable.