### PR TITLE
AnnotationSpec fixes

### DIFF
--- a/src/main/java/com/squareup/javapoet/AnnotationSpec.java
+++ b/src/main/java/com/squareup/javapoet/AnnotationSpec.java
@@ -121,7 +121,9 @@ public final class AnnotationSpec {
 
   public Builder toBuilder() {
     Builder builder = new Builder(type);
-    builder.members.putAll(members);
+    for (Map.Entry<String, List<CodeBlock>> entry : members.entrySet()) {
+      builder.members.put(entry.getKey(), new ArrayList<>(entry.getValue()));
+    }
     return builder;
   }
 
@@ -215,6 +217,14 @@ public final class AnnotationSpec {
     @Override
     public Builder visitType(TypeMirror t, Entry entry) {
       return builder.addMember(entry.name, "$T.class", t);
+    }
+
+    @Override
+    public Builder visitArray(List<? extends AnnotationValue> values, Entry entry) {
+      for (AnnotationValue value : values) {
+        value.accept(this, new Entry(entry.name, value));
+      }
+      return builder;
     }
   }
 

--- a/src/test/java/com/squareup/javapoet/AnnotationSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/AnnotationSpecTest.java
@@ -85,6 +85,9 @@ public final class AnnotationSpecTest {
     int p();
 
     AnnotationC q() default @AnnotationC("foo");
+
+    Class<? extends Number>[] r() default {Byte.class, Short.class, Integer.class, Long.class};
+
   }
 
   @HasDefaultsAnnotation(
@@ -94,7 +97,8 @@ public final class AnnotationSpecTest {
       m = {9, 8, 1},
       l = Override.class,
       j = @AnnotationA,
-      q = @AnnotationC("bar"))
+      q = @AnnotationC("bar"),
+      r = {Float.class, Double.class})
   public class IsAnnotated {
     // empty
   }
@@ -116,6 +120,7 @@ public final class AnnotationSpecTest {
             + ", l = java.lang.Override.class"
             + ", j = @com.squareup.javapoet.AnnotationSpecTest.AnnotationA"
             + ", q = @com.squareup.javapoet.AnnotationSpecTest.AnnotationC(\"bar\")"
+            + ", r = {java.lang.Float.class, java.lang.Double.class}"
             + ")");
   }
 
@@ -130,19 +135,103 @@ public final class AnnotationSpecTest {
     assertThat(file.toString()).isEqualTo(
         "package com.squareup.javapoet;\n"
             + "\n"
+            + "import java.lang.Double;\n"
+            + "import java.lang.Float;\n"
             + "import java.lang.Override;\n"
             + "\n"
             + "@AnnotationSpecTest.HasDefaultsAnnotation(\n"
             + "    o = AnnotationSpecTest.Breakfast.PANCAKES,\n"
             + "    p = 1701,\n"
             + "    f = 11.1,\n"
-            + "    m = {9, 8, 1},\n"
+            + "    m = {\n"
+            + "        9,\n"
+            + "        8,\n"
+            + "        1\n"
+            + "    },\n"
             + "    l = Override.class,\n"
             + "    j = @AnnotationSpecTest.AnnotationA,\n"
-            + "    q = @AnnotationSpecTest.AnnotationC(\"bar\")\n"
+            + "    q = @AnnotationSpecTest.AnnotationC(\"bar\"),\n"
+            + "    r = {\n"
+            + "        Float.class,\n"
+            + "        Double.class\n"
+            + "    }\n"
             + ")\n"
             + "class IsAnnotated {\n"
             + "}\n"
     );
+  }
+
+  @Test
+  public void testEmptyArray() {
+    AnnotationSpec.Builder builder = AnnotationSpec.builder(HasDefaultsAnnotation.class);
+    builder.addMember("n", "$L", "{}");
+    assertThat(builder.build().toString()).isEqualTo(
+        "@com.squareup.javapoet.AnnotationSpecTest.HasDefaultsAnnotation(" + "n = {}" + ")");
+    builder.addMember("m", "$L", "{}");
+    assertThat(builder.build().toString())
+        .isEqualTo(
+            "@com.squareup.javapoet.AnnotationSpecTest.HasDefaultsAnnotation("
+                + "n = {}, m = {}"
+                + ")");
+  }
+
+  @Test
+  public void testDynamicArrayOfEnumConstants() {
+    AnnotationSpec.Builder builder = AnnotationSpec.builder(HasDefaultsAnnotation.class);
+    builder.addMember("n", "$T.$L", Breakfast.class, Breakfast.PANCAKES);
+    assertThat(builder.build().toString()).isEqualTo(
+        "@com.squareup.javapoet.AnnotationSpecTest.HasDefaultsAnnotation("
+            + "n = com.squareup.javapoet.AnnotationSpecTest.Breakfast.PANCAKES"
+            + ")");
+
+    // builder = AnnotationSpec.builder(HasDefaultsAnnotation.class);
+    builder.addMember("n", "$T.$L", Breakfast.class, Breakfast.WAFFLES);
+    builder.addMember("n", "$T.$L", Breakfast.class, Breakfast.PANCAKES);
+    assertThat(builder.build().toString()).isEqualTo(
+        "@com.squareup.javapoet.AnnotationSpecTest.HasDefaultsAnnotation("
+            + "n = {"
+            + "com.squareup.javapoet.AnnotationSpecTest.Breakfast.PANCAKES"
+            + ", com.squareup.javapoet.AnnotationSpecTest.Breakfast.WAFFLES"
+            + ", com.squareup.javapoet.AnnotationSpecTest.Breakfast.PANCAKES"
+            + "})");
+
+    builder = builder.build().toBuilder(); // idempotent
+    assertThat(builder.build().toString()).isEqualTo(
+        "@com.squareup.javapoet.AnnotationSpecTest.HasDefaultsAnnotation("
+            + "n = {"
+            + "com.squareup.javapoet.AnnotationSpecTest.Breakfast.PANCAKES"
+            + ", com.squareup.javapoet.AnnotationSpecTest.Breakfast.WAFFLES"
+            + ", com.squareup.javapoet.AnnotationSpecTest.Breakfast.PANCAKES"
+            + "})");
+
+    builder.addMember("n", "$T.$L", Breakfast.class, Breakfast.WAFFLES);
+    assertThat(builder.build().toString()).isEqualTo(
+        "@com.squareup.javapoet.AnnotationSpecTest.HasDefaultsAnnotation("
+            + "n = {"
+            + "com.squareup.javapoet.AnnotationSpecTest.Breakfast.PANCAKES"
+            + ", com.squareup.javapoet.AnnotationSpecTest.Breakfast.WAFFLES"
+            + ", com.squareup.javapoet.AnnotationSpecTest.Breakfast.PANCAKES"
+            + ", com.squareup.javapoet.AnnotationSpecTest.Breakfast.WAFFLES"
+            + "})");
+  }
+
+  @Test
+  public void testHasDefaultAnnotationToBuilder() {
+    String name = IsAnnotated.class.getCanonicalName();
+    TypeElement element = compilation.getElements().getTypeElement(name);
+    AnnotationSpec.Builder builder = AnnotationSpec.get(element.getAnnotationMirrors().get(0))
+        .toBuilder();
+    builder.addMember("m", "$L", 123);
+    assertThat(builder.build().toString()).isEqualTo(
+        "@com.squareup.javapoet.AnnotationSpecTest.HasDefaultsAnnotation("
+            + "o = com.squareup.javapoet.AnnotationSpecTest.Breakfast.PANCAKES"
+            + ", p = 1701"
+            + ", f = 11.1"
+            + ", m = {9, 8, 1, 123}"
+            + ", l = java.lang.Override.class"
+            + ", j = @com.squareup.javapoet.AnnotationSpecTest.AnnotationA"
+            + ", q = @com.squareup.javapoet.AnnotationSpecTest.AnnotationC(\"bar\")"
+            + ", r = {java.lang.Float.class, java.lang.Double.class}"
+            + ")");
   }
 }


### PR DESCRIPTION
AnnotationSpec.toBuilder() did return an immutable collection.
AnnotationSpec.get(AnnotationMirror) visitor now visits arrays as well.