### PR TITLE
AnnotationSpec.get and MethodSpec.overriding

### DIFF
--- a/src/main/java/com/squareup/javapoet/AnnotationSpec.java
+++ b/src/main/java/com/squareup/javapoet/AnnotationSpec.java
@@ -25,6 +25,14 @@ import java.util.Map;
 
 import static com.squareup.javapoet.Util.checkNotNull;
 
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.SimpleAnnotationValueVisitor7;
+
 /** A generated annotation on a declaration. */
 public final class AnnotationSpec {
   public final TypeName type;
@@ -90,6 +98,18 @@ public final class AnnotationSpec {
     codeWriter.emit(whitespace + "}");
   }
 
+  public static AnnotationSpec get(AnnotationMirror annotation) {
+    TypeElement element = (TypeElement) annotation.getAnnotationType().asElement();
+    AnnotationSpec.Builder builder = AnnotationSpec.builder(ClassName.get(element));
+    Visitor visitor = new Visitor(builder);
+    for (ExecutableElement executableElement : annotation.getElementValues().keySet()) {
+      String name = executableElement.getSimpleName().toString();
+      AnnotationValue value = annotation.getElementValues().get(executableElement);
+      value.accept(visitor, new Entry(name, value));
+    }
+    return builder.build();
+  }
+
   public static Builder builder(ClassName type) {
     checkNotNull(type, "type == null");
     return new Builder(type);
@@ -152,4 +172,50 @@ public final class AnnotationSpec {
       return new AnnotationSpec(this);
     }
   }
+
+  /**
+   * Tuple of name and value.
+   */
+  private static class Entry {
+    final String name;
+    final AnnotationValue value;
+
+    Entry(String name, AnnotationValue value) {
+      this.name = name;
+      this.value = value;
+    }
+  }
+
+  /**
+   * Annotation value visitor adding members to the given builder instance.
+   */
+  private static class Visitor extends SimpleAnnotationValueVisitor7<Builder, Entry> {
+    final Builder builder;
+
+    Visitor(Builder builder) {
+      super(builder);
+      this.builder = builder;
+    }
+
+    @Override
+    protected Builder defaultAction(Object o, Entry entry) {
+      return builder.addMember(entry.name, "$L", entry.value);
+    }
+
+    @Override
+    public Builder visitAnnotation(AnnotationMirror a, Entry entry) {
+      return builder.addMember(entry.name, "$L", get(a));
+    }
+
+    @Override
+    public Builder visitEnumConstant(VariableElement c, Entry entry) {
+      return builder.addMember(entry.name, "$T.$L", c.asType(), c.getSimpleName());
+    }
+
+    @Override
+    public Builder visitType(TypeMirror t, Entry entry) {
+      return builder.addMember(entry.name, "$T.class", t);
+    }
+  }
+
 }

--- a/src/test/java/com/squareup/javapoet/AnnotationSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/AnnotationSpecTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.javapoet;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.lang.annotation.Annotation;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import javax.lang.model.element.TypeElement;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.google.testing.compile.CompilationRule;
+
+public final class AnnotationSpecTest {
+
+  @Retention(RetentionPolicy.RUNTIME)
+  public @interface AnnotationA {
+  }
+
+  @Inherited
+  @Retention(RetentionPolicy.RUNTIME)
+  public @interface AnnotationB {
+  }
+
+  @Retention(RetentionPolicy.RUNTIME)
+  public @interface AnnotationC {
+    String value();
+  }
+
+  static enum Breakfast {
+    WAFFLES, PANCAKES
+  }
+
+  @Retention(RetentionPolicy.RUNTIME)
+  public @interface HasDefaultsAnnotation {
+
+    byte a() default 5;
+
+    short b() default 6;
+
+    int c() default 7;
+
+    long d() default 8;
+
+    float e() default 9.0f;
+
+    double f() default 10.0;
+
+    char g() default 'k';
+
+    boolean h() default true;
+
+    Breakfast i() default Breakfast.WAFFLES;
+
+    AnnotationA j() default @AnnotationA();
+
+    String k() default "maple";
+
+    Class<? extends Annotation> l() default AnnotationB.class;
+
+    int[] m() default {1, 2, 3};
+
+    Breakfast[] n() default {Breakfast.WAFFLES, Breakfast.PANCAKES};
+
+    Breakfast o();
+
+    int p();
+
+    AnnotationC q() default @AnnotationC("foo");
+  }
+
+  @HasDefaultsAnnotation(
+      o = Breakfast.PANCAKES,
+      p = 1701,
+      f = 11.1,
+      m = {9, 8, 1},
+      l = Override.class,
+      j = @AnnotationA,
+      q = @AnnotationC("bar"))
+  public class IsAnnotated {
+    // empty
+  }
+
+  @Rule
+  public final CompilationRule compilation = new CompilationRule();
+
+  @Test
+  public void testHasDefaultAnnotation() {
+    String name = IsAnnotated.class.getCanonicalName();
+    TypeElement element = compilation.getElements().getTypeElement(name);
+    AnnotationSpec annotation = AnnotationSpec.get(element.getAnnotationMirrors().get(0));
+    assertThat(annotation.toString()).isEqualTo(
+        "@com.squareup.javapoet.AnnotationSpecTest.HasDefaultsAnnotation("
+            + "o = com.squareup.javapoet.AnnotationSpecTest.Breakfast.PANCAKES"
+            + ", p = 1701"
+            + ", f = 11.1"
+            + ", m = {9, 8, 1}"
+            + ", l = java.lang.Override.class"
+            + ", j = @com.squareup.javapoet.AnnotationSpecTest.AnnotationA"
+            + ", q = @com.squareup.javapoet.AnnotationSpecTest.AnnotationC(\"bar\")"
+            + ")");
+  }
+
+  @Test
+  public void testHasDefaultAnnotationWithImport() {
+    String name = IsAnnotated.class.getCanonicalName();
+    TypeElement element = compilation.getElements().getTypeElement(name);
+    AnnotationSpec annotation = AnnotationSpec.get(element.getAnnotationMirrors().get(0));
+    TypeSpec.Builder typeBuilder = TypeSpec.classBuilder(IsAnnotated.class.getSimpleName());
+    typeBuilder.addAnnotation(annotation);
+    JavaFile file = JavaFile.builder("com.squareup.javapoet", typeBuilder.build()).build();
+    assertThat(file.toString()).isEqualTo(
+        "package com.squareup.javapoet;\n"
+            + "\n"
+            + "import java.lang.Override;\n"
+            + "\n"
+            + "@AnnotationSpecTest.HasDefaultsAnnotation(\n"
+            + "    o = AnnotationSpecTest.Breakfast.PANCAKES,\n"
+            + "    p = 1701,\n"
+            + "    f = 11.1,\n"
+            + "    m = {9, 8, 1},\n"
+            + "    l = Override.class,\n"
+            + "    j = @AnnotationSpecTest.AnnotationA,\n"
+            + "    q = @AnnotationSpecTest.AnnotationC(\"bar\")\n"
+            + ")\n"
+            + "class IsAnnotated {\n"
+            + "}\n"
+    );
+  }
+}


### PR DESCRIPTION
Added static get method to AnnotationSpec using an AnnotationMirror as source.

Next, I implemented some of the TODOs in MethodSpec.overriding - and changed the signature to include an ExecutableType. That allows the actual generic type parameters retrieval for the return type and the signature.
See the interface extending parameterized interfaces test case: ExtendsOthers in MethodSpecTest.

PS: This time, checkstyle and unit tests are green: https://travis-ci.org/sormuras/javapoet