### PR TITLE
Poetry, or javax.lang.model-related utilities.

### DIFF
--- a/src/main/java/com/squareup/javapoet/MethodSpec.java
+++ b/src/main/java/com/squareup/javapoet/MethodSpec.java
@@ -22,16 +22,10 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import javax.lang.model.SourceVersion;
-import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
-import javax.lang.model.element.TypeParameterElement;
-import javax.lang.model.element.VariableElement;
-import javax.lang.model.type.TypeMirror;
-import javax.lang.model.type.TypeVariable;
 
 import static com.squareup.javapoet.Util.checkArgument;
 import static com.squareup.javapoet.Util.checkNotNull;
@@ -98,7 +92,8 @@ public final class MethodSpec {
     boolean firstParameter = true;
     for (Iterator<ParameterSpec> i = parameters.iterator(); i.hasNext();) {
       ParameterSpec parameter = i.next();
-      if (!firstParameter) codeWriter.emit(", ");
+      if (!firstParameter)
+        codeWriter.emit(", ");
       parameter.emit(codeWriter, !i.hasNext() && varargs);
       firstParameter = false;
     }
@@ -114,7 +109,8 @@ public final class MethodSpec {
       codeWriter.emit(" throws");
       boolean firstException = true;
       for (TypeName exception : exceptions) {
-        if (!firstException) codeWriter.emit(",");
+        if (!firstException)
+          codeWriter.emit(",");
         codeWriter.emit(" $T", exception);
         firstException = false;
       }
@@ -145,7 +141,8 @@ public final class MethodSpec {
     return name.equals(CONSTRUCTOR);
   }
 
-  @Override public String toString() {
+  @Override
+  public String toString() {
     StringWriter out = new StringWriter();
     try {
       CodeWriter codeWriter = new CodeWriter(out);
@@ -162,52 +159,6 @@ public final class MethodSpec {
 
   public static Builder constructorBuilder() {
     return new Builder(CONSTRUCTOR);
-  }
-
-  /**
-   * Create a builder which overrides {@code method}. This will copy its visibility modifiers, type
-   * parameters, return type, name, parameters, and throws declarations. An {@link Override}
-   * annotation will be added.
-   */
-  public static Builder overriding(ExecutableElement method) {
-    checkNotNull(method, "method == null");
-
-    Set<Modifier> modifiers = method.getModifiers();
-    if (modifiers.contains(Modifier.PRIVATE)
-        || modifiers.contains(Modifier.FINAL)
-        || modifiers.contains(Modifier.STATIC)) {
-      throw new IllegalArgumentException("cannot override method with modifiers: " + modifiers);
-    }
-
-    String methodName = method.getSimpleName().toString();
-    MethodSpec.Builder methodBuilder = MethodSpec.methodBuilder(methodName);
-
-    // TODO copy method annotations.
-    // TODO check to ensure we're not duplicating override annotation.
-    methodBuilder.addAnnotation(Override.class);
-
-    modifiers = new LinkedHashSet<>(modifiers); // Local copy so we can remove.
-    modifiers.remove(Modifier.ABSTRACT);
-    methodBuilder.addModifiers(modifiers);
-
-    for (TypeParameterElement typeParameterElement : method.getTypeParameters()) {
-      methodBuilder.addTypeVariable(
-          TypeVariableName.get((TypeVariable) typeParameterElement.asType()));
-    }
-
-    methodBuilder.returns(TypeName.get(method.getReturnType()));
-
-    for (VariableElement parameter : method.getParameters()) {
-      // TODO copy parameter annotations.
-      methodBuilder.addParameter(TypeName.get(parameter.asType()),
-          parameter.getSimpleName().toString());
-    }
-
-    for (TypeMirror thrownType : method.getThrownTypes()) {
-      methodBuilder.addException(TypeName.get(thrownType));
-    }
-
-    return methodBuilder;
   }
 
   public Builder toBuilder() {
@@ -240,8 +191,8 @@ public final class MethodSpec {
     private CodeBlock defaultValue;
 
     private Builder(String name) {
-      checkArgument(name.equals(CONSTRUCTOR) || SourceVersion.isName(name),
-          "not a valid name: %s", name);
+      checkArgument(name.equals(CONSTRUCTOR) || SourceVersion.isName(name), "not a valid name: %s",
+          name);
       this.name = name;
       this.returnType = name.equals(CONSTRUCTOR) ? null : TypeName.VOID;
     }
@@ -363,8 +314,9 @@ public final class MethodSpec {
     }
 
     /**
-     * @param controlFlow the control flow construct and its code, such as "if (foo == 5)".
-     * Shouldn't contain braces or newline characters.
+     * @param controlFlow
+     *          the control flow construct and its code, such as "if (foo == 5)". Shouldn't contain
+     *          braces or newline characters.
      */
     public Builder beginControlFlow(String controlFlow, Object... args) {
       code.beginControlFlow(controlFlow, args);
@@ -372,8 +324,9 @@ public final class MethodSpec {
     }
 
     /**
-     * @param controlFlow the control flow construct and its code, such as "else if (foo == 10)".
-     *     Shouldn't contain braces or newline characters.
+     * @param controlFlow
+     *          the control flow construct and its code, such as "else if (foo == 10)". Shouldn't
+     *          contain braces or newline characters.
      */
     public Builder nextControlFlow(String controlFlow, Object... args) {
       code.nextControlFlow(controlFlow, args);
@@ -386,8 +339,9 @@ public final class MethodSpec {
     }
 
     /**
-     * @param controlFlow the optional control flow construct and its code, such as
-     *     "while(foo == 20)". Only used for "do/while" control flows.
+     * @param controlFlow
+     *          the optional control flow construct and its code, such as "while(foo == 20)". Only
+     *          used for "do/while" control flows.
      */
     public Builder endControlFlow(String controlFlow, Object... args) {
       code.endControlFlow(controlFlow, args);

--- a/src/main/java/com/squareup/javapoet/Poetry.java
+++ b/src/main/java/com/squareup/javapoet/Poetry.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.javapoet;
+
+import static com.squareup.javapoet.Util.checkNotNull;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.TypeParameterElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.ExecutableType;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.type.TypeVariable;
+import javax.lang.model.util.Elements;
+import javax.lang.model.util.Types;
+
+/**
+ * Provides utilities based on parsing elements and types from javax.lang.model instances.
+ *
+ * @author Christian Stein
+ */
+public class Poetry {
+
+  protected final Elements elements;
+  protected final Types types;
+
+  public Poetry(Elements elements, Types types) {
+    checkNotNull(elements, "elements==null");
+    checkNotNull(types, "types==null");
+    this.elements = elements;
+    this.types = types;
+  }
+
+  /**
+   * Create a method spec builder which overrides {@code method}.
+   *
+   * Same as {@code overriding(method, (DeclaredType) method.getEnclosingElement().asType())}.
+   */
+  public MethodSpec.Builder overriding(ExecutableElement method) {
+    return overriding(method, (DeclaredType) method.getEnclosingElement().asType());
+  }
+
+  /**
+   * Create a method spec builder which overrides {@code method} that is viewed as being a member of
+   * the specified {@code containing} class or interface.
+   *
+   * This will copy its visibility modifiers, type parameters, return type, name, parameters, and
+   * throws declarations. An {@link Override} annotation will be added.
+   */
+  public MethodSpec.Builder overriding(ExecutableElement method, DeclaredType containing) {
+    checkNotNull(method, "method == null");
+    checkNotNull(containing, "containing == null");
+
+    Set<Modifier> modifiers = method.getModifiers();
+    if (modifiers.contains(Modifier.PRIVATE)
+        || modifiers.contains(Modifier.FINAL)
+        || modifiers.contains(Modifier.STATIC)) {
+      throw new IllegalArgumentException("cannot override method with modifiers: " + modifiers);
+    }
+
+    String methodName = method.getSimpleName().toString();
+    MethodSpec.Builder methodBuilder = MethodSpec.methodBuilder(methodName);
+
+    methodBuilder.addAnnotation(Override.class);
+    TypeMirror overrideType = elements.getTypeElement(Override.class.getCanonicalName()).asType();
+    for (AnnotationMirror mirror : method.getAnnotationMirrors()) {
+      if (types.isSameType(mirror.getAnnotationType(), overrideType)) {
+        continue;
+      }
+      methodBuilder.addAnnotation(AnnotationSpec.get(mirror));
+    }
+
+    modifiers = new LinkedHashSet<>(modifiers); // Local copy so we can remove.
+    modifiers.remove(Modifier.ABSTRACT);
+    methodBuilder.addModifiers(modifiers);
+
+    for (TypeParameterElement typeParameterElement : method.getTypeParameters()) {
+      TypeVariable var = (TypeVariable) typeParameterElement.asType();
+      methodBuilder.addTypeVariable(TypeVariableName.get(var));
+    }
+
+    ExecutableType executableType = (ExecutableType) types.asMemberOf(containing, method);
+    methodBuilder.returns(TypeName.get(executableType.getReturnType()));
+
+    List<? extends VariableElement> parameters = method.getParameters();
+    List<? extends TypeMirror> parameterTypes = executableType.getParameterTypes();
+    for (int index = 0; index < parameters.size(); index++) {
+      VariableElement parameter = parameters.get(index);
+      TypeName type = TypeName.get(parameterTypes.get(index));
+      String name = parameter.getSimpleName().toString();
+      Modifier[] paramods = new Modifier[parameter.getModifiers().size()];
+      parameter.getModifiers().toArray(paramods);
+      ParameterSpec.Builder psb = ParameterSpec.builder(type, name, paramods);
+      for (AnnotationMirror mirror : parameter.getAnnotationMirrors()) {
+        psb.addAnnotation(AnnotationSpec.get(mirror));
+      }
+      methodBuilder.addParameter(psb.build());
+    }
+
+    for (TypeMirror thrownType : method.getThrownTypes()) {
+      methodBuilder.addException(TypeName.get(thrownType));
+    }
+
+    if (method.isVarArgs()) {
+      methodBuilder.varargs();
+    }
+
+    return methodBuilder;
+  }
+
+}

--- a/src/test/java/com/squareup/javapoet/MethodSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/MethodSpecTest.java
@@ -15,33 +15,12 @@
  */
 package com.squareup.javapoet;
 
-import com.google.common.collect.ImmutableSet;
-import com.google.testing.compile.CompilationRule;
-import java.io.Closeable;
-import java.io.IOException;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Target;
-import java.util.List;
-import javax.lang.model.element.ExecutableElement;
-import javax.lang.model.element.Modifier;
-import javax.lang.model.element.TypeElement;
-import org.junit.Ignore;
-import org.junit.Rule;
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
+
 import org.junit.Test;
 
-import static com.google.common.collect.Iterables.getOnlyElement;
-import static com.google.common.truth.Truth.assertThat;
-import static javax.lang.model.util.ElementFilter.methodsIn;
-import static org.junit.Assert.fail;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 public final class MethodSpecTest {
-  @Rule public final CompilationRule compilation = new CompilationRule();
-
-  private TypeElement getElement(Class<?> clazz) {
-    return compilation.getElements().getTypeElement(clazz.getCanonicalName());
-  }
 
   @Test public void nullAnnotationsAddition() {
     try {
@@ -79,78 +58,4 @@ public final class MethodSpecTest {
     }
   }
 
-  @Target(ElementType.PARAMETER)
-  @interface Nullable {
-  }
-
-  @SuppressWarnings("unused") // Used via mirror API.
-  abstract static class Everything {
-    @Deprecated protected abstract <T extends Runnable & Closeable> Runnable everything(
-        @Nullable String thing, List<? extends T> things) throws IOException, SecurityException;
-  }
-
-  @SuppressWarnings("unused") // Used via mirror API.
-  abstract static class HasAnnotation {
-    @Override public abstract String toString();
-  }
-
-  @Test public void overrideEverything() {
-    TypeElement classElement = getElement(Everything.class);
-    ExecutableElement methodElement = getOnlyElement(methodsIn(classElement.getEnclosedElements()));
-
-    MethodSpec method = MethodSpec.overriding(methodElement).build();
-    assertThat(method.toString()).isEqualTo(""
-        + "@java.lang.Override\n"
-        + "protected <T extends java.lang.Runnable & java.io.Closeable> "
-        + "java.lang.Runnable everything(java.lang.String arg0, java.util.List<? extends T> arg1) "
-        + "throws java.io.IOException, java.lang.SecurityException {\n"
-        + "}\n");
-    // TODO see TODOs in MethodSpec.override
-    //assertThat(method.toString()).isEqualTo(""
-    //    + "@java.lang.Override\n"
-    //    + "@java.lang.Deprecated\n"
-    //    + "protected <T extends java.lang.Runnable & java.io.Closeable> "
-    //    + "java.lang.Runnable everything("
-    //    + "@com.squareup.javapoet.MethodSpecTest.Nullable java.lang.String arg0, "
-    //    + "java.util.List<? extends T> arg1) "
-    //    + "throws java.io.IOException, java.lang.SecurityException {\n"
-    //    + "}\n");
-  }
-
-  @Ignore // TODO see TODOs in MethodSpec.override
-  @Test public void overrideDoesNotCopyOverrideAnnotation() {
-    TypeElement classElement = getElement(Everything.class);
-    ExecutableElement methodElement = getOnlyElement(methodsIn(classElement.getEnclosedElements()));
-
-    MethodSpec method = MethodSpec.overriding(methodElement).build();
-    assertThat(method.toString()).isEqualTo(""
-        + "@java.lang.Override\n"
-        + "public java.lang.String toString() {"
-        + "}");
-  }
-
-  @Test public void overrideInvalidModifiers() {
-    ExecutableElement method = mock(ExecutableElement.class);
-    when(method.getModifiers()).thenReturn(ImmutableSet.of(Modifier.FINAL));
-    try {
-      MethodSpec.overriding(method);
-      fail();
-    } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessage("cannot override method with modifiers: [final]");
-    }
-    when(method.getModifiers()).thenReturn(ImmutableSet.of(Modifier.PRIVATE));
-    try {
-      MethodSpec.overriding(method);
-      fail();
-    } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessage("cannot override method with modifiers: [private]");
-    }
-    when(method.getModifiers()).thenReturn(ImmutableSet.of(Modifier.STATIC));
-    try {
-      MethodSpec.overriding(method);
-      fail();
-    } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessage("cannot override method with modifiers: [static]");
-    }
-  }
 }

--- a/src/test/java/com/squareup/javapoet/PoetryTest.java
+++ b/src/test/java/com/squareup/javapoet/PoetryTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.javapoet;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.google.common.truth.Truth.assertThat;
+import static javax.lang.model.util.ElementFilter.methodsIn;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.util.Elements;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.testing.compile.CompilationRule;
+
+public final class PoetryTest {
+
+  @Rule
+  public final CompilationRule compilation = new CompilationRule();
+
+  private TypeElement getElement(Class<?> clazz) {
+    return compilation.getElements().getTypeElement(clazz.getCanonicalName());
+  }
+
+  private ExecutableElement findFirst(Collection<ExecutableElement> elements, String name) {
+    for (ExecutableElement executableElement : elements) {
+      if (executableElement.getSimpleName().toString().equals(name))
+        return executableElement;
+    }
+    throw new IllegalArgumentException(name + " not found in " + elements);
+  }
+
+  @Target(ElementType.PARAMETER)
+  @interface Nullable {
+  }
+
+  abstract static class Everything {
+    @Deprecated protected abstract <T extends Runnable & Closeable> Runnable everything(
+        @Nullable String thing, List<? extends T> things) throws IOException, SecurityException;
+  }
+
+  abstract static class HasAnnotation {
+    @Override public abstract String toString();
+  }
+
+  interface ExtendsOthers extends Callable<Integer>, Comparable<Long> {
+    // empty on purpose
+  }
+
+  @Test public void overrideEverything() {
+    Poetry poetry = new Poetry(compilation.getElements(), compilation.getTypes());
+    TypeElement classElement = getElement(Everything.class);
+    DeclaredType classType = (DeclaredType) classElement.asType();
+    ExecutableElement methodElement = getOnlyElement(methodsIn(classElement.getEnclosedElements()));
+    MethodSpec method = poetry.overriding(methodElement, classType).build();
+    assertThat(method.toString()).isEqualTo(
+        ""
+            + "@java.lang.Override\n"
+            + "@java.lang.Deprecated\n"
+            + "protected <T extends java.lang.Runnable & java.io.Closeable> "
+            + "java.lang.Runnable everything("
+            + "@com.squareup.javapoet.PoetryTest.Nullable java.lang.String arg0, "
+            + "java.util.List<? extends T> arg1) "
+            + "throws java.io.IOException, java.lang.SecurityException {\n"
+            + "}\n");
+  }
+
+  @Test public void overrideDoesNotCopyOverrideAnnotation() {
+    Poetry poetry = new Poetry(compilation.getElements(), compilation.getTypes());
+    TypeElement classElement = getElement(HasAnnotation.class);
+    DeclaredType classType = (DeclaredType) classElement.asType();
+    ExecutableElement methodElement = getOnlyElement(methodsIn(classElement.getEnclosedElements()));
+    MethodSpec method = poetry.overriding(methodElement, classType).build();
+    assertThat(method.toString()).isEqualTo(
+        "" + "@java.lang.Override\n" + "public java.lang.String toString() {\n" + "}\n");
+  }
+
+  @Test public void overrideExtendsOthersWorksWithActualTypeParameters() {
+    Elements elements = compilation.getElements();
+    Poetry poetry = new Poetry(elements, compilation.getTypes());
+    TypeElement classElement = getElement(ExtendsOthers.class);
+    DeclaredType classType = (DeclaredType) classElement.asType();
+    List<ExecutableElement> methods = methodsIn(elements.getAllMembers(classElement));
+    MethodSpec method = poetry.overriding(findFirst(methods, "call"), classType).build();
+    assertThat(method.toString()).isEqualTo(
+        ""
+            + "@java.lang.Override\n"
+            + "public java.lang.Integer call() throws java.lang.Exception {\n"
+            + "}\n");
+    method = poetry.overriding(findFirst(methods, "compareTo"), classType).build();
+    assertThat(method.toString()).isEqualTo(
+        "" + "@java.lang.Override\n" + "public int compareTo(java.lang.Long arg0) {\n" + "}\n");
+  }
+
+  @Test public void overrideInvalidModifiers() {
+    Poetry poetry = new Poetry(compilation.getElements(), compilation.getTypes());
+    ExecutableElement method = mock(ExecutableElement.class);
+    when(method.getModifiers()).thenReturn(ImmutableSet.of(Modifier.FINAL));
+    Element element = mock(Element.class);
+    when(element.asType()).thenReturn(mock(DeclaredType.class));
+    when(method.getEnclosingElement()).thenReturn(element);
+    try {
+      poetry.overriding(method);
+      fail();
+    } catch (IllegalArgumentException expected) {
+      assertThat(expected).hasMessage("cannot override method with modifiers: [final]");
+    }
+    when(method.getModifiers()).thenReturn(ImmutableSet.of(Modifier.PRIVATE));
+    try {
+      poetry.overriding(method);
+      fail();
+    } catch (IllegalArgumentException expected) {
+      assertThat(expected).hasMessage("cannot override method with modifiers: [private]");
+    }
+    when(method.getModifiers()).thenReturn(ImmutableSet.of(Modifier.STATIC));
+    try {
+      poetry.overriding(method);
+      fail();
+    } catch (IllegalArgumentException expected) {
+      assertThat(expected).hasMessage("cannot override method with modifiers: [static]");
+    }
+  }
+
+}


### PR DESCRIPTION
The name `Poetry` is an abstract working title. Is `JavaxModelUtil` better?

The purpose is to collect non-trivial parsing/transforming methods like `MethodSpec.overriding()`, that usually need processing utilities like Elements and Types from [javax.lang.model.util](http://docs.oracle.com/javase/7/docs/api/javax/lang/model/util/package-summary.html) in one place. 
In Poetry, you can also re-use common utility methods like `ClassName.isClassOrInterface(Element)` or `ClassName.getPackage(Element)`.
`AnnotationSpec.get(AnnotationMirror)` and all related private classes are a good candidates for moving, too. Actually, even all trivial methods like `ClassName.get(TypeElement)` could move to Poetry. That way, you keep the JavaPoet mode classes clean & simple & free from static factories.

Instead of writing:
```java
MethodSpec ms = MethodSpec.overriding(method, containing, type, elements);
```
you get:
```java
MethodSpec ms = new Poetry(type, elements).overriding(method, containing);
```
The complete implementation of `MethodSpec.overriding()` is included.
