### PR TITLE
MemberRef $R implemented.

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,77 @@ class HelloWorld {
 }
 ```
 
+### $R for References
+
+When generating code, you may point to already compiled elements like methods, fields
+and especially the `enum` constant fields. Enter `$R`:
+
+```java
+CodeBlock.builder().add("$R", Thread.State.NEW).build();
+```
+
+That produces the fully-qualified member name:
+
+```java
+java.lang.Thread.State.NEW
+```
+
+A more complex example with ex- and implicit `MemberRef` creations for methods, fields, enum
+constants:
+
+```java
+Method convert = TimeUnit.class.getMethod("convert", long.class, TimeUnit.class);
+
+MethodSpec.Builder method = MethodSpec.methodBuilder("minutesToSeconds")
+  .addModifiers(Modifier.STATIC)
+  .returns(long.class)
+  .addParameter(long.class, "minutes")
+  .addStatement("return $R.$R(minutes, $R)", TimeUnit.SECONDS, convert, TimeUnit.MINUTES);
+
+TypeSpec util = TypeSpec.classBuilder("Util")
+  .addMethod(method)
+  .build();
+
+JavaFile.builder("readme", util).build();
+```
+
+That generates the following `.java` file, complete with the necessary `import`s:
+
+```java
+package readme;
+
+import java.util.concurrent.TimeUnit;
+
+class Util {
+  static long minutesToSeconds(long minutes) {
+    return TimeUnit.SECONDS.convert(minutes, TimeUnit.MINUTES);
+  }
+}
+```
+
+`$R` lets you reference **static** members:
+* enum constants, like e.g. `TimeUnit.MINUTES` above
+* static fields, like `String.CASE_INSENSITIVE_ORDER`
+* static methods, like `Class.forName(String)`
+
+References to **instance** members are also supported. Here, it's up to you providing some object
+as a call target. You can use any literal including `"this"`, `"super"`, `TypeName`s and
+even `MemberRef`erences like can be seen with `TimeUnit.SECONDS` in the example above.
+
+The `MemberRef` API allows optional type arguments as parameters. Those can be used to specify
+the generic return type of a method:
+
+```java
+MemberRef emptyList = MemberRef.get(Collections.class.getMethod("emptyList"), String.class);
+CodeBlock.builder().add("$R()", emptyList).build();
+```
+
+Which yields:
+
+```java
+java.util.Collections.<java.lang.String>emptyList()
+```
+
 ### $N for Names
 
 Generated code is often self-referential. Use **`$N`** to refer to another generated declaration by

--- a/src/main/java/com/squareup/javapoet/CodeWriter.java
+++ b/src/main/java/com/squareup/javapoet/CodeWriter.java
@@ -247,6 +247,12 @@ final class CodeWriter {
 
         case "$R":
           MemberRef memberRef = (MemberRef) codeBlock.args.get(a++);
+          if (memberRef.isStatic) {
+            if (isImportedStatically(memberRef.type.canonicalName, memberRef.name)) {
+              emitAndIndent(memberRef.name);
+              break;
+            }
+          }
           memberRef.emit(this);
           break;
 
@@ -305,14 +311,18 @@ final class CodeWriter {
     return part;
   }
 
+  private boolean isImportedStatically(String canonicalTypeName, String memberName) {
+    String explicit = canonicalTypeName + "." + memberName;
+    String wildcard = canonicalTypeName + ".*";
+    return staticImports.contains(explicit) || staticImports.contains(wildcard);
+  }
+
   private boolean emitStaticImportMember(String canonical, String part) throws IOException {
     String partWithoutLeadingDot = part.substring(1);
     if (partWithoutLeadingDot.isEmpty()) return false;
     char first = partWithoutLeadingDot.charAt(0);
     if (!Character.isJavaIdentifierStart(first)) return false;
-    String explicit = canonical + "." + extractMemberName(partWithoutLeadingDot);
-    String wildcard = canonical + ".*";
-    if (staticImports.contains(explicit) || staticImports.contains(wildcard)) {
+    if (isImportedStatically(canonical, extractMemberName(partWithoutLeadingDot))) {
       emitAndIndent(partWithoutLeadingDot);
       return true;
     }

--- a/src/main/java/com/squareup/javapoet/CodeWriter.java
+++ b/src/main/java/com/squareup/javapoet/CodeWriter.java
@@ -245,6 +245,11 @@ final class CodeWriter {
           typeName.emit(this);
           break;
 
+        case "$R":
+          MemberRef memberRef = (MemberRef) codeBlock.args.get(a++);
+          memberRef.emit(this);
+          break;
+
         case "$$":
           emitAndIndent("$");
           break;

--- a/src/main/java/com/squareup/javapoet/JavaFile.java
+++ b/src/main/java/com/squareup/javapoet/JavaFile.java
@@ -238,6 +238,14 @@ public final class JavaFile {
       return addStaticImport(ClassName.get(clazz), names);
     }
 
+    public Builder addStaticImport(MemberRef... refs) {
+      for (MemberRef ref : refs) {
+        checkArgument(ref.isStatic, "only static member references allowed, got %s", ref);
+        addStaticImport(ref.type, ref.name);
+      }
+      return this;
+    }
+
     public Builder addStaticImport(ClassName className, String... names) {
       checkArgument(className != null, "className == null");
       checkArgument(names != null, "names == null");

--- a/src/main/java/com/squareup/javapoet/MemberRef.java
+++ b/src/main/java/com/squareup/javapoet/MemberRef.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.squareup.javapoet;
+
+import static java.lang.reflect.Modifier.isStatic;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.TypeMirror;
+
+/**
+ * Member reference class.
+ *
+ * Use {@code $R} in format strings to insert member references into your generated code.
+ *
+ * @author Christian Stein
+ */
+public final class MemberRef {
+  /**
+   * Defines all well-known member flavours, like {@code ENUM}, {@code FIELD} and {@code METHOD},
+   * that can be refered to.
+   */
+  public enum Kind {
+    ENUM, FIELD, METHOD
+  }
+
+  /** Simple getter using JavaPoet-model types only. */
+  public static MemberRef get(Kind kind, ClassName type, String name, boolean statik,
+      TypeName... typeArguments) {
+    Util.checkNotNull(kind, "kind == null");
+    Util.checkNotNull(type, "type == null");
+    Util.checkNotNull(name, "name == null");
+    Util.checkNotNull(typeArguments, "typeArguments == null");
+    if (kind != Kind.METHOD) {
+      Util.checkArgument(typeArguments.length == 0, "MemberRef %s mustn't have type args!", kind);
+    }
+    return new MemberRef(kind, type, name, statik, Arrays.asList(typeArguments));
+  }
+
+  public static MemberRef get(Enum<?> constant) {
+    Util.checkNotNull(constant, "constant == null");
+    ClassName type = ClassName.get(constant.getDeclaringClass());
+    String name = constant.name();
+    return get(Kind.ENUM, type, name, true);
+  }
+
+  public static MemberRef get(Field field) {
+    Util.checkNotNull(field, "field == null");
+    ClassName type = ClassName.get(field.getDeclaringClass());
+    String name = field.getName();
+    boolean statik = isStatic(field.getModifiers());
+    return get(Kind.FIELD, type, name, statik);
+  }
+
+  public static MemberRef get(Method method, Type... types) {
+    Util.checkNotNull(method, "method == null");
+    Util.checkNotNull(types, "types == null");
+    ClassName type = ClassName.get(method.getDeclaringClass());
+    String name = method.getName();
+    boolean statik = isStatic(method.getModifiers());
+    return get(Kind.METHOD, type, name, statik, TypeName.list(types).toArray(new TypeName[0]));
+  }
+
+  public static MemberRef get(VariableElement variable) {
+    Util.checkNotNull(variable, "variable == null");
+    ClassName type = ClassName.get((TypeElement) variable.getEnclosingElement());
+    String name = variable.getSimpleName().toString();
+    boolean statik = variable.getModifiers().contains(Modifier.STATIC);
+    if (variable.getKind() == ElementKind.ENUM_CONSTANT) return get(Kind.FIELD, type, name, statik);
+    if (variable.getKind() == ElementKind.FIELD) return get(Kind.FIELD, type, name, statik);
+    throw new IllegalArgumentException("unsupported element kind: " + variable.getKind());
+  }
+
+  public static MemberRef get(ExecutableElement executable, TypeMirror... types) {
+    Util.checkNotNull(executable, "executable == null");
+    Util.checkNotNull(types, "types == null");
+    ClassName type = ClassName.get((TypeElement) executable.getEnclosingElement());
+    String name = executable.getSimpleName().toString();
+    boolean statik = executable.getModifiers().contains(Modifier.STATIC);
+    return get(Kind.METHOD, type, name, statik, TypeName.list(types).toArray(new TypeName[0]));
+  }
+
+  public final Kind kind;
+  public final ClassName type;
+  public final String name;
+  public final boolean isStatic;
+  public final List<TypeName> typeArguments;
+
+  MemberRef(Kind kind, ClassName type, String name, boolean statik) {
+    this(kind, type, name, statik, Collections.<TypeName>emptyList());
+  }
+
+  MemberRef(Kind kind, ClassName type, String name, boolean statik, List<TypeName> typeArguments) {
+    this.kind = kind;
+    this.type = type;
+    this.name = name;
+    this.isStatic = statik;
+    this.typeArguments = Util.immutableList(typeArguments);
+  }
+
+  @Override public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null) return false;
+    if (getClass() != o.getClass()) return false;
+    MemberRef r = (MemberRef) o;
+    if (isStatic != r.isStatic) return false;
+    if (!kind.equals(r.kind)) return false;
+    if (!type.equals(r.type)) return false;
+    if (!typeArguments.equals(r.typeArguments)) return false;
+    return name.equals(r.name);
+  }
+
+  @Override public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + (isStatic ? 1731 : 1233);
+    result = prime * result + kind.hashCode();
+    result = prime * result + name.hashCode();
+    result = prime * result + type.hashCode();
+    result = prime * result + typeArguments.hashCode();
+    return result;
+  }
+
+  @Override public String toString() {
+    return type.canonicalName + "." + name;
+  }
+
+  void emit(CodeWriter codeWriter) throws IOException {
+    if (isStatic) {
+      codeWriter.emit("$T.", type);
+    }
+    if (kind == Kind.METHOD) {
+      emitTypeArguments(codeWriter);
+    }
+    codeWriter.emit("$L", name);
+  }
+
+  void emitTypeArguments(CodeWriter codeWriter) throws IOException {
+    if (typeArguments.isEmpty()) return;
+    codeWriter.emit("<");
+    codeWriter.emit("$T", typeArguments.get(0));
+    for (int index = 1; index < typeArguments.size(); index++) {
+      codeWriter.emit(", $T", typeArguments.get(index));
+    }
+    codeWriter.emit(">");
+  }
+}

--- a/src/main/java/com/squareup/javapoet/TypeName.java
+++ b/src/main/java/com/squareup/javapoet/TypeName.java
@@ -308,6 +308,15 @@ public class TypeName {
     return result;
   }
 
+  /** Converts an array of type mirrors to a list of type names. */
+  static List<TypeName> list(TypeMirror[] types) {
+    List<TypeName> result = new ArrayList<>(types.length);
+    for (TypeMirror type : types) {
+      result.add(get(type));
+    }
+    return result;
+  }
+
   /** Returns the array component of {@code type}, or null if {@code type} is not an array. */
   static TypeName arrayComponent(TypeName type) {
     return type instanceof ArrayTypeName

--- a/src/test/java/com/squareup/javapoet/AnnotationSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/AnnotationSpecTest.java
@@ -202,15 +202,15 @@ public final class AnnotationSpecTest {
 
   @Test public void dynamicArrayOfEnumConstants() {
     AnnotationSpec.Builder builder = AnnotationSpec.builder(HasDefaultsAnnotation.class);
-    builder.addMember("n", "$T.$L", Breakfast.class, Breakfast.PANCAKES.name());
+    builder.addMember("n", "$R", Breakfast.PANCAKES);
     assertThat(builder.build().toString()).isEqualTo(
         "@com.squareup.javapoet.AnnotationSpecTest.HasDefaultsAnnotation("
             + "n = com.squareup.javapoet.AnnotationSpecTest.Breakfast.PANCAKES"
             + ")");
 
     // builder = AnnotationSpec.builder(HasDefaultsAnnotation.class);
-    builder.addMember("n", "$T.$L", Breakfast.class, Breakfast.WAFFLES.name());
-    builder.addMember("n", "$T.$L", Breakfast.class, Breakfast.PANCAKES.name());
+    builder.addMember("n", "$R", Breakfast.WAFFLES);
+    builder.addMember("n", "$R", Breakfast.PANCAKES);
     assertThat(builder.build().toString()).isEqualTo(
         "@com.squareup.javapoet.AnnotationSpecTest.HasDefaultsAnnotation("
             + "n = {"
@@ -228,7 +228,7 @@ public final class AnnotationSpecTest {
             + ", com.squareup.javapoet.AnnotationSpecTest.Breakfast.PANCAKES"
             + "})");
 
-    builder.addMember("n", "$T.$L", Breakfast.class, Breakfast.WAFFLES.name());
+    builder.addMember("n", "$R", Breakfast.WAFFLES);
     assertThat(builder.build().toString()).isEqualTo(
         "@com.squareup.javapoet.AnnotationSpecTest.HasDefaultsAnnotation("
             + "n = {"

--- a/src/test/java/com/squareup/javapoet/MemberRefTest.java
+++ b/src/test/java/com/squareup/javapoet/MemberRefTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.javapoet;
+
+import static com.google.common.truth.Truth.assertThat;
+import static java.lang.Thread.State.NEW;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.TimeUnit;
+import javax.lang.model.element.Modifier;
+import org.junit.Test;
+import com.squareup.javapoet.MemberRef.Kind;
+
+public class MemberRefTest {
+  @Test public void readmeExampleWithThreadStateNew() {
+    CodeBlock block = CodeBlock.builder().add("$R", NEW).build();
+    assertThat(block.toString()).isEqualTo("java.lang.Thread.State.NEW");
+  }
+
+  @Test public void readmeExampleWithTimeUnitConvert() throws Exception {
+    Method convert = TimeUnit.class.getMethod("convert", long.class, TimeUnit.class);
+    MethodSpec.Builder method = MethodSpec.methodBuilder("minutesToSeconds")
+        .returns(long.class)
+        .addParameter(long.class, "minutes")
+        .addStatement("$R()", System.class.getMethod("gc"))
+        .addStatement("return $R.$R(minutes, $R)", TimeUnit.SECONDS, convert, TimeUnit.MINUTES);
+    String unit = "java.util.concurrent.TimeUnit";
+    assertThat(method.build().toString()).isEqualTo(""
+        + "long minutesToSeconds(long minutes) {\n"
+        + "  java.lang.System.gc();\n"
+        + "  return " + unit + ".SECONDS.convert(minutes, " + unit + ".MINUTES);\n"
+        + "}\n");
+  }
+
+  @Test public void readmeExampleWithMethodChaining() throws Exception {
+    Method builder = CodeBlock.class.getMethod("builder");
+    Method add = CodeBlock.Builder.class.getMethod("add", String.class, Object[].class);
+    Method build = CodeBlock.Builder.class.getMethod("build");
+    CodeBlock block = CodeBlock.builder()
+        .add("$R().$R(\"$$R\", $R).$R()", builder, add, NEW, build)
+        .build();
+    assertThat(block.toString()).isEqualTo(""
+        + "com.squareup.javapoet.CodeBlock.builder()"
+        + ".add(\"$R\", java.lang.Thread.State.NEW)"
+        + ".build()");
+  }
+
+  @Test public void equals() throws Exception {
+    MemberRef expected = MemberRef.get(NEW);
+    assertThat(expected.kind).isEqualTo(Kind.ENUM);
+    String name = "NEW";
+    assertThat(expected).isEqualTo(MemberRef.get(NEW));
+    assertThat(expected).isEqualTo(MemberRef.get(
+        Kind.ENUM,
+        ClassName.get(Thread.State.class),
+        name,
+        true));
+    name = "serialVersionUID";
+    expected = MemberRef.get(String.class.getDeclaredField(name));
+    assertThat(expected.kind).isEqualTo(Kind.FIELD);
+    assertThat(expected).isEqualTo(MemberRef.get(String.class.getDeclaredField(name)));
+    assertThat(expected).isEqualTo(MemberRef.get(
+        Kind.FIELD,
+        ClassName.get(String.class),
+        name,
+        true));
+    name = "valueOf";
+    expected = MemberRef.get(String.class.getMethod(name, int.class));
+    assertThat(expected.kind).isEqualTo(Kind.METHOD);
+    assertThat(expected).isEqualTo(MemberRef.get(String.class.getMethod(name, int.class)));
+    assertThat(expected).isEqualTo(MemberRef.get(
+        Kind.METHOD,
+        ClassName.get(String.class),
+        name,
+        true));
+  }
+
+  @Test public void importStaticNone() throws Exception {
+    assertThat(JavaFile.builder("readme", typeSpec("Util"))
+        .build().toString()).isEqualTo(""
+        + "package readme;\n"
+        + "\n"
+        + "import java.lang.System;\n"
+        + "import java.util.concurrent.TimeUnit;\n"
+        + "\n"
+        + "class Util {\n"
+        + "  public static long minutesToSeconds(long minutes) {\n"
+        + "    System.gc();\n"
+        + "    return TimeUnit.SECONDS.convert(minutes, TimeUnit.MINUTES);\n"
+        + "  }\n"
+        + "}\n");
+  }
+
+  TypeSpec typeSpec(String name) {
+    try {
+      Method convert = TimeUnit.class.getMethod("convert", long.class, TimeUnit.class);
+      MethodSpec method = MethodSpec.methodBuilder("minutesToSeconds")
+          .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+          .returns(long.class)
+          .addParameter(long.class, "minutes")
+          .addStatement("$R()", System.class.getMethod("gc"))
+          .addStatement("return $R.$R(minutes, $R)", TimeUnit.SECONDS, convert, TimeUnit.MINUTES)
+          .build();
+      return TypeSpec.classBuilder(name).addMethod(method).build();
+    } catch (Exception e) {
+      throw new RuntimeException("should not happen!");
+    }
+  }
+}

--- a/src/test/java/com/squareup/javapoet/MemberRefTest.java
+++ b/src/test/java/com/squareup/javapoet/MemberRefTest.java
@@ -104,6 +104,25 @@ public class MemberRefTest {
         + "}\n");
   }
 
+  @Test public void importStaticAll() throws Exception {
+    assertThat(JavaFile.builder("readme", typeSpec("Util"))
+        .addStaticImport(MemberRef.get(TimeUnit.SECONDS), MemberRef.get(TimeUnit.MINUTES))
+        .addStaticImport(MemberRef.get(System.class.getMethod("gc")))
+        .build().toString()).isEqualTo(""
+        + "package readme;\n"
+        + "\n"
+        + "import static java.lang.System.gc;\n"
+        + "import static java.util.concurrent.TimeUnit.MINUTES;\n"
+        + "import static java.util.concurrent.TimeUnit.SECONDS;\n"
+        + "\n"
+        + "class Util {\n"
+        + "  public static long minutesToSeconds(long minutes) {\n"
+        + "    gc();\n"
+        + "    return SECONDS.convert(minutes, MINUTES);\n"
+        + "  }\n"
+        + "}\n");
+  }
+
   TypeSpec typeSpec(String name) {
     try {
       Method convert = TimeUnit.class.getMethod("convert", long.class, TimeUnit.class);

--- a/src/test/java/com/squareup/javapoet/TypeSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/TypeSpecTest.java
@@ -29,12 +29,15 @@ import java.util.EventListener;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Random;
 
 import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.ElementFilter;
 
 import org.junit.Assert;
 import org.junit.Rule;
@@ -44,6 +47,7 @@ import org.junit.runners.JUnit4;
 import org.mockito.Mockito;
 
 import static com.google.common.truth.Truth.assertThat;
+import static java.lang.Thread.State.NEW;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 
@@ -56,6 +60,19 @@ public final class TypeSpecTest {
 
   private TypeElement getElement(Class<?> clazz) {
     return compilation.getElements().getTypeElement(clazz.getCanonicalName());
+  }
+
+  private ExecutableElement findMethod(Class<?> clazz, String name, Class<?>... parameterTypes) {
+    List<? extends Element> elements = getElement(clazz).getEnclosedElements();
+    for (ExecutableElement method : ElementFilter.methodsIn(elements)) {
+      if (method.getSimpleName().toString().equals(name)) {
+        if (method.getParameters().isEmpty() && parameterTypes.length == 0) {
+          return method;
+        }
+        throw new UnsupportedOperationException("possibly not unique: " + method);
+      }
+    }
+    throw new NoSuchElementException("Method named " + name + " not found in " + clazz);
   }
 
   private boolean isJava8() {
@@ -1977,6 +1994,39 @@ public final class TypeSpecTest {
             + "    return FOO;\n"
             + "  }\n"
             + "}\n");
+  }
+
+  @Test public void refToEnumConstant() {
+    assertThat(codeBlock("$R", NEW).toString()).isEqualTo("java.lang.Thread.State.NEW");
+    MemberRef ref = MemberRef.get(NEW);
+    assertThat(codeBlock("$R", ref).toString()).isEqualTo("java.lang.Thread.State.NEW");
+    ref = MemberRef.get(ElementFilter.fieldsIn(getElement(Thread.State.class)
+        .getEnclosedElements()).get(0));
+    assertThat(codeBlock("$R", ref).toString()).isEqualTo("java.lang.Thread.State.NEW");
+  }
+
+  // non-static and protected for testing MemberRef
+  protected <T> List<T> refReturningGenericList() {
+    return Collections.emptyList();
+  }
+
+  @Test
+  public void refToMember() throws Exception {
+    MemberRef ref = MemberRef.get(Collections.class.getMethod("emptyList"));
+    String expected = "java.util.Collections.emptyList";
+    assertThat(codeBlock("$R", ref).toString()).isEqualTo(expected);
+    ref = MemberRef.get(Collections.class.getMethod("emptyList"), String.class);
+    expected = "java.util.Collections.<java.lang.String>emptyList";
+    assertThat(codeBlock("$R", ref).toString()).isEqualTo(expected);
+    ExecutableElement executableElement = findMethod(Collections.class, "emptyList");
+    ref = MemberRef.get(executableElement, getElement(String.class).asType());
+    assertThat(codeBlock("$R", ref).toString()).isEqualTo(expected);
+    executableElement = findMethod(TypeSpecTest.class, "refReturningGenericList");
+    expected = "this.<java.lang.String>refReturningGenericList";
+    ref = MemberRef.get(executableElement, getElement(String.class).asType());
+    assertThat(codeBlock("this.$R", ref).toString()).isEqualTo(expected);
+    ref = MemberRef.get(TypeSpecTest.class.getField("compilation"));
+    assertThat(codeBlock("this.$R", ref).toString()).isEqualTo("this.compilation");
   }
 
   @Test public void equalsAndHashCode() {


### PR DESCRIPTION
Solves #317 similar to #350 - but focusses on the `$R` part, only. That means:

* ~~no static import support~~ already base feature of JavaPoet 1.5.0
* using `boolean isStatic` flag instead of `Set<Modifiers>`
* no more internal subclassing of `MemberRef`