### PR TITLE
Reformatting headers of Overriden methods in CodeBlock.java

### DIFF
--- a/src/main/java/com/squareup/javapoet/CodeBlock.java
+++ b/src/main/java/com/squareup/javapoet/CodeBlock.java
@@ -69,18 +69,21 @@ public final class CodeBlock {
     return formatParts.isEmpty();
   }
 
-  @Override public boolean equals(Object o) {
+  @Override
+  public boolean equals(Object o) {
     if (this == o) return true;
     if (o == null) return false;
     if (getClass() != o.getClass()) return false;
     return toString().equals(o.toString());
   }
 
-  @Override public int hashCode() {
+  @Override
+  public int hashCode() {
     return toString().hashCode();
   }
 
-  @Override public String toString() {
+  @Override
+  public String toString() {
     StringWriter out = new StringWriter();
     try {
       new CodeWriter(out).emit(this);


### PR DESCRIPTION
In CodeBlock.java, the equals(), hashCode(), and toString() methods had an "@Override" annotation that was located on the same line as their respective method headers. This was slightly confusing, and I changed the annotation location to be above the method headers in order to increase readability and conform to Java code conventions.