### PR TITLE
TypeName#annotated clean up

### DIFF
--- a/src/main/java/com/squareup/javapoet/ArrayTypeName.java
+++ b/src/main/java/com/squareup/javapoet/ArrayTypeName.java
@@ -19,7 +19,6 @@ import java.io.IOException;
 import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -39,10 +38,6 @@ public final class ArrayTypeName extends TypeName {
   private ArrayTypeName(TypeName componentType, List<AnnotationSpec> annotations) {
     super(annotations);
     this.componentType = checkNotNull(componentType, "rawType == null");
-  }
-
-  @Override public ArrayTypeName annotated(AnnotationSpec... annotations) {
-    return annotated(Arrays.asList(annotations));
   }
 
   @Override public ArrayTypeName annotated(List<AnnotationSpec> annotations) {

--- a/src/main/java/com/squareup/javapoet/ClassName.java
+++ b/src/main/java/com/squareup/javapoet/ClassName.java
@@ -17,7 +17,6 @@ package com.squareup.javapoet;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -53,10 +52,6 @@ public final class ClassName extends TypeName implements Comparable<ClassName> {
     this.canonicalName = names.get(0).isEmpty()
         ? Util.join(".", names.subList(1, names.size()))
         : Util.join(".", names);
-  }
-
-  @Override public ClassName annotated(AnnotationSpec... annotations) {
-    return annotated(Arrays.asList(annotations));
   }
 
   @Override public ClassName annotated(List<AnnotationSpec> annotations) {

--- a/src/main/java/com/squareup/javapoet/ParameterizedTypeName.java
+++ b/src/main/java/com/squareup/javapoet/ParameterizedTypeName.java
@@ -48,10 +48,6 @@ public final class ParameterizedTypeName extends TypeName {
     }
   }
 
-  @Override public ParameterizedTypeName annotated(AnnotationSpec... annotations) {
-    return annotated(Arrays.asList(annotations));
-  }
-
   @Override public ParameterizedTypeName annotated(List<AnnotationSpec> annotations) {
     return new ParameterizedTypeName(rawType, typeArguments, annotations);
   }

--- a/src/main/java/com/squareup/javapoet/TypeName.java
+++ b/src/main/java/com/squareup/javapoet/TypeName.java
@@ -104,9 +104,8 @@ public class TypeName {
     this(null, annotations);
   }
 
-  public TypeName annotated(AnnotationSpec... annotations) {
-    Util.checkNotNull(annotations, "annotations == null");
-    return new TypeName(keyword, Arrays.asList(annotations));
+  public final TypeName annotated(AnnotationSpec... annotations) {
+    return annotated(Arrays.asList(annotations));
   }
 
   public TypeName annotated(List<AnnotationSpec> annotations) {

--- a/src/main/java/com/squareup/javapoet/TypeVariableName.java
+++ b/src/main/java/com/squareup/javapoet/TypeVariableName.java
@@ -49,10 +49,6 @@ public final class TypeVariableName extends TypeName {
     }
   }
 
-  @Override public TypeVariableName annotated(AnnotationSpec... annotations) {
-    return annotated(Arrays.asList(annotations));
-  }
-
   @Override public TypeVariableName annotated(List<AnnotationSpec> annotations) {
     return new TypeVariableName(name, bounds, annotations);
   }

--- a/src/main/java/com/squareup/javapoet/WildcardTypeName.java
+++ b/src/main/java/com/squareup/javapoet/WildcardTypeName.java
@@ -54,10 +54,6 @@ public final class WildcardTypeName extends TypeName {
     }
   }
 
-  @Override public WildcardTypeName annotated(AnnotationSpec... annotations) {
-    return annotated(Arrays.asList(annotations));
-  }
-
   @Override public WildcardTypeName annotated(List<AnnotationSpec> annotations) {
     return new WildcardTypeName(upperBounds, lowerBounds, annotations);
   }


### PR DESCRIPTION
Made `TypeName#annotated(AnnotationSpec... annotations)` final and use the `List<AnnotationSpec>` variant.
Removed all unnecessary overridden methods from various TypeName subclasses.