### PR TITLE
Refer to local TypeSpecs via simple name markers.

### DIFF
--- a/src/main/java/com/squareup/javapoet/CodeWriter.java
+++ b/src/main/java/com/squareup/javapoet/CodeWriter.java
@@ -121,6 +121,11 @@ final class CodeWriter {
     return this;
   }
 
+  TypeSpec peekType() {
+    checkState(!typeSpecStack.isEmpty(), "expected to be emitting a TypeSpec");
+    return typeSpecStack.get(typeSpecStack.size() - 1);
+  }
+
   public void emitComment(CodeBlock codeBlock) throws IOException {
     trailingNewline = true; // Force the '//' prefix for the comment.
     comment = true;
@@ -320,18 +325,31 @@ final class CodeWriter {
     }
   }
 
+  ClassName resolve(String simpleName, TypeSpec typeSpec, int i) {
+    if (Objects.equals(typeSpec.name, simpleName)) {
+      return stackClassName(i, simpleName);
+    }
+    for (TypeSpec nested : typeSpec.typeSpecs) {
+      if (Objects.equals(nested.name, simpleName)) {
+        return stackClassName(i, simpleName);
+      }
+      return resolve(simpleName, nested, i);
+    }
+    return null;
+  }
+
   /**
    * Returns the class referenced by {@code simpleName}, using the current nesting context and
    * imports.
    */
-  // TODO(jwilson): also honor superclass members when resolving names.
-  private ClassName resolve(String simpleName) {
+  ClassName resolve(String simpleName) {
     // Match a child of the current (potentially nested) class.
     for (int i = typeSpecStack.size() - 1; i >= 0; i--) {
       TypeSpec typeSpec = typeSpecStack.get(i);
       for (TypeSpec visibleChild : typeSpec.typeSpecs) {
-        if (Objects.equals(visibleChild.name, simpleName)) {
-          return stackClassName(i, simpleName);
+        ClassName resolved = resolve(simpleName, visibleChild, i);
+        if (resolved != null) {
+          return resolved;
         }
       }
     }

--- a/src/main/java/com/squareup/javapoet/MarkerName.java
+++ b/src/main/java/com/squareup/javapoet/MarkerName.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.javapoet;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public final class MarkerName extends TypeName {
+  private final String marker;
+
+  MarkerName(List<AnnotationSpec> annotations) {
+    this(annotations, "");
+  }
+
+  MarkerName(List<AnnotationSpec> annotations, String name) {
+    super(annotations);
+    this.marker = name;
+  }
+
+  public MarkerName(String name) {
+    this(new ArrayList<AnnotationSpec>(), name);
+  }
+
+  @Override public TypeName annotated(List<AnnotationSpec> annotations) {
+    return new MarkerName(annotations);
+  }
+
+  @Override CodeWriter emit(CodeWriter out) throws IOException {
+    String name = marker.isEmpty() ? out.peekType().name : marker;
+    ClassName className = out.resolve(name);
+    Util.checkArgument(className != null, "marker %s unresolved", marker);
+    return emitAnnotations(out).emitAndIndent(out.lookupName(className));
+  }
+}

--- a/src/test/java/com/squareup/javapoet/JavaFileTest.java
+++ b/src/test/java/com/squareup/javapoet/JavaFileTest.java
@@ -212,7 +212,7 @@ public final class JavaFileTest {
         + "class A {\n"
         + "  class B {\n"
         + "    class C {\n"
-        + "      Twin.D d;\n"
+        + "      A.Twin.D d;\n"
         + "\n"
         + "      class Nested {\n"
         + "        class Twin {\n"

--- a/src/test/java/com/squareup/javapoet/TypeSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/TypeSpecTest.java
@@ -617,28 +617,25 @@ public final class TypeSpecTest {
   }
 
   @Test public void nestedClasses() throws Exception {
-    ClassName taco = ClassName.get(tacosPackage, "Combo", "Taco");
-    ClassName topping = ClassName.get(tacosPackage, "Combo", "Taco", "Topping");
-    ClassName chips = ClassName.get(tacosPackage, "Combo", "Chips");
-    ClassName sauce = ClassName.get(tacosPackage, "Combo", "Sauce");
     TypeSpec typeSpec = TypeSpec.classBuilder("Combo")
-        .addField(taco, "taco")
-        .addField(chips, "chips")
-        .addType(TypeSpec.classBuilder(taco.simpleName())
+        .addField(new MarkerName(""), "combo")
+        .addField(new MarkerName("Taco"), "taco")
+        .addField(new MarkerName("Chips"), "chips")
+        .addType(TypeSpec.classBuilder("Taco")
             .addModifiers(Modifier.STATIC)
-            .addField(ParameterizedTypeName.get(ClassName.get(List.class), topping), "toppings")
-            .addField(sauce, "sauce")
-            .addType(TypeSpec.enumBuilder(topping.simpleName())
+            .addField(ParameterizedTypeName.get(ClassName.get(List.class), new MarkerName("Topping")), "toppings")
+            .addField(new MarkerName("Sauce"), "sauce")
+            .addType(TypeSpec.enumBuilder("Topping")
                 .addEnumConstant("SHREDDED_CHEESE")
                 .addEnumConstant("LEAN_GROUND_BEEF")
                 .build())
             .build())
-        .addType(TypeSpec.classBuilder(chips.simpleName())
+        .addType(TypeSpec.classBuilder("Chips")
             .addModifiers(Modifier.STATIC)
-            .addField(topping, "topping")
-            .addField(sauce, "dippingSauce")
+            .addField(new MarkerName("Topping"), "topping")
+            .addField(new MarkerName("Sauce"), "dippingSauce")
             .build())
-        .addType(TypeSpec.enumBuilder(sauce.simpleName())
+        .addType(TypeSpec.enumBuilder("Sauce")
             .addEnumConstant("SOUR_CREAM")
             .addEnumConstant("SALSA")
             .addEnumConstant("QUESO")
@@ -653,6 +650,8 @@ public final class TypeSpecTest {
         + "import java.util.List;\n"
         + "\n"
         + "class Combo {\n"
+        + "  Combo combo;\n"
+        + "\n"
         + "  Taco taco;\n"
         + "\n"
         + "  Chips chips;\n"
@@ -670,7 +669,7 @@ public final class TypeSpecTest {
         + "  }\n"
         + "\n"
         + "  static class Chips {\n"
-        + "    Taco.Topping topping;\n"
+        + "    Topping topping;\n"
         + "\n"
         + "    Sauce dippingSauce;\n"
         + "  }\n"
@@ -830,8 +829,6 @@ public final class TypeSpecTest {
     assertThat(toString(top)).isEqualTo(""
         + "package com.squareup.tacos;\n"
         + "\n"
-        + "import com.squareup.donuts.Bottom;\n"
-        + "\n"
         + "class Top {\n"
         + "  Top internalTop;\n"
         + "\n"
@@ -839,7 +836,7 @@ public final class TypeSpecTest {
         + "\n"
         + "  com.squareup.donuts.Top externalTop;\n"
         + "\n"
-        + "  Bottom externalBottom;\n"
+        + "  com.squareup.donuts.Bottom externalBottom;\n"
         + "\n"
         + "  class Middle {\n"
         + "    Top internalTop;\n"


### PR DESCRIPTION
I followed the `OtherName` idea and propose this PR as a comparsion to #382 Self type.

See sample usage, with an empty marker for _self_ behaviour:
```java
@Test public void nestedClasses() throws Exception {
  TypeSpec typeSpec = TypeSpec.classBuilder("Combo")
      .addField(new MarkerName(""), "combo")
      .addField(new MarkerName("Taco"), "taco")
      .addField(new MarkerName("Chips"), "chips")
      .addType(TypeSpec.classBuilder("Taco")
          .addModifiers(Modifier.STATIC)
          .addField(ParameterizedTypeName.get(ClassName.get(List.class), new MarkerName("Topping")), "toppings")
          .addField(new MarkerName("Sauce"), "sauce")
...
```

 * The class name `MarkerName` is not final ... does `LocalName` smell better?
 * Of course, a `TypeName.SELF` constant can initialized with `new MarkerName("")`.

Had to tweak some exptected rendered class sources, as the new recursive resolve seems to evaluate differently. Find more comments inline.