### PR TITLE
Proposing JavaxLangModelPoet for parsing javax.lang.model elements and types.

### DIFF
--- a/src/main/java/com/squareup/javapoet/JavaxLangModelPoet.java
+++ b/src/main/java/com/squareup/javapoet/JavaxLangModelPoet.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.javapoet;
+
+import static com.squareup.javapoet.Util.checkNotNull;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.TypeParameterElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.ExecutableType;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.type.TypeVariable;
+import javax.lang.model.util.Elements;
+import javax.lang.model.util.Types;
+
+/**
+ * Provides utilities based on parsing elements and types from javax.lang.model instances.
+ *
+ * @author Christian Stein
+ */
+class JavaxLangModelPoet {
+
+  protected final Elements elements;
+  protected final Types types;
+
+  JavaxLangModelPoet(Elements elements, Types types) {
+    checkNotNull(elements, "elements==null");
+    checkNotNull(types, "types==null");
+    this.elements = elements;
+    this.types = types;
+  }
+
+  /**
+   * Create a method spec builder that copied 1:1 from {@code method} and is viewed as being a
+   * member of the specified {@code containing} class or interface.
+   *
+   * This will copy its modifiers, annotations, type parameters, return type, name, parameters and
+   * throws declarations.
+   */
+  public MethodSpec.Builder builder(ExecutableElement method, DeclaredType containing) {
+    checkNotNull(method, "method == null");
+    checkNotNull(containing, "containing == null");
+
+    String methodName = method.getSimpleName().toString();
+    MethodSpec.Builder methodBuilder = MethodSpec.methodBuilder(methodName);
+    methodBuilder.addModifiers(method.getModifiers());
+
+    for (AnnotationMirror mirror : method.getAnnotationMirrors()) {
+      methodBuilder.addAnnotation(AnnotationSpec.get(mirror));
+    }
+
+    for (TypeParameterElement typeParameterElement : method.getTypeParameters()) {
+      TypeVariable var = (TypeVariable) typeParameterElement.asType();
+      methodBuilder.addTypeVariable(TypeVariableName.get(var));
+    }
+
+    ExecutableType executableType = (ExecutableType) types.asMemberOf(containing, method);
+    methodBuilder.returns(TypeName.get(executableType.getReturnType()));
+
+    List<? extends VariableElement> parameters = method.getParameters();
+    List<? extends TypeMirror> parameterTypes = executableType.getParameterTypes();
+    for (int index = 0; index < parameters.size(); index++) {
+      VariableElement parameter = parameters.get(index);
+      TypeName type = TypeName.get(parameterTypes.get(index));
+      String name = parameter.getSimpleName().toString();
+      Modifier[] paramods = new Modifier[parameter.getModifiers().size()];
+      parameter.getModifiers().toArray(paramods);
+      ParameterSpec.Builder psb = ParameterSpec.builder(type, name, paramods);
+      for (AnnotationMirror mirror : parameter.getAnnotationMirrors()) {
+        psb.addAnnotation(AnnotationSpec.get(mirror));
+      }
+      methodBuilder.addParameter(psb.build());
+    }
+    methodBuilder.varargs(method.isVarArgs());
+
+    for (TypeMirror thrownType : method.getThrownTypes()) {
+      methodBuilder.addException(TypeName.get(thrownType));
+    }
+
+    return methodBuilder;
+  }
+
+  /**
+   * Create a method spec builder which overrides {@code method}.
+   *
+   * Same as {@code overriding(method, (DeclaredType) method.getEnclosingElement().asType())}.
+   */
+  public MethodSpec.Builder overriding(ExecutableElement method) {
+    return overriding(method, (DeclaredType) method.getEnclosingElement().asType());
+  }
+
+  /**
+   * Create a method spec builder which overrides {@code method} that is viewed as being a member of
+   * the specified {@code containing} class or interface.
+   *
+   * This will copy its visibility modifiers, type parameters, return type, name, parameters, and
+   * throws declarations. An {@link Override} annotation will be added.
+   */
+  public MethodSpec.Builder overriding(ExecutableElement method, DeclaredType containing) {
+    checkNotNull(method, "method == null");
+    checkNotNull(containing, "containing == null");
+
+    Set<Modifier> modifiers = method.getModifiers();
+    if (modifiers.contains(Modifier.PRIVATE)
+        || modifiers.contains(Modifier.FINAL)
+        || modifiers.contains(Modifier.STATIC)) {
+      throw new IllegalArgumentException("cannot override method with modifiers: " + modifiers);
+    }
+
+    MethodSpec.Builder methodBuilder = builder(method, containing);
+    methodBuilder.annotations().clear();
+    methodBuilder.modifiers().clear();
+
+    methodBuilder.addAnnotation(Override.class);
+    TypeMirror overrideType = elements.getTypeElement(Override.class.getCanonicalName()).asType();
+    for (AnnotationMirror mirror : method.getAnnotationMirrors()) {
+      if (types.isSameType(mirror.getAnnotationType(), overrideType)) {
+        continue;
+      }
+      methodBuilder.addAnnotation(AnnotationSpec.get(mirror));
+    }
+
+    modifiers = new LinkedHashSet<>(modifiers);
+    modifiers.remove(Modifier.ABSTRACT);
+    methodBuilder.addModifiers(modifiers);
+
+    return methodBuilder;
+  }
+}

--- a/src/test/java/com/squareup/javapoet/JavaxLangModelPoetTest.java
+++ b/src/test/java/com/squareup/javapoet/JavaxLangModelPoetTest.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.javapoet;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.google.common.truth.Truth.assertThat;
+import static javax.lang.model.util.ElementFilter.methodsIn;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.util.Elements;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.testing.compile.CompilationRule;
+
+public final class JavaxLangModelPoetTest {
+
+  @Rule
+  public final CompilationRule compilation = new CompilationRule();
+
+  private TypeElement getElement(Class<?> clazz) {
+    return compilation.getElements().getTypeElement(clazz.getCanonicalName());
+  }
+
+  private ExecutableElement findFirst(Collection<ExecutableElement> elements, String name) {
+    for (ExecutableElement executableElement : elements) {
+      if (executableElement.getSimpleName().toString().equals(name))
+        return executableElement;
+    }
+    throw new IllegalArgumentException(name + " not found in " + elements);
+  }
+
+  @Target(ElementType.PARAMETER)
+  @interface Nullable {
+  }
+
+  abstract static class Everything {
+    @Deprecated
+    protected abstract <T extends Runnable & Closeable> Runnable everything(@Nullable String thing,
+        List<? extends T> things) throws IOException, SecurityException;
+  }
+
+  abstract static class HasAnnotation {
+    @Override
+    public abstract String toString();
+  }
+
+  interface ExtendsOthers extends Callable<Integer>, Comparable<Long> {
+    // empty on purpose
+  }
+
+  @Test
+  public void buildEverything() {
+    JavaxLangModelPoet poet = new JavaxLangModelPoet(compilation.getElements(), compilation.getTypes());
+    TypeElement classElement = getElement(Everything.class);
+    DeclaredType classType = (DeclaredType) classElement.asType();
+    ExecutableElement methodElement = getOnlyElement(methodsIn(classElement.getEnclosedElements()));
+
+    MethodSpec method = poet.builder(methodElement, classType).build();
+    assertThat(method.toString()).isEqualTo(""
+        + "@java.lang.Deprecated\n"
+        + "protected abstract <T extends java.lang.Runnable & java.io.Closeable> "
+        + "java.lang.Runnable everything("
+        + "@com.squareup.javapoet.JavaxLangModelPoetTest.Nullable java.lang.String arg0, "
+        + "java.util.List<? extends T> arg1) "
+        + "throws java.io.IOException, java.lang.SecurityException;\n");
+  }
+
+  @Test
+  public void buildHasAnnotation() {
+    JavaxLangModelPoet poet = new JavaxLangModelPoet(compilation.getElements(), compilation.getTypes());
+    TypeElement classElement = getElement(HasAnnotation.class);
+    DeclaredType classType = (DeclaredType) classElement.asType();
+    ExecutableElement methodElement = getOnlyElement(methodsIn(classElement.getEnclosedElements()));
+
+    MethodSpec method = poet.builder(methodElement, classType).build();
+    assertThat(method.toString()).isEqualTo("public abstract java.lang.String toString();\n");
+  }
+
+  @Test
+  public void buildExtendsOthersWorksWithActualTypeParameters() {
+    Elements elements = compilation.getElements();
+    JavaxLangModelPoet poet = new JavaxLangModelPoet(elements, compilation.getTypes());
+    TypeElement classElement = getElement(ExtendsOthers.class);
+    DeclaredType classType = (DeclaredType) classElement.asType();
+    List<ExecutableElement> methods = methodsIn(elements.getAllMembers(classElement));
+
+    MethodSpec method = poet.builder(findFirst(methods, "call"), classType).build();
+    assertThat(method.toString()).isEqualTo(
+        "public abstract java.lang.Integer call() throws java.lang.Exception;\n");
+
+    method = poet.builder(findFirst(methods, "compareTo"), classType).build();
+    assertThat(method.toString())
+        .isEqualTo("public abstract int compareTo(java.lang.Long arg0);\n");
+  }
+
+  @Test
+  public void overrideEverything() {
+    JavaxLangModelPoet poet = new JavaxLangModelPoet(compilation.getElements(), compilation.getTypes());
+    TypeElement classElement = getElement(Everything.class);
+    DeclaredType classType = (DeclaredType) classElement.asType();
+    ExecutableElement methodElement = getOnlyElement(methodsIn(classElement.getEnclosedElements()));
+
+    MethodSpec method = poet.overriding(methodElement, classType).build();
+    assertThat(method.toString()).isEqualTo(""
+        + "@java.lang.Override\n"
+        + "@java.lang.Deprecated\n"
+        + "protected <T extends java.lang.Runnable & java.io.Closeable> "
+        + "java.lang.Runnable everything("
+        + "@com.squareup.javapoet.JavaxLangModelPoetTest.Nullable java.lang.String arg0, "
+        + "java.util.List<? extends T> arg1) "
+        + "throws java.io.IOException, java.lang.SecurityException {\n"
+        + "}\n");
+  }
+
+  @Test
+  public void overrideDoesNotCopyOverrideAnnotation() {
+    JavaxLangModelPoet poet = new JavaxLangModelPoet(compilation.getElements(), compilation.getTypes());
+    TypeElement classElement = getElement(HasAnnotation.class);
+    DeclaredType classType = (DeclaredType) classElement.asType();
+    ExecutableElement methodElement = getOnlyElement(methodsIn(classElement.getEnclosedElements()));
+
+    MethodSpec method = poet.overriding(methodElement, classType).build();
+    assertThat(method.toString()).isEqualTo(""
+        + "@java.lang.Override\n"
+        + "public java.lang.String toString() {\n"
+        + "}\n");
+  }
+
+  @Test
+  public void overrideExtendsOthersWorksWithActualTypeParameters() {
+    Elements elements = compilation.getElements();
+    JavaxLangModelPoet poet = new JavaxLangModelPoet(elements, compilation.getTypes());
+    TypeElement classElement = getElement(ExtendsOthers.class);
+    DeclaredType classType = (DeclaredType) classElement.asType();
+    List<ExecutableElement> methods = methodsIn(elements.getAllMembers(classElement));
+
+    MethodSpec method = poet.overriding(findFirst(methods, "call"), classType).build();
+    assertThat(method.toString()).isEqualTo(""
+        + "@java.lang.Override\n"
+        + "public java.lang.Integer call() throws java.lang.Exception {\n"
+        + "}\n");
+
+    method = poet.overriding(findFirst(methods, "compareTo"), classType).build();
+    assertThat(method.toString()).isEqualTo(""
+        + "@java.lang.Override\n"
+        + "public int compareTo(java.lang.Long arg0) {\n"
+        + "}\n");
+  }
+
+  @Test
+  public void overrideInvalidModifiers() {
+    JavaxLangModelPoet poet = new JavaxLangModelPoet(compilation.getElements(), compilation.getTypes());
+    ExecutableElement method = mock(ExecutableElement.class);
+    when(method.getModifiers()).thenReturn(ImmutableSet.of(Modifier.FINAL));
+    Element element = mock(Element.class);
+    when(element.asType()).thenReturn(mock(DeclaredType.class));
+    when(method.getEnclosingElement()).thenReturn(element);
+    try {
+      poet.overriding(method);
+      fail();
+    } catch (IllegalArgumentException expected) {
+      assertThat(expected).hasMessage("cannot override method with modifiers: [final]");
+    }
+    when(method.getModifiers()).thenReturn(ImmutableSet.of(Modifier.PRIVATE));
+    try {
+      poet.overriding(method);
+      fail();
+    } catch (IllegalArgumentException expected) {
+      assertThat(expected).hasMessage("cannot override method with modifiers: [private]");
+    }
+    when(method.getModifiers()).thenReturn(ImmutableSet.of(Modifier.STATIC));
+    try {
+      poet.overriding(method);
+      fail();
+    } catch (IllegalArgumentException expected) {
+      assertThat(expected).hasMessage("cannot override method with modifiers: [static]");
+    }
+  }
+
+}

--- a/src/test/java/com/squareup/javapoet/MethodSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/MethodSpecTest.java
@@ -15,33 +15,15 @@
  */
 package com.squareup.javapoet;
 
-import com.google.common.collect.ImmutableSet;
 import com.google.testing.compile.CompilationRule;
-import java.io.Closeable;
-import java.io.IOException;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Target;
-import java.util.List;
-import javax.lang.model.element.ExecutableElement;
-import javax.lang.model.element.Modifier;
-import javax.lang.model.element.TypeElement;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
-import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.common.truth.Truth.assertThat;
-import static javax.lang.model.util.ElementFilter.methodsIn;
 import static org.junit.Assert.fail;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public final class MethodSpecTest {
   @Rule public final CompilationRule compilation = new CompilationRule();
-
-  private TypeElement getElement(Class<?> clazz) {
-    return compilation.getElements().getTypeElement(clazz.getCanonicalName());
-  }
 
   @Test public void nullAnnotationsAddition() {
     try {
@@ -79,78 +61,4 @@ public final class MethodSpecTest {
     }
   }
 
-  @Target(ElementType.PARAMETER)
-  @interface Nullable {
-  }
-
-  @SuppressWarnings("unused") // Used via mirror API.
-  abstract static class Everything {
-    @Deprecated protected abstract <T extends Runnable & Closeable> Runnable everything(
-        @Nullable String thing, List<? extends T> things) throws IOException, SecurityException;
-  }
-
-  @SuppressWarnings("unused") // Used via mirror API.
-  abstract static class HasAnnotation {
-    @Override public abstract String toString();
-  }
-
-  @Test public void overrideEverything() {
-    TypeElement classElement = getElement(Everything.class);
-    ExecutableElement methodElement = getOnlyElement(methodsIn(classElement.getEnclosedElements()));
-
-    MethodSpec method = MethodSpec.overriding(methodElement).build();
-    assertThat(method.toString()).isEqualTo(""
-        + "@java.lang.Override\n"
-        + "protected <T extends java.lang.Runnable & java.io.Closeable> "
-        + "java.lang.Runnable everything(java.lang.String arg0, java.util.List<? extends T> arg1) "
-        + "throws java.io.IOException, java.lang.SecurityException {\n"
-        + "}\n");
-    // TODO see TODOs in MethodSpec.override
-    //assertThat(method.toString()).isEqualTo(""
-    //    + "@java.lang.Override\n"
-    //    + "@java.lang.Deprecated\n"
-    //    + "protected <T extends java.lang.Runnable & java.io.Closeable> "
-    //    + "java.lang.Runnable everything("
-    //    + "@com.squareup.javapoet.MethodSpecTest.Nullable java.lang.String arg0, "
-    //    + "java.util.List<? extends T> arg1) "
-    //    + "throws java.io.IOException, java.lang.SecurityException {\n"
-    //    + "}\n");
-  }
-
-  @Ignore // TODO see TODOs in MethodSpec.override
-  @Test public void overrideDoesNotCopyOverrideAnnotation() {
-    TypeElement classElement = getElement(Everything.class);
-    ExecutableElement methodElement = getOnlyElement(methodsIn(classElement.getEnclosedElements()));
-
-    MethodSpec method = MethodSpec.overriding(methodElement).build();
-    assertThat(method.toString()).isEqualTo(""
-        + "@java.lang.Override\n"
-        + "public java.lang.String toString() {"
-        + "}");
-  }
-
-  @Test public void overrideInvalidModifiers() {
-    ExecutableElement method = mock(ExecutableElement.class);
-    when(method.getModifiers()).thenReturn(ImmutableSet.of(Modifier.FINAL));
-    try {
-      MethodSpec.overriding(method);
-      fail();
-    } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessage("cannot override method with modifiers: [final]");
-    }
-    when(method.getModifiers()).thenReturn(ImmutableSet.of(Modifier.PRIVATE));
-    try {
-      MethodSpec.overriding(method);
-      fail();
-    } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessage("cannot override method with modifiers: [private]");
-    }
-    when(method.getModifiers()).thenReturn(ImmutableSet.of(Modifier.STATIC));
-    try {
-      MethodSpec.overriding(method);
-      fail();
-    } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessage("cannot override method with modifiers: [static]");
-    }
-  }
 }


### PR DESCRIPTION
Follow up from https://github.com/square/javapoet/issues/273

Implementation outline:
 * Package-private JavaxLangModelPoet w/ test created.
 * Moved/finished `overriding` implementation and all related tests to this poet and its test class.
 * Enhanced signature to `MethodSpec.overriding(Elements, Types, ExecutableElement, DeclaredType)` - all necessary ensuring generic type resolution at processing time.

Two (or more) issues:
 * needed a way to interact with (read clear) the MethodSpec.Builder annotation and modifier lists. Instead of removing the `private` from the field declaration, I introduced package-private accessor methods: `MethodSpec.Builder#annotations()` and `~#modifiers()`. See [JavaxLangModelPoet.java#L130](https://github.com/sormuras/javapoet/blob/javaxlangmodelpoet/src/main/java/com/squareup/javapoet/JavaxLangModelPoet.java#L130)
 * the builder()-method does *not* copy the `@Override` annotation from `HasAnnotation#toString` in the unit test - I think, that's okay, because `@Override` uses `RetentionPolicy.SOURCE` and the unit test utilizes Googles `CompilationRule` that analyzes the annotation at runtime. I guess, when the test is running inside a real processing environment, the `@Override` carries over as expected. Need to verify my brave assumption, though.

What do you think?