### PR TITLE
Fix bug when using javapoet with Eclipse compiler

### DIFF
--- a/src/main/java/com/squareup/javapoet/TypeVariableName.java
+++ b/src/main/java/com/squareup/javapoet/TypeVariableName.java
@@ -16,18 +16,13 @@
 package com.squareup.javapoet;
 
 import java.io.IOException;
-import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import javax.lang.model.element.NestingKind;
-import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.TypeParameterElement;
-import javax.lang.model.type.DeclaredType;
-import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 
 import static com.squareup.javapoet.Util.checkArgument;

--- a/src/main/java/com/squareup/javapoet/TypeVariableName.java
+++ b/src/main/java/com/squareup/javapoet/TypeVariableName.java
@@ -125,9 +125,7 @@ public final class TypeVariableName extends TypeName {
       TypeParameterElement upperBoundElement =
           (TypeParameterElement) ((javax.lang.model.type.TypeVariable) upperBound).asElement();
       if (upperBoundElement.getBounds().size() > 1) {
-        List<TypeMirror> result = new ArrayList<>();
-        result.addAll(upperBoundElement.getBounds());
-        return result;
+        return upperBoundElement.getBounds();
       }
     }
 

--- a/src/main/java/com/squareup/javapoet/TypeVariableName.java
+++ b/src/main/java/com/squareup/javapoet/TypeVariableName.java
@@ -124,9 +124,11 @@ public final class TypeVariableName extends TypeName {
     } else if (upperBound.getKind() == TypeKind.TYPEVAR) {
       TypeParameterElement upperBoundElement =
           (TypeParameterElement) ((javax.lang.model.type.TypeVariable) upperBound).asElement();
-      List<TypeMirror> result = new ArrayList<>();
-      result.addAll(upperBoundElement.getBounds());
-      return result;
+      if (upperBoundElement.getBounds().size() > 1) {
+        List<TypeMirror> result = new ArrayList<>();
+        result.addAll(upperBoundElement.getBounds());
+        return result;
+      }
     }
 
     return Collections.singletonList(upperBound);

--- a/src/main/java/com/squareup/javapoet/TypeVariableName.java
+++ b/src/main/java/com/squareup/javapoet/TypeVariableName.java
@@ -97,39 +97,11 @@ public final class TypeVariableName extends TypeName {
    * is made gnarly by the need to unpack Java 8's new IntersectionType with reflection. We don't
    * have that type in Java 7, and {@link TypeVariable}'s array of bounds is sufficient anyway.
    */
-  @SuppressWarnings("unchecked") // Gross things in support of Java 7 and Java 8.
   private static List<? extends TypeMirror> typeVariableBounds(
       javax.lang.model.type.TypeVariable typeVariable) {
-    TypeMirror upperBound = typeVariable.getUpperBound();
-
-    // On Java 8, unwrap an intersection type into its component bounds.
-    if ("INTERSECTION".equals(upperBound.getKind().name())) {
-      try {
-        Method method = upperBound.getClass().getMethod("getBounds");
-        return (List<? extends TypeMirror>) method.invoke(upperBound);
-      } catch (Exception e) {
-        throw new RuntimeException(e);
-      }
-    }
-
-    // On Java 7, intersection types exist but without explicit API. Use a (clumsy) heuristic.
-    if (upperBound.getKind() == TypeKind.DECLARED) {
-      TypeElement upperBoundElement = (TypeElement) ((DeclaredType) upperBound).asElement();
-      if (upperBoundElement.getNestingKind() == NestingKind.ANONYMOUS) {
-        List<TypeMirror> result = new ArrayList<>();
-        result.add(upperBoundElement.getSuperclass());
-        result.addAll(upperBoundElement.getInterfaces());
-        return result;
-      }
-    } else if (upperBound.getKind() == TypeKind.TYPEVAR) {
-      TypeParameterElement upperBoundElement =
-          (TypeParameterElement) ((javax.lang.model.type.TypeVariable) upperBound).asElement();
-      if (upperBoundElement.getBounds().size() > 1) {
-        return upperBoundElement.getBounds();
-      }
-    }
-
-    return Collections.singletonList(upperBound);
+    TypeParameterElement upperBoundElement =
+        (TypeParameterElement) ((javax.lang.model.type.TypeVariable) typeVariable).asElement();
+    return upperBoundElement.getBounds();
   }
 
   /** Returns type variable equivalent to {@code type}. */

--- a/src/main/java/com/squareup/javapoet/TypeVariableName.java
+++ b/src/main/java/com/squareup/javapoet/TypeVariableName.java
@@ -88,9 +88,7 @@ public final class TypeVariableName extends TypeName {
   }
 
   /**
-   * Returns a list of type mirrors representing the unpacked bounds of {@code typeVariable}. This
-   * is made gnarly by the need to unpack Java 8's new IntersectionType with reflection. We don't
-   * have that type in Java 7, and {@link TypeVariable}'s array of bounds is sufficient anyway.
+   * Returns a list of type mirrors representing the unpacked bounds of {@code typeVariable}.
    */
   private static List<? extends TypeMirror> typeVariableBounds(
       javax.lang.model.type.TypeVariable typeVariable) {

--- a/src/main/java/com/squareup/javapoet/TypeVariableName.java
+++ b/src/main/java/com/squareup/javapoet/TypeVariableName.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.List;
 import javax.lang.model.element.NestingKind;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.TypeParameterElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
@@ -120,6 +121,12 @@ public final class TypeVariableName extends TypeName {
         result.addAll(upperBoundElement.getInterfaces());
         return result;
       }
+    } else if (upperBound.getKind() == TypeKind.TYPEVAR) {
+      TypeParameterElement upperBoundElement =
+          (TypeParameterElement) ((javax.lang.model.type.TypeVariable) upperBound).asElement();
+      List<TypeMirror> result = new ArrayList<>();
+      result.addAll(upperBoundElement.getBounds());
+      return result;
     }
 
     return Collections.singletonList(upperBound);


### PR DESCRIPTION
For the following code:
```
public interface Interface1 {}
public interface Interface 2 {}
public T myMethod(T input) {}
```
a code generator (javax.annotation.processing.Processor) in eclipse will have a TypeVariable for the return type T instead of a DeclaredType.

This results in a stack overflow exception, because the return value of Collections.singletonList(upperBound) ends up returning a list containing, in essence, the input parameter.