### PR TITLE
MethodSpec.varargs(boolean) added

### DIFF
--- a/src/main/java/com/squareup/javapoet/MethodSpec.java
+++ b/src/main/java/com/squareup/javapoet/MethodSpec.java
@@ -323,7 +323,11 @@ public final class MethodSpec {
     }
 
     public Builder varargs() {
-      this.varargs = true;
+      return varargs(true);
+    }
+
+    public Builder varargs(boolean varargs) {
+      this.varargs = varargs;
       return this;
     }
 


### PR DESCRIPTION
First, the PR contains a minor update of the varargs()-method in the MethodSpec.Builder:
 * added method varargs(boolean varargs) which allows a) setting the value to false and b) cleaner code in API usage, i.e. `builder.varargs(method.isVarArgs())` instead of
```java
if (method.isVarArgs()) {
  builder.varargs();
}
```
 * second, the `boolean chainable` is introduced. It indicates a assignable type relation between the method container and the method return type. Usually, it means, the method returns `this`. That relation is difficult to reflect after the MethodSpec is built. It is easier to obtain, when the annotation process is running and providing Types utilities:
```java
boolean chainable = processingEnv.getTypeUtils().isAssignable(declaringType, method.getReturnType());
```
Knowing chainability(?) when creating return statements is crucial, when you're creating facade implementations of methods. See [StashGenerator.java#L172](https://github.com/sormuras/stash/blob/master/src/stash/de/sormuras/stash/StashGenerator.java#L172) as an example.