### PR TITLE
Self type

### DIFF
--- a/src/main/java/com/squareup/javapoet/CodeWriter.java
+++ b/src/main/java/com/squareup/javapoet/CodeWriter.java
@@ -121,6 +121,14 @@ final class CodeWriter {
     return this;
   }
 
+  TypeSpec peekType(int depth) {
+    checkState(!typeSpecStack.isEmpty(), "expected to be emitting a TypeSpec");
+    checkArgument(depth >= 0, "depth must not be negative, got %d", depth);
+    checkArgument(depth < typeSpecStack.size(), "depth %d exceeds nesting TypeSpec stack: %d",
+        depth, typeSpecStack.size() - 1);
+    return typeSpecStack.get(typeSpecStack.size() - 1 - depth);
+  }
+
   public void emitComment(CodeBlock codeBlock) throws IOException {
     trailingNewline = true; // Force the '//' prefix for the comment.
     comment = true;
@@ -325,7 +333,7 @@ final class CodeWriter {
    * imports.
    */
   // TODO(jwilson): also honor superclass members when resolving names.
-  private ClassName resolve(String simpleName) {
+  ClassName resolve(String simpleName) {
     // Match a child of the current (potentially nested) class.
     for (int i = typeSpecStack.size() - 1; i >= 0; i--) {
       TypeSpec typeSpec = typeSpecStack.get(i);

--- a/src/main/java/com/squareup/javapoet/SelfName.java
+++ b/src/main/java/com/squareup/javapoet/SelfName.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.javapoet;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public final class SelfName extends TypeName {
+
+  private final int depth;
+
+  SelfName(List<AnnotationSpec> annotations) {
+    this(annotations, 0);
+  }
+
+  SelfName(List<AnnotationSpec> annotations, int depth) {
+    super(annotations);
+    this.depth = depth;
+  }
+
+  public SelfName(int depth) {
+    this(new ArrayList<AnnotationSpec>(), depth);
+  }
+
+  @Override public TypeName annotated(List<AnnotationSpec> annotations) {
+    return new SelfName(annotations);
+  }
+
+  @Override CodeWriter emit(CodeWriter out) throws IOException {
+ // ClassName className = out.resolve(name == null ? out.peekType().name : name);
+    ClassName className = out.resolve(out.peekType(depth).name);
+    return emitAnnotations(out).emitAndIndent(out.lookupName(className));
+  }
+
+}

--- a/src/main/java/com/squareup/javapoet/TypeName.java
+++ b/src/main/java/com/squareup/javapoet/TypeName.java
@@ -75,6 +75,7 @@ public class TypeName {
   public static final TypeName FLOAT = new TypeName("float");
   public static final TypeName DOUBLE = new TypeName("double");
   public static final ClassName OBJECT = ClassName.get("java.lang", "Object");
+  public static final TypeName SELF = new SelfName(new ArrayList<AnnotationSpec>());
 
   private static final ClassName BOXED_VOID = ClassName.get("java.lang", "Void");
   private static final ClassName BOXED_BOOLEAN = ClassName.get("java.lang", "Boolean");

--- a/src/test/java/com/squareup/javapoet/CodeBlockTest.java
+++ b/src/test/java/com/squareup/javapoet/CodeBlockTest.java
@@ -188,4 +188,15 @@ public final class CodeBlockTest {
       assertThat(expected).hasMessage("statement exit $] has no matching statement enter $[");
     }
   }
+
+  @Test public void selfNameFailsWithoutTypeSpecContext() {
+    CodeBlock codeBlock = CodeBlock.builder().add("$T", TypeName.SELF).build();
+    try {
+      // We can't report this error until rendering type because code blocks might be composed.
+      codeBlock.toString();
+      fail();
+    } catch (IllegalStateException expected) {
+      assertThat(expected).hasMessage("expected to be emitting a TypeSpec");
+    }    
+  }
 }

--- a/src/test/java/com/squareup/javapoet/TypeSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/TypeSpecTest.java
@@ -624,19 +624,25 @@ public final class TypeSpecTest {
     TypeSpec typeSpec = TypeSpec.classBuilder("Combo")
         .addField(taco, "taco")
         .addField(chips, "chips")
+        .addField(TypeName.SELF, "combo")
         .addType(TypeSpec.classBuilder(taco.simpleName())
             .addModifiers(Modifier.STATIC)
             .addField(ParameterizedTypeName.get(ClassName.get(List.class), topping), "toppings")
             .addField(sauce, "sauce")
+            .addField(TypeName.SELF, "taco")
             .addType(TypeSpec.enumBuilder(topping.simpleName())
                 .addEnumConstant("SHREDDED_CHEESE")
                 .addEnumConstant("LEAN_GROUND_BEEF")
+                .addField(new SelfName(2), "C")
+                .addField(new SelfName(1), "T")
+                .addField(new SelfName(0), "Q")
                 .build())
             .build())
         .addType(TypeSpec.classBuilder(chips.simpleName())
             .addModifiers(Modifier.STATIC)
             .addField(topping, "topping")
             .addField(sauce, "dippingSauce")
+            .addField(TypeName.SELF, "chips")
             .build())
         .addType(TypeSpec.enumBuilder(sauce.simpleName())
             .addEnumConstant("SOUR_CREAM")
@@ -657,15 +663,25 @@ public final class TypeSpecTest {
         + "\n"
         + "  Chips chips;\n"
         + "\n"
+        + "  Combo combo;\n"
+        + "\n"
         + "  static class Taco {\n"
         + "    List<Topping> toppings;\n"
         + "\n"
         + "    Sauce sauce;\n"
         + "\n"
+        + "    Taco taco;\n"
+        + "\n"
         + "    enum Topping {\n"
         + "      SHREDDED_CHEESE,\n"
         + "\n"
-        + "      LEAN_GROUND_BEEF\n"
+        + "      LEAN_GROUND_BEEF;\n"
+        + "\n"
+        + "      Combo C;\n"
+        + "\n"
+        + "      Taco T;\n"
+        + "\n"
+        + "      Topping Q;\n"
         + "    }\n"
         + "  }\n"
         + "\n"
@@ -673,6 +689,8 @@ public final class TypeSpecTest {
         + "    Taco.Topping topping;\n"
         + "\n"
         + "    Sauce dippingSauce;\n"
+        + "\n"
+        + "    Chips chips;\n"
         + "  }\n"
         + "\n"
         + "  enum Sauce {\n"
@@ -1944,6 +1962,44 @@ public final class TypeSpecTest {
       fail();
     } catch (IllegalArgumentException expected) {
     }
+  }
+
+  @Test public void selfName() {
+    AnnotationSpec anno = AnnotationSpec.builder(ClassName.get("anno", "Tation")).build();
+    AnnotationSpec none = AnnotationSpec.builder(ClassName.get("anno", "NonNull")).build();
+    TypeName selfWithAnno1 = TypeName.SELF.annotated(Arrays.asList(anno));
+    TypeName selfWithAnno2 = TypeName.SELF.annotated(Arrays.asList(anno, none));
+    TypeSpec taco = TypeSpec.classBuilder("Taco")
+        .addField(TypeName.SELF, "mFoo", Modifier.PRIVATE)
+        .addField(selfWithAnno1, "FOO", Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
+        .addStaticBlock(CodeBlock.builder()
+            .addStatement("FOO = new $T()", TypeName.SELF)
+            .build())
+        .addMethod(MethodSpec.methodBuilder("toSelf")
+            .addAnnotation(Override.class)
+            .addModifiers(Modifier.PUBLIC)
+            .returns(selfWithAnno2)
+            .addCode("return FOO;\n")
+            .build())
+        .build();
+    assertThat(toString(taco)).isEqualTo(""
+        + "package com.squareup.tacos;\n"
+        + "\n"
+        + "import anno.NonNull;\n"
+        + "import anno.Tation;\n"
+        + "import java.lang.Override;\n"
+        + "\n"
+        + "class Taco {\n"
+        + "  private static final @Tation Taco FOO;\n\n"
+        + "  static {\n"
+        + "    FOO = new Taco();\n"
+        + "  }\n\n"
+        + "  private Taco mFoo;\n\n"
+        + "  @Override\n"
+        + "  public @Tation @NonNull Taco toSelf() {\n"
+        + "    return FOO;\n"
+        + "  }\n"
+        + "}\n");
   }
 
   @Test public void staticCodeBlock() {


### PR DESCRIPTION
Using existing functionality in `CodeWriter` with a simple TypeName subclass named `SelfName` does the trick.

Open ends
 * ~~Catch NoSuchElement/IndexOutOfBounds when stack is empty and report it to the user. Might happen in plain CodeBlocks.~~
 * ~~Introduce `TypeName.self()` factory instead of `SelfName.get`. Or even move the `get()`to `TypeSpec`?~~
 * Needs more tests.
 * Convince Jesse. :smile: 