### PR TITLE
equals() and hashCode() implemented.

### DIFF
--- a/src/main/java/com/squareup/javapoet/AnnotationSpec.java
+++ b/src/main/java/com/squareup/javapoet/AnnotationSpec.java
@@ -183,13 +183,14 @@ public final class AnnotationSpec {
   }
 
   @Override public boolean equals(Object o) {
-    return o instanceof AnnotationSpec
-        && ((AnnotationSpec) o).type.equals(type)
-        && ((AnnotationSpec) o).members.equals(members);
+    if (this == o) return true;
+    if (o == null) return false;
+    if (getClass() != o.getClass()) return false;
+    return toString().equals(o.toString());
   }
 
   @Override public int hashCode() {
-    return type.hashCode() + 37 * members.hashCode();
+    return toString().hashCode();
   }
 
   @Override public String toString() {

--- a/src/main/java/com/squareup/javapoet/CodeBlock.java
+++ b/src/main/java/com/squareup/javapoet/CodeBlock.java
@@ -69,6 +69,17 @@ public final class CodeBlock {
     return formatParts.isEmpty();
   }
 
+  @Override public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null) return false;
+    if (getClass() != o.getClass()) return false;
+    return toString().equals(o.toString());
+  }
+
+  @Override public int hashCode() {
+    return toString().hashCode();
+  }
+
   @Override public String toString() {
     StringWriter out = new StringWriter();
     try {

--- a/src/main/java/com/squareup/javapoet/CodeWriter.java
+++ b/src/main/java/com/squareup/javapoet/CodeWriter.java
@@ -327,7 +327,7 @@ final class CodeWriter {
 
     // Match the top-level class.
     if (typeSpecStack.size() > 0 && Objects.equals(typeSpecStack.get(0).name, simpleName)) {
-      return ClassName.get(packageName, simpleName);
+      return ClassName.get(getPackageNameNullSafe(), simpleName);
     }
 
     // Match an imported type.
@@ -340,11 +340,15 @@ final class CodeWriter {
 
   /** Returns the class named {@code simpleName} when nested in the class at {@code stackDepth}. */
   private ClassName stackClassName(int stackDepth, String simpleName) {
-    ClassName className = ClassName.get(packageName, typeSpecStack.get(0).name);
+    ClassName className = ClassName.get(getPackageNameNullSafe(), typeSpecStack.get(0).name);
     for (int i = 1; i <= stackDepth; i++) {
       className = className.nestedClass(typeSpecStack.get(i).name);
     }
     return className.nestedClass(simpleName);
+  }
+
+  private String getPackageNameNullSafe() {
+    return packageName == null ? "" : packageName;
   }
 
   /**

--- a/src/main/java/com/squareup/javapoet/FieldSpec.java
+++ b/src/main/java/com/squareup/javapoet/FieldSpec.java
@@ -65,6 +65,17 @@ public final class FieldSpec {
     codeWriter.emit(";\n");
   }
 
+  @Override public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null) return false;
+    if (getClass() != o.getClass()) return false;
+    return toString().equals(o.toString());
+  }
+
+  @Override public int hashCode() {
+    return toString().hashCode();
+  }
+
   @Override public String toString() {
     StringWriter out = new StringWriter();
     try {

--- a/src/main/java/com/squareup/javapoet/JavaFile.java
+++ b/src/main/java/com/squareup/javapoet/JavaFile.java
@@ -147,6 +147,17 @@ public final class JavaFile {
     codeWriter.popPackage();
   }
 
+  @Override public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null) return false;
+    if (getClass() != o.getClass()) return false;
+    return toString().equals(o.toString());
+  }
+
+  @Override public int hashCode() {
+    return toString().hashCode();
+  }
+
   @Override public String toString() {
     try {
       StringBuilder result = new StringBuilder();

--- a/src/main/java/com/squareup/javapoet/MethodSpec.java
+++ b/src/main/java/com/squareup/javapoet/MethodSpec.java
@@ -149,6 +149,17 @@ public final class MethodSpec {
     return name.equals(CONSTRUCTOR);
   }
 
+  @Override public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null) return false;
+    if (getClass() != o.getClass()) return false;
+    return toString().equals(o.toString());
+  }
+
+  @Override public int hashCode() {
+    return toString().hashCode();
+  }
+
   @Override public String toString() {
     StringWriter out = new StringWriter();
     try {

--- a/src/main/java/com/squareup/javapoet/ParameterSpec.java
+++ b/src/main/java/com/squareup/javapoet/ParameterSpec.java
@@ -56,6 +56,17 @@ public final class ParameterSpec {
     }
   }
 
+  @Override public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null) return false;
+    if (getClass() != o.getClass()) return false;
+    return toString().equals(o.toString());
+  }
+
+  @Override public int hashCode() {
+    return toString().hashCode();
+  }
+
   @Override public String toString() {
     StringWriter out = new StringWriter();
     try {

--- a/src/main/java/com/squareup/javapoet/TypeName.java
+++ b/src/main/java/com/squareup/javapoet/TypeName.java
@@ -139,6 +139,17 @@ public class TypeName {
     throw new UnsupportedOperationException("cannot unbox " + this);
   }
 
+  @Override public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null) return false;
+    if (getClass() != o.getClass()) return false;
+    return toString().equals(o.toString());
+  }
+
+  @Override public int hashCode() {
+    return toString().hashCode();
+  }
+
   @Override public final String toString() {
     try {
       StringBuilder result = new StringBuilder();

--- a/src/main/java/com/squareup/javapoet/TypeSpec.java
+++ b/src/main/java/com/squareup/javapoet/TypeSpec.java
@@ -269,6 +269,17 @@ public final class TypeSpec {
     }
   }
 
+  @Override public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null) return false;
+    if (getClass() != o.getClass()) return false;
+    return toString().equals(o.toString());
+  }
+
+  @Override public int hashCode() {
+    return toString().hashCode();
+  }
+
   @Override public String toString() {
     StringWriter out = new StringWriter();
     try {

--- a/src/test/java/com/squareup/javapoet/AnnotationSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/AnnotationSpecTest.java
@@ -103,6 +103,17 @@ public final class AnnotationSpecTest {
 
   @Rule public final CompilationRule compilation = new CompilationRule();
 
+  @Test public void equalsAndHashCode() {
+    AnnotationSpec a = AnnotationSpec.builder(AnnotationC.class).build();
+    AnnotationSpec b = AnnotationSpec.builder(AnnotationC.class).build();
+    assertThat(a.equals(b)).isTrue();
+    assertThat(a.hashCode()).isEqualTo(b.hashCode());
+    a = AnnotationSpec.builder(AnnotationC.class).addMember("value", "$S", "123").build();
+    b = AnnotationSpec.builder(AnnotationC.class).addMember("value", "$S", "123").build();
+    assertThat(a.equals(b)).isTrue();
+    assertThat(a.hashCode()).isEqualTo(b.hashCode());
+  }
+
   @Test public void defaultAnnotation() {
     String name = IsAnnotated.class.getCanonicalName();
     TypeElement element = compilation.getElements().getTypeElement(name);

--- a/src/test/java/com/squareup/javapoet/CodeBlockTest.java
+++ b/src/test/java/com/squareup/javapoet/CodeBlockTest.java
@@ -21,6 +21,17 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 
 public final class CodeBlockTest {
+  @Test public void equalsAndHashCode() {
+    CodeBlock a = CodeBlock.builder().build();
+    CodeBlock b = CodeBlock.builder().build();
+    assertThat(a.equals(b)).isTrue();
+    assertThat(a.hashCode()).isEqualTo(b.hashCode());
+    a = CodeBlock.builder().add("$L", "taco").build();
+    b = CodeBlock.builder().add("$L", "taco").build();
+    assertThat(a.equals(b)).isTrue();
+    assertThat(a.hashCode()).isEqualTo(b.hashCode());
+  }
+
   @Test public void indentCannotBeIndexed() {
     try {
       CodeBlock.builder().add("$1>", "taco").build();

--- a/src/test/java/com/squareup/javapoet/FieldSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/FieldSpecTest.java
@@ -20,10 +20,21 @@ import org.junit.Test;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 
-public class FieldSpecTest {
+import javax.lang.model.element.Modifier;
 
-  @Test
-  public void nullAnnotationsAddition() {
+public class FieldSpecTest {
+  @Test public void equalsAndHashCode() {
+    FieldSpec a = FieldSpec.builder(int.class, "foo").build();
+    FieldSpec b = FieldSpec.builder(int.class, "foo").build();
+    assertThat(a.equals(b)).isTrue();
+    assertThat(a.hashCode()).isEqualTo(b.hashCode());
+    a = FieldSpec.builder(int.class, "FOO", Modifier.PUBLIC, Modifier.STATIC).build();
+    b = FieldSpec.builder(int.class, "FOO", Modifier.PUBLIC, Modifier.STATIC).build();
+    assertThat(a.equals(b)).isTrue();
+    assertThat(a.hashCode()).isEqualTo(b.hashCode());
+  }
+
+  @Test public void nullAnnotationsAddition() {
     try {
       FieldSpec.builder(int.class, "foo").addAnnotations(null);
       fail();

--- a/src/test/java/com/squareup/javapoet/MethodSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/MethodSpecTest.java
@@ -188,4 +188,22 @@ public final class MethodSpecTest {
       assertThat(expected).hasMessage("cannot override method with modifiers: [static]");
     }
   }
+
+  @Test public void equalsAndHashCode() {
+    MethodSpec a = MethodSpec.constructorBuilder().build();
+    MethodSpec b = MethodSpec.constructorBuilder().build();
+    assertThat(a.equals(b)).isTrue();
+    assertThat(a.hashCode()).isEqualTo(b.hashCode());
+    a = MethodSpec.methodBuilder("taco").build();
+    b = MethodSpec.methodBuilder("taco").build();
+    assertThat(a.equals(b)).isTrue();
+    assertThat(a.hashCode()).isEqualTo(b.hashCode());
+    TypeElement classElement = getElement(Everything.class);
+    ExecutableElement methodElement = getOnlyElement(methodsIn(classElement.getEnclosedElements()));
+    a = MethodSpec.overriding(methodElement).build();
+    b = MethodSpec.overriding(methodElement).build();
+    assertThat(a.equals(b)).isTrue();
+    assertThat(a.hashCode()).isEqualTo(b.hashCode());
+  }
+
 }

--- a/src/test/java/com/squareup/javapoet/ParameterSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/ParameterSpecTest.java
@@ -20,10 +20,21 @@ import org.junit.Test;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 
-public class ParameterSpecTest {
+import javax.lang.model.element.Modifier;
 
-  @Test
-  public void nullAnnotationsAddition() {
+public class ParameterSpecTest {
+  @Test public void equalsAndHashCode() {
+    ParameterSpec a = ParameterSpec.builder(int.class, "foo").build();
+    ParameterSpec b = ParameterSpec.builder(int.class, "foo").build();
+    assertThat(a.equals(b)).isTrue();
+    assertThat(a.hashCode()).isEqualTo(b.hashCode());
+    a = ParameterSpec.builder(int.class, "i").addModifiers(Modifier.STATIC).build();
+    b = ParameterSpec.builder(int.class, "i").addModifiers(Modifier.STATIC).build();
+    assertThat(a.equals(b)).isTrue();
+    assertThat(a.hashCode()).isEqualTo(b.hashCode());
+  }
+
+  @Test public void nullAnnotationsAddition() {
     try {
       ParameterSpec.builder(int.class, "foo").addAnnotations(null);
       fail();

--- a/src/test/java/com/squareup/javapoet/TypeNameTest.java
+++ b/src/test/java/com/squareup/javapoet/TypeNameTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.javapoet;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.Serializable;
+import java.rmi.server.UID;
+import java.util.Comparator;
+import java.util.Set;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TypeNameTest {
+
+  @Test public void equalsAndHashCodePrimitive() {
+    test(TypeName.BOOLEAN, TypeName.BOOLEAN);
+    test(TypeName.BYTE, TypeName.BYTE);
+    test(TypeName.CHAR, TypeName.CHAR);
+    test(TypeName.DOUBLE, TypeName.DOUBLE);
+    test(TypeName.FLOAT, TypeName.FLOAT);
+    test(TypeName.INT, TypeName.INT);
+    test(TypeName.LONG, TypeName.LONG);
+    test(TypeName.SHORT, TypeName.SHORT);
+    test(TypeName.VOID, TypeName.VOID);
+  }
+
+  @Test public void equalsAndHashCodeArrayTypeName() {
+    test(ArrayTypeName.of(Object.class), ArrayTypeName.of(Object.class));
+    test(TypeName.get(Object[].class), ArrayTypeName.of(Object.class));
+    // ? check(ClassName.bestGuess("java.lang.Object[]"), ArrayTypeName.of(Object.class));
+  }
+
+  @Test public void equalsAndHashCodeClassName() {
+    test(ClassName.get(Object.class), ClassName.get(Object.class));
+    test(TypeName.get(Object.class), ClassName.get(Object.class));
+    test(ClassName.bestGuess("java.lang.Object"), ClassName.get(Object.class));
+  }
+  
+  @Test public void equalsAndHashCodeParameterizedTypeName() {
+    test(ParameterizedTypeName.get(Object.class), ParameterizedTypeName.get(Object.class));
+    test(ParameterizedTypeName.get(Set.class, UID.class), ParameterizedTypeName.get(Set.class, UID.class));
+  }
+  
+  @Test public void equalsAndHashCodeTypeVariableName() {
+    test(TypeVariableName.get(Object.class), TypeVariableName.get(Object.class));
+    TypeVariableName typeVariable1 = TypeVariableName.get("T", Comparator.class, Serializable.class);
+    TypeVariableName typeVariable2 = TypeVariableName.get("T", Comparator.class, Serializable.class);
+    test(typeVariable1, typeVariable2);
+  }
+
+  @Test public void equalsAndHashCodeWildcardTypeName() {
+    test(WildcardTypeName.subtypeOf(Object.class), WildcardTypeName.subtypeOf(Object.class));
+    test(WildcardTypeName.subtypeOf(Serializable.class), WildcardTypeName.subtypeOf(Serializable.class));
+    test(WildcardTypeName.supertypeOf(String.class), WildcardTypeName.supertypeOf(String.class));
+  }
+
+  private void test(TypeName a, TypeName b) {
+    Assert.assertEquals(a.toString(), b.toString());
+    assertThat(a.equals(b)).isTrue();
+    assertThat(a.hashCode()).isEqualTo(b.hashCode());
+  }
+
+}

--- a/src/test/java/com/squareup/javapoet/TypeSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/TypeSpecTest.java
@@ -36,6 +36,7 @@ import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeMirror;
 
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -82,6 +83,7 @@ public final class TypeSpecTest {
         + "    return \"taco\";\n"
         + "  }\n"
         + "}\n");
+    Assert.assertEquals(472949424, taco.hashCode()); // update expected number if source changes
   }
 
   @Test public void interestingTypes() throws Exception {
@@ -1963,6 +1965,25 @@ public final class TypeSpecTest {
             + "    return FOO;\n"
             + "  }\n"
             + "}\n");
+  }
+
+  @Test public void equalsAndHashCode() {
+    TypeSpec a = TypeSpec.interfaceBuilder("taco").build();
+    TypeSpec b = TypeSpec.interfaceBuilder("taco").build();
+    assertThat(a.equals(b)).isTrue();
+    assertThat(a.hashCode()).isEqualTo(b.hashCode());
+    a = TypeSpec.classBuilder("taco").build();
+    b = TypeSpec.classBuilder("taco").build();
+    assertThat(a.equals(b)).isTrue();
+    assertThat(a.hashCode()).isEqualTo(b.hashCode());
+    a = TypeSpec.enumBuilder("taco").addEnumConstant("SALSA").build();
+    b = TypeSpec.enumBuilder("taco").addEnumConstant("SALSA").build();
+    assertThat(a.equals(b)).isTrue();
+    assertThat(a.hashCode()).isEqualTo(b.hashCode());
+    a = TypeSpec.annotationBuilder("taco").build();
+    b = TypeSpec.annotationBuilder("taco").build();
+    assertThat(a.equals(b)).isTrue();
+    assertThat(a.hashCode()).isEqualTo(b.hashCode());
   }
 
   private CodeBlock codeBlock(String format, Object... args) {


### PR DESCRIPTION
https://github.com/square/javapoet/issues/345
Take 2

If a common base class for all Specs, Names and CodeBlock is too intrusive/restrictive, I'll unroll the two methods into all types extending Base.