### PR TITLE
Add a method to AnnotationSpec to explicitly add a value member

### DIFF
--- a/src/main/java/com/squareup/javapoet/AnnotationSpec.java
+++ b/src/main/java/com/squareup/javapoet/AnnotationSpec.java
@@ -153,6 +153,7 @@ public final class AnnotationSpec {
     // return literal/toString anyway
     return builder.addMember(name, "$L", value);
   }
+
   public static AnnotationSpec get(AnnotationMirror annotation) {
     TypeElement element = (TypeElement) annotation.getAnnotationType().asElement();
     AnnotationSpec.Builder builder = AnnotationSpec.builder(ClassName.get(element));
@@ -163,6 +164,15 @@ public final class AnnotationSpec {
       value.accept(visitor, new Entry(name, value));
     }
     return builder.build();
+  }
+
+  public static AnnotationSpec createSimpleAnnotation(ClassName type, Object value) {
+    checkNotNull(type, "type == null");
+    return addAnnotationValue(AnnotationSpec.builder(type), "value", value).build();
+  }
+
+  public static AnnotationSpec createSimpleAnnotation(Class<?> type, Object value) {
+    return createSimpleAnnotation(ClassName.get(type), value);
   }
 
   public static Builder builder(ClassName type) {

--- a/src/test/java/com/squareup/javapoet/AnnotationSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/AnnotationSpecTest.java
@@ -340,6 +340,22 @@ public final class AnnotationSpecTest {
         + "}\n");
   }
 
+  @Test public void simpleAnnotation() {
+    AnnotationSpec spec = AnnotationSpec.createSimpleAnnotation(AnnotationC.class, "test");
+    TypeSpec taco = TypeSpec.classBuilder("Taco")
+        .addAnnotation(spec)
+        .build();
+
+    assertThat(toString(taco)).isEqualTo(""
+        + "package com.squareup.tacos;\n"
+        + "\n"
+        + "import com.squareup.javapoet.AnnotationSpecTest;\n"
+        + "\n"
+        + "@AnnotationSpecTest.AnnotationC(\"test\")\n"
+        + "class Taco {\n"
+        + "}\n");
+  }
+
   private String toString(TypeSpec typeSpec) {
     return JavaFile.builder("com.squareup.tacos", typeSpec).build().toString();
   }


### PR DESCRIPTION
When I started working with JavaPoet a bit, I didn't really have a strong understanding of the internals of annotations (the fact that the default member name is "value"), so I thought this could be useful for some people that just want to explicitly add an annotation like SupressWarnings or any other annotation that uses the "value" member.