### PR TITLE
Issue 253 - Added support for annotations on enum values

### DIFF
--- a/src/main/java/com/squareup/javapoet/TypeSpec.java
+++ b/src/main/java/com/squareup/javapoet/TypeSpec.java
@@ -131,6 +131,7 @@ public final class TypeSpec {
     try {
       if (enumName != null) {
         codeWriter.emitJavadoc(javadoc);
+        codeWriter.emitAnnotations(annotations, false);
         codeWriter.emit("$L", enumName);
         if (!anonymousTypeArguments.formatParts.isEmpty()) {
           codeWriter.emit("(");
@@ -352,7 +353,6 @@ public final class TypeSpec {
     }
 
     public Builder addAnnotations(Iterable<AnnotationSpec> annotationSpecs) {
-      checkState(anonymousTypeArguments == null, "forbidden on anonymous types.");
       checkArgument(annotationSpecs != null, "annotationSpecs == null");
       for (AnnotationSpec annotationSpec : annotationSpecs) {
         this.annotations.add(annotationSpec);
@@ -361,7 +361,6 @@ public final class TypeSpec {
     }
 
     public Builder addAnnotation(AnnotationSpec annotationSpec) {
-      checkState(anonymousTypeArguments == null, "forbidden on anonymous types.");
       this.annotations.add(annotationSpec);
       return this;
     }

--- a/src/test/java/com/squareup/javapoet/TypeSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/TypeSpecTest.java
@@ -441,6 +441,31 @@ public final class TypeSpecTest {
         + "}\n");
   }
 
+  /** https://github.com/square/javapoet/issues/253 */
+  @Test public void enumWithAnnotatedValues() throws Exception {
+    TypeSpec roshambo = TypeSpec.enumBuilder("Roshambo")
+        .addModifiers(Modifier.PUBLIC)
+        .addEnumConstant("ROCK", TypeSpec.anonymousClassBuilder("")
+            .addAnnotation(Deprecated.class)
+            .build())
+        .addEnumConstant("PAPER")
+        .addEnumConstant("SCISSORS")
+        .build();
+    assertThat(toString(roshambo)).isEqualTo(""
+        + "package com.squareup.tacos;\n"
+        + "\n"
+        + "import java.lang.Deprecated;\n"
+        + "\n"
+        + "public enum Roshambo {\n"
+        + "  @Deprecated\n"
+        + "  ROCK,\n"
+        + "\n"
+        + "  PAPER,\n"
+        + "\n"
+        + "  SCISSORS\n"
+        + "}\n");
+  }
+
   @Test public void methodThrows() throws Exception {
     TypeSpec taco = TypeSpec.classBuilder("Taco")
         .addModifiers(Modifier.ABSTRACT)


### PR DESCRIPTION
Per issue [253](https://github.com/square/javapoet/issues/253), this change relaxes the prohibition on annotations for anonymous classes and adds the annotation  to the emitter.