### PR TITLE
Prevent import of types located in the default package. 

### DIFF
--- a/src/main/java/com/squareup/javapoet/CodeWriter.java
+++ b/src/main/java/com/squareup/javapoet/CodeWriter.java
@@ -309,6 +309,9 @@ final class CodeWriter {
   }
 
   private void importableType(ClassName className) {
+    if (className.packageName().isEmpty()) {
+      return;
+    }
     ClassName topLevelClassName = className.topLevelClassName();
     String simpleName = topLevelClassName.simpleName();
     ClassName replaced = importableTypes.put(simpleName, topLevelClassName);

--- a/src/test/java/com/squareup/javapoet/JavaFileTest.java
+++ b/src/test/java/com/squareup/javapoet/JavaFileTest.java
@@ -295,6 +295,18 @@ public final class JavaFileTest {
         + "}\n");
   }
 
+  @Test public void defaultPackageTypesAreNotImported() throws Exception {
+    String source = JavaFile.builder("hello",
+          TypeSpec.classBuilder("World").addSuperinterface(ClassName.get("", "Test")).build())
+        .build()
+        .toString();
+    assertThat(source).isEqualTo(""
+        + "package hello;\n"
+        + "\n"
+        + "class World implements Test {\n"
+        + "}\n");
+  }
+
   @Test public void topOfFileComment() throws Exception {
     String source = JavaFile.builder("com.squareup.tacos",
         TypeSpec.classBuilder("Taco").build())


### PR DESCRIPTION
A possible solution for #369 - don't put empty class names with empty package names into the `importableTypes` map.