### PR TITLE
Rename toBuilder() to builder().

### DIFF
--- a/src/main/java/com/squareup/javapoet/AnnotationSpec.java
+++ b/src/main/java/com/squareup/javapoet/AnnotationSpec.java
@@ -99,7 +99,7 @@ public final class AnnotationSpec {
     return builder(ClassName.get(type));
   }
 
-  public Builder toBuilder() {
+  public Builder builder() {
     Builder builder = new Builder(type);
     builder.members.putAll(members);
     return builder;

--- a/src/main/java/com/squareup/javapoet/CodeBlock.java
+++ b/src/main/java/com/squareup/javapoet/CodeBlock.java
@@ -86,13 +86,6 @@ public final class CodeBlock {
     return new Builder();
   }
 
-  public Builder toBuilder() {
-    Builder builder = new Builder();
-    builder.formatParts.addAll(formatParts);
-    builder.args.addAll(args);
-    return builder;
-  }
-
   public static final class Builder {
     final List<String> formatParts = new ArrayList<>();
     final List<Object> args = new ArrayList<>();

--- a/src/main/java/com/squareup/javapoet/FieldSpec.java
+++ b/src/main/java/com/squareup/javapoet/FieldSpec.java
@@ -89,7 +89,7 @@ public final class FieldSpec {
     return builder(TypeName.get(type), name, modifiers);
   }
 
-  public Builder toBuilder() {
+  public Builder builder() {
     Builder builder = new Builder(type, name);
     builder.javadoc.add(javadoc);
     builder.annotations.addAll(annotations);

--- a/src/main/java/com/squareup/javapoet/JavaFile.java
+++ b/src/main/java/com/squareup/javapoet/JavaFile.java
@@ -157,7 +157,7 @@ public final class JavaFile {
     return new Builder(packageName, typeSpec);
   }
 
-  public Builder toBuilder() {
+  public Builder builder() {
     Builder builder = new Builder(packageName, typeSpec);
     builder.fileComment.add(fileComment);
     builder.skipJavaLangImports = skipJavaLangImports;

--- a/src/main/java/com/squareup/javapoet/MethodSpec.java
+++ b/src/main/java/com/squareup/javapoet/MethodSpec.java
@@ -210,7 +210,7 @@ public final class MethodSpec {
     return methodBuilder;
   }
 
-  public Builder toBuilder() {
+  public Builder builder() {
     Builder builder = new Builder(name);
     builder.javadoc.add(javadoc);
     builder.annotations.addAll(annotations);

--- a/src/main/java/com/squareup/javapoet/ParameterSpec.java
+++ b/src/main/java/com/squareup/javapoet/ParameterSpec.java
@@ -79,7 +79,7 @@ public final class ParameterSpec {
     return builder(TypeName.get(type), name, modifiers);
   }
 
-  public Builder toBuilder() {
+  public Builder builder() {
     Builder builder = new Builder(type, name);
     builder.annotations.addAll(annotations);
     builder.modifiers.addAll(modifiers);

--- a/src/main/java/com/squareup/javapoet/TypeSpec.java
+++ b/src/main/java/com/squareup/javapoet/TypeSpec.java
@@ -102,7 +102,7 @@ public final class TypeSpec {
     return new Builder(Kind.ANNOTATION, checkNotNull(name, "name == null"), null);
   }
 
-  public Builder toBuilder() {
+  public Builder builder() {
     Builder builder = new Builder(kind, name, anonymousTypeArguments);
     builder.javadoc.add(javadoc);
     builder.annotations.addAll(annotations);


### PR DESCRIPTION
I had a small insight: the only place where the static builder()
method conflicted with the non-static builder() method was in
CodeBlock. That class is composable: it's just as easy to create
a new code block, and call add(), as it is to convert an existing
code block into a builder. So we don't need the toBuilder() method
there anyway.