### PR TITLE
Add precondition check when specifying the superclass

### DIFF
--- a/src/main/java/com/squareup/javapoet/TypeSpec.java
+++ b/src/main/java/com/squareup/javapoet/TypeSpec.java
@@ -366,6 +366,9 @@ public final class TypeSpec {
     }
 
     public Builder superclass(TypeName superclass) {
+      checkState(this.superclass == ClassName.OBJECT,
+          "superclass already set to " + this.superclass);
+      checkArgument(!superclass.isPrimitive(), "superclass may not be a primitive");
       this.superclass = superclass;
       return this;
     }

--- a/src/test/java/com/squareup/javapoet/TypeSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/TypeSpecTest.java
@@ -1738,6 +1738,22 @@ public final class TypeSpecTest {
     }
   }
 
+  @Test public void invalidSuperClass() {
+    try {
+      TypeSpec.classBuilder("foo")
+          .superclass(ClassName.get(List.class))
+          .superclass(ClassName.get(Map.class));
+      fail();
+    } catch (IllegalStateException expected) {
+    }
+    try {
+      TypeSpec.classBuilder("foo")
+          .superclass(TypeName.INT);
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
+  }
+
   private CodeBlock codeBlock(String format, Object... args) {
     return CodeBlock.builder()
         .add(format, args)


### PR DESCRIPTION
This is a simple check to avoid duplicate settings and primitive
types. This does not assert that the parameter is set to
`ClassName.OBJECT` twice, as that seemed to be an unnecessary
complication.