### PR TITLE
Escape special char values.

### DIFF
--- a/src/main/java/com/squareup/javapoet/AnnotationSpec.java
+++ b/src/main/java/com/squareup/javapoet/AnnotationSpec.java
@@ -235,7 +235,11 @@ public final class AnnotationSpec {
         return addMember(memberName, "$Lf", value);
       }
       if (value instanceof Character) {
-        return addMember(memberName, "'$L'", value);
+        String literal = CodeWriter.stringLiteral(value.toString(), "");
+        literal = literal.substring(1, literal.length() - 1);
+        if (literal.equals("\\\"")) literal = "\"";
+        if (literal.equals("'")) literal = "\\'";
+        return addMember(memberName, "'$L'", literal);
       }
       return addMember(memberName, "$L", value);
     }

--- a/src/main/java/com/squareup/javapoet/CodeWriter.java
+++ b/src/main/java/com/squareup/javapoet/CodeWriter.java
@@ -419,6 +419,10 @@ final class CodeWriter {
 
   /** Returns the string literal representing {@code data}, including wrapping quotes. */
   String stringLiteral(String value) {
+    return stringLiteral(value, indent);
+  }
+
+  static String stringLiteral(String value, String indent) {
     StringBuilder result = new StringBuilder();
     result.append('"');
     for (int i = 0; i < value.length(); i++) {

--- a/src/test/java/com/squareup/javapoet/AnnotationSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/AnnotationSpecTest.java
@@ -62,7 +62,7 @@ public final class AnnotationSpecTest {
 
     double f() default 10.0;
 
-    char g() default 'k';
+    char[] g() default {0, 0xCAFE, 'z', '€', '"', '\'', '\t', '\n'};
 
     boolean h() default true;
 
@@ -313,7 +313,16 @@ public final class AnnotationSpecTest {
         + "    d = 8,\n"
         + "    e = 9.0f,\n"
         + "    f = 11.1,\n"
-        + "    g = 'k',\n"
+        + "    g = {\n"
+        + "        '\\u0000',\n"
+        + "        '쫾',\n"
+        + "        'z',\n"
+        + "        '€',\n"
+        + "        '\"',\n"
+        + "        '\\'',\n"
+        + "        '\\t',\n"
+        + "        '\\n'\n"
+        + "    },\n"
         + "    h = true,\n"
         + "    i = AnnotationSpecTest.Breakfast.WAFFLES,\n"
         + "    j = @AnnotationSpecTest.AnnotationA,\n"


### PR DESCRIPTION
Fixes #395 if the value is a single ``'`` character.