### PR TITLE
Fix bug when using javapoet with Eclipse compiler

### DIFF
--- a/src/main/java/com/squareup/javapoet/TypeVariableName.java
+++ b/src/main/java/com/squareup/javapoet/TypeVariableName.java
@@ -120,6 +120,12 @@ public final class TypeVariableName extends TypeName {
         result.addAll(upperBoundElement.getInterfaces());
         return result;
       }
+    } else if (upperBound.getKind() == TypeKind.TYPEVAR) {
+      TypeParameterElement upperBoundElement =
+          (TypeParameterElement) ((javax.lang.model.type.TypeVariable) upperBound).asElement();
+      List<TypeMirror> result = new ArrayList<>();
+      result.addAll(upperBoundElement.getBounds());
+      return result;
     }
 
     return Collections.singletonList(upperBound);


### PR DESCRIPTION
For the following code:

public interface Interface1 {}
public interface Interface 2 {}
public T myMethod(T input) {}

a code generator (javax.annotation.processing.Processor) in eclipse will have a TypeVariable for the return type T instead of a DeclaredType.

This results in a stack overflow exception, because the return value of Collections.singletonList(upperBound) ends up returning a list containing, in essence, the input parameter.