### PR TITLE
Added the ability to use indexes in format arguments

### DIFF
--- a/src/test/java/com/squareup/javapoet/CodeBlockTest.java
+++ b/src/test/java/com/squareup/javapoet/CodeBlockTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.javapoet;
+
+import org.junit.Test;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
+
+public class CodeBlockTest {
+  
+  @Test
+  public void indentCannotBeIndexed() {
+    try {
+      CodeBlock.builder().add("$1>", "taco").build();
+      fail();
+    } catch (IllegalStateException exp) {
+      assertThat(exp).hasMessage("$$, $>, $<, $[ and $] may not have an index");
+    }
+  }
+  
+  @Test
+  public void deindentCannotBeIndexed() {
+    try {
+      CodeBlock.builder().add("$1<", "taco").build();
+      fail();
+    } catch (IllegalStateException exp) {
+      assertThat(exp).hasMessage("$$, $>, $<, $[ and $] may not have an index");
+    }
+  }
+  
+  @Test
+  public void dollarSignEscapeCannotBeIndexed() {
+    try {
+      CodeBlock.builder().add("$1$", "taco").build();
+      fail();
+    } catch (IllegalStateException exp) {
+      assertThat(exp).hasMessage("$$, $>, $<, $[ and $] may not have an index");
+    }
+  }
+ 
+  @Test
+  public void statementBeginningCannotBeIndexed() {
+    try {
+      CodeBlock.builder().add("$1[", "taco").build();
+      fail();
+    } catch (IllegalStateException exp) {
+      assertThat(exp).hasMessage("$$, $>, $<, $[ and $] may not have an index");
+    }
+  }
+  
+  @Test
+  public void statementEndingCannotBeIndexed() {
+    try {
+      CodeBlock.builder().add("$1]", "taco").build();
+      fail();
+    } catch (IllegalStateException exp) {
+      assertThat(exp).hasMessage("$$, $>, $<, $[ and $] may not have an index");
+    }
+  }
+  
+  @Test
+  public void nameFormatCanBeIndexed() {
+    CodeBlock block = CodeBlock.builder().add("$N $1N", "taco").build();
+    assertThat(block.toString()).isEqualTo("taco taco");
+  }
+  
+  @Test
+  public void literalFormatCanBeIndexed() {
+    CodeBlock block = CodeBlock.builder().add("$L $1L", "taco").build();
+    assertThat(block.toString()).isEqualTo("taco taco");
+  }
+  
+  @Test
+  public void stringFormatCanBeIndexed() {
+    CodeBlock block = CodeBlock.builder().add("$S $1S", "taco").build();
+    assertThat(block.toString()).isEqualTo("\"taco\" \"taco\"");
+  }
+  
+  @Test
+  public void typeFormatCanBeIndexed() {
+    CodeBlock block = CodeBlock.builder().add("$T $1T", String.class).build();
+    assertThat(block.toString()).isEqualTo("java.lang.String java.lang.String");
+  }
+  
+  @Test
+  public void indexTooHigh() {
+    try {
+      CodeBlock.builder().add("$T $2T", String.class).build();
+      fail();
+    } catch (IllegalArgumentException exp) {
+      assertThat(exp).hasMessage("Argument index 2 in '$T $2T' is larger than number of parameters");
+    }
+  }
+  
+  @Test
+  public void indexIsZero() {
+    try {
+    CodeBlock.builder().add("$T $0T", String.class).build();
+    fail();
+    } catch(IllegalArgumentException exp) {
+      assertThat(exp).hasMessage("Argument index 0 in '$T $0T' is less than one, the minimum format index");
+    }
+  }
+  
+  @Test
+  public void indexIsNegative() {
+    try {
+      CodeBlock.builder().add("$T $-1T", String.class).build();
+      fail();
+    } catch (IllegalArgumentException exp) {
+      assertThat(exp).hasMessage("invalid format string: $T $-1T");
+    }
+  }
+  
+  @Test
+  public void indexWithoutFormatType() {
+    try {
+      CodeBlock.builder().add("$1", String.class).build();
+      fail();
+    } catch (IllegalArgumentException exp) {
+      assertThat(exp).hasMessage("Dangling format characters '$1' in format string '$1'");
+    }
+  }
+  
+  @Test
+  public void indexWithoutFormatTypeNotAtStringEnd() {
+    try {
+      CodeBlock.builder().add("$1 taco", String.class).build();
+      fail();
+    } catch (IllegalArgumentException exp) {
+      assertThat(exp).hasMessage("invalid format string: $1 taco");
+    }
+  }
+  
+  @Test
+  public void formatIndicatorAlone() {
+    try {
+      CodeBlock.builder().add("$", String.class).build();
+      fail();
+    } catch (IllegalStateException exp) {
+      assertThat(exp).hasMessage("dangling $ in format string $");
+    }
+  }
+  
+  @Test
+  public void formatIndicatorWithoutIndexOrFormatType() {
+    try {
+      CodeBlock.builder().add("$ tacoString", String.class).build();
+      fail();
+    } catch (IllegalArgumentException exp) {
+      assertThat(exp).hasMessage("invalid format string: $ tacoString");
+    }
+  }
+  
+  @Test
+  public void indexingDoesNotIncreaseNaturalIndex() {
+    CodeBlock block = CodeBlock.builder().add("$L $L $2L $L", 1, 2, 3).build();
+    assertThat(block.toString()).isEqualTo("1 2 2 3");
+  }
+  
+  @Test
+  public void indexingSelectsProperPosition() {
+    CodeBlock block = CodeBlock.builder().add("$L $L $L $3L $2L $1L", 1, 2, 3).build();
+    assertThat(block.toString()).isEqualTo("1 2 3 3 2 1");
+  }
+  
+  @Test
+  public void indexingCanBeInterleved() {
+    CodeBlock block = CodeBlock.builder().add("$L $3L $L $2L $L $1L", 1, 2, 3).build();
+    assertThat(block.toString()).isEqualTo("1 3 2 2 3 1");
+  }
+  
+  @Test
+  public void sameIndexCanBeUsedWithDifferentFormats() {
+    CodeBlock block = CodeBlock.builder().add("$1T.out.println($1S)", ClassName.get(System.class)).build();
+    assertThat(block.toString()).isEqualTo("java.lang.System.out.println(\"java.lang.System\")");
+  }
+  
+}

--- a/src/test/java/com/squareup/javapoet/TypeSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/TypeSpecTest.java
@@ -1043,6 +1043,32 @@ public final class TypeSpecTest {
         + "  }\n"
         + "}\n");
   }
+  
+  @Test public void indexedElseIf() throws Exception {
+    TypeSpec taco = TypeSpec.classBuilder("Taco")
+        .addMethod(MethodSpec.methodBuilder("choices")
+            .beginControlFlow("if ($1L != null || $1L == $2L)", "taco", "otherTaco")
+            .addStatement("$T.out.println($S)", System.class, "only one taco? NOO!")
+            .nextControlFlow("else if ($1L.$3L && $2L.$3L)", "taco", "otherTaco", "isSupreme()")
+            .addStatement("$T.out.println($S)", System.class, "taco heaven")
+            .endControlFlow()
+            .build())
+        .build();
+    assertThat(toString(taco)).isEqualTo(""
+        + "package com.squareup.tacos;\n"
+        + "\n"
+        + "import java.lang.System;\n"
+        + "\n"
+        + "class Taco {\n"
+        + "  void choices() {\n"
+        + "    if (taco != null || taco == otherTaco) {\n"
+        + "      System.out.println(\"only one taco? NOO!\");\n"
+        + "    } else if (taco.isSupreme() && otherTaco.isSupreme()) {\n"
+        + "      System.out.println(\"taco heaven\");\n"
+        + "    }\n"
+        + "  }\n"
+        + "}\n");
+  }
 
   @Test public void elseIf() throws Exception {
     TypeSpec taco = TypeSpec.classBuilder("Taco")
@@ -1815,15 +1841,6 @@ public final class TypeSpecTest {
       fail();
     } catch (IllegalArgumentException expected) {
       assertThat(expected).hasMessage("expected type but was java.lang.String");
-    }
-  }
-
-  @Test public void tooManyArguments() {
-    try {
-      CodeBlock.builder().add("$$", "foo");
-      fail();
-    } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessage("unexpected args for $$: [foo]");
     }
   }
 


### PR DESCRIPTION
In response to issue #238 I added in the ability to use indexes in the format strings.

I used the $-index-format syntax discussed in that thread and made the index start at one to be consistent with the way that java formatters act.