### PR TITLE
Upgrade Maven Checkstyle Plugin to 2.17 using Checkstyle 6.11.2

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -99,7 +99,7 @@
     <module name="InnerAssignment"/>
     <!--<module name="MagicNumber"/>-->
     <module name="MissingSwitchDefault"/>
-    <module name="RedundantThrows"/>
+    <!--module name="RedundantThrows"/-->
     <module name="SimplifyBooleanExpression"/>
     <module name="SimplifyBooleanReturn"/>
 

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>2.13</version>
+        <version>2.17</version>
         <configuration>
           <failsOnError>true</failsOnError>
           <configLocation>checkstyle.xml</configLocation>

--- a/src/main/java/com/squareup/javapoet/CodeWriter.java
+++ b/src/main/java/com/squareup/javapoet/CodeWriter.java
@@ -66,11 +66,11 @@ final class CodeWriter {
     this(out, "  ");
   }
 
-  public CodeWriter(Appendable out, String indent) {
+  CodeWriter(Appendable out, String indent) {
     this(out, indent, Collections.<String, ClassName>emptyMap());
   }
 
-  public CodeWriter(Appendable out, String indent, Map<String, ClassName> importedTypes) {
+  CodeWriter(Appendable out, String indent, Map<String, ClassName> importedTypes) {
     this.out = checkNotNull(out, "out == null");
     this.indent = checkNotNull(indent, "indent == null");
     this.importedTypes = checkNotNull(importedTypes, "importedTypes == null");

--- a/src/main/java/com/squareup/javapoet/TypeSpec.java
+++ b/src/main/java/com/squareup/javapoet/TypeSpec.java
@@ -321,7 +321,7 @@ public final class TypeSpec {
     private final Set<Modifier> implicitTypeModifiers;
     private final Set<Modifier> asMemberModifiers;
 
-    private Kind(Set<Modifier> implicitFieldModifiers,
+    Kind(Set<Modifier> implicitFieldModifiers,
         Set<Modifier> implicitMethodModifiers,
         Set<Modifier> implicitTypeModifiers,
         Set<Modifier> asMemberModifiers) {


### PR DESCRIPTION
 * Removed redundant modifiers in CodeWriter and TypeSpec
 * Module RedundantThrows commented out - it was removed from CS
 * Java 8 method reference syntax parsing fixed