### PR TITLE
Prevent potential NPE when getting package reference.

### DIFF
--- a/src/main/java/com/squareup/javapoet/ClassName.java
+++ b/src/main/java/com/squareup/javapoet/ClassName.java
@@ -104,7 +104,8 @@ public final class ClassName extends TypeName implements Comparable<ClassName> {
     for (Class<?> c = clazz; c != null; c = c.getEnclosingClass()) {
       names.add(c.getSimpleName());
     }
-    names.add(clazz.getPackage().getName());
+    if (clazz.getPackage() != null)
+      names.add(clazz.getPackage().getName());
     Collections.reverse(names);
     return new ClassName(names);
   }


### PR DESCRIPTION
Class.getPackage() might return null, and does for Proxy instances.
Better guard .getName() with null-check.