### PR TITLE
Fix import error.

### DIFF
--- a/src/main/java/com/squareup/javapoet/CodeWriter.java
+++ b/src/main/java/com/squareup/javapoet/CodeWriter.java
@@ -49,6 +49,7 @@ final class CodeWriter {
   private final List<TypeSpec> typeSpecStack = new ArrayList<>();
   private final Map<ClassName, String> importedTypes;
   private final Set<ClassName> importableTypes = new LinkedHashSet<>();
+  private final Set<String> referencedNames = new LinkedHashSet<>();
   private boolean trailingNewline;
 
   /**
@@ -280,6 +281,7 @@ final class CodeWriter {
       String importedName = importedTypes.get(className);
       if (importedName != null) {
         if (!javadoc) importableTypes.add(className);
+        referencedNames.add(importedName);
         return importedName;
       }
 
@@ -301,6 +303,7 @@ final class CodeWriter {
       return className.simpleName(); // Special case: a class referring to itself!
     }
 
+    referencedNames.add(classNames.get(0));
     return Util.join(".", classNames.subList(prefixLength, classNames.size()));
   }
 
@@ -391,6 +394,7 @@ final class CodeWriter {
     // Find the simple names that can be imported, and the classes that they target.
     Map<String, ClassName> simpleNameToType = new LinkedHashMap<>();
     for (ClassName className : importableTypes) {
+      if (referencedNames.contains(className.simpleName())) continue;
       if (simpleNameToType.containsKey(className.simpleName())) continue;
       simpleNameToType.put(className.simpleName(), className);
     }

--- a/src/test/java/com/squareup/javapoet/TypeSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/TypeSpecTest.java
@@ -811,6 +811,25 @@ public final class TypeSpecTest {
         + "}\n");
   }
 
+  @Test public void simpleNamesConflictInThisAndOtherPackage() throws Exception {
+    FieldSpec internalOther = FieldSpec.builder(
+        ClassName.get(tacosPackage, "Other"), "internalOther").build();
+    FieldSpec externalOther = FieldSpec.builder(
+        ClassName.get(donutsPackage, "Other"), "externalOther").build();
+    TypeSpec gen = TypeSpec.classBuilder("Gen")
+        .addField(internalOther)
+        .addField(externalOther)
+        .build();
+    assertThat(toString(gen)).isEqualTo(""
+        + "package com.squareup.tacos;\n"
+        + "\n"
+        + "class Gen {\n"
+        + "  Other internalOther;\n"
+        + "\n"
+        + "  com.squareup.donuts.Other externalOther;\n"
+        + "}\n");
+  }
+
   @Test public void originatingElementsIncludesThoseOfNestedTypes() {
     Element outerElement = Mockito.mock(Element.class);
     Element innerElement = Mockito.mock(Element.class);


### PR DESCRIPTION
When a type in the current package has the same name as a type in another package, javapoet should not attempt to import the other package's type; rather, it should just refer to it by its fully qualified name.