### PR TITLE
Static import corner case tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 Change Log
 ==========
 
+JavaPoet 1.5.0-SNAPSHOT *(not yet released)*
+----------------------------
+
+ * New: `import static`! See `JavaFile.Builder.addStaticImport()` variants.
+ * New: Overload `NameAllocator.newName(String)` for creating a one-off name without a tag.
+ * Fix: AnnotationSpec escapes character literals properly.
+ * Fix: Don't stack overflow when `TypeVariableName` is part of `ParameterizedTypeName`.
+ * Fix: Reporting not used indexed arguments in like `add("$1S", "a", "b")`.
+ * Fix: Prevent import of types located in the default package, i.e. have no package name.
+
+
 JavaPoet 1.4.0 *(2015-11-13)*
 ----------------------------
 

--- a/src/main/java/com/squareup/javapoet/CodeWriter.java
+++ b/src/main/java/com/squareup/javapoet/CodeWriter.java
@@ -290,7 +290,8 @@ final class CodeWriter {
     return this;
   }
 
-  private static String gleanMemberName(String part) {
+  private static String extractMemberName(String part) {
+    checkArgument(Character.isJavaIdentifierStart(part.charAt(0)), "not an identifier: %s", part);
     for (int i = 1; i <= part.length(); i++) {
       if (!SourceVersion.isIdentifier(part.substring(0, i))) {
         return part.substring(0, i - 1);
@@ -301,14 +302,14 @@ final class CodeWriter {
 
   private boolean emitStaticImportMember(String canonical, String part) throws IOException {
     String partWithoutLeadingDot = part.substring(1);
+    if (partWithoutLeadingDot.isEmpty()) return false;
     char first = partWithoutLeadingDot.charAt(0);
-    if (!partWithoutLeadingDot.isEmpty() && Character.isJavaIdentifierStart(first)) {
-      String explicit = canonical + "." + gleanMemberName(partWithoutLeadingDot);
-      String wildcard = canonical + ".*";
-      if (staticImports.contains(explicit) || staticImports.contains(wildcard)) {
-        emitAndIndent(partWithoutLeadingDot);
-        return true;
-      }
+    if (!Character.isJavaIdentifierStart(first)) return false;
+    String explicit = canonical + "." + extractMemberName(partWithoutLeadingDot);
+    String wildcard = canonical + ".*";
+    if (staticImports.contains(explicit) || staticImports.contains(wildcard)) {
+      emitAndIndent(partWithoutLeadingDot);
+      return true;
     }
     return false;
   }


### PR DESCRIPTION
@swankjesse wrote in #398 
> I suspect there’s a few unlikely corner cases, such as when the last format part is a $T, but this is certainly better than what we have now. I might take a pass at this code to get rid of the nasty word glean and to try to tighten up those exotic & unlikely cases.

* Is `extractMemberName` better?
* Fix and test for the "one character member name" like `$T.X` is included.
* More exotic cases are tested. Which are missing?
* Does [wire](https://github.com/square/wire) work with current SNAPSHOT of JavaPoet?

>  I’m also tempted to try to make this work with $L, so you don’t need to statically know what you’re statically importing!

Sounds like a brave plan. You mean like having `$T.$L` resolve to `.addStaticImport($T, $L)` ? Same with `$T.$N`?