### PR TITLE
TypeName.equals() and .hashCode() now respect attached annotations.

### DIFF
--- a/src/main/java/com/squareup/javapoet/ArrayTypeName.java
+++ b/src/main/java/com/squareup/javapoet/ArrayTypeName.java
@@ -44,15 +44,6 @@ public final class ArrayTypeName extends TypeName {
     return new ArrayTypeName(componentType, annotations);
   }
 
-  @Override public boolean equals(Object o) {
-    return o instanceof ArrayTypeName
-        && ((ArrayTypeName) o).componentType.equals(componentType);
-  }
-
-  @Override public int hashCode() {
-    return 31 * componentType.hashCode();
-  }
-
   @Override CodeWriter emit(CodeWriter out) throws IOException {
     return emitAnnotations(out).emit("$T[]", componentType);
   }

--- a/src/main/java/com/squareup/javapoet/ClassName.java
+++ b/src/main/java/com/squareup/javapoet/ClassName.java
@@ -198,15 +198,6 @@ public final class ClassName extends TypeName implements Comparable<ClassName> {
     return (PackageElement) type;
   }
 
-  @Override public boolean equals(Object o) {
-    return o instanceof ClassName
-        && canonicalName.equals(((ClassName) o).canonicalName);
-  }
-
-  @Override public int hashCode() {
-    return canonicalName.hashCode();
-  }
-
   @Override public int compareTo(ClassName o) {
     return canonicalName.compareTo(o.canonicalName);
   }

--- a/src/main/java/com/squareup/javapoet/ParameterizedTypeName.java
+++ b/src/main/java/com/squareup/javapoet/ParameterizedTypeName.java
@@ -30,7 +30,6 @@ import static com.squareup.javapoet.Util.checkNotNull;
 public final class ParameterizedTypeName extends TypeName {
   public final ClassName rawType;
   public final List<TypeName> typeArguments;
-  private final int hashCode;
 
   ParameterizedTypeName(ClassName rawType, List<TypeName> typeArguments) {
     this(rawType, typeArguments, new ArrayList<AnnotationSpec>());
@@ -41,7 +40,6 @@ public final class ParameterizedTypeName extends TypeName {
     super(annotations);
     this.rawType = checkNotNull(rawType, "rawType == null");
     this.typeArguments = Util.immutableList(typeArguments);
-    this.hashCode = rawType.hashCode() + 31 * typeArguments.hashCode();
 
     checkArgument(!this.typeArguments.isEmpty(), "no type arguments: %s", rawType);
     for (TypeName typeArgument : this.typeArguments) {
@@ -52,16 +50,6 @@ public final class ParameterizedTypeName extends TypeName {
 
   @Override public ParameterizedTypeName annotated(List<AnnotationSpec> annotations) {
     return new ParameterizedTypeName(rawType, typeArguments, annotations);
-  }
-
-  @Override public boolean equals(Object o) {
-    return o instanceof ParameterizedTypeName
-        && ((ParameterizedTypeName) o).rawType.equals(rawType)
-        && ((ParameterizedTypeName) o).typeArguments.equals(typeArguments);
-  }
-
-  @Override public int hashCode() {
-    return hashCode;
   }
 
   @Override CodeWriter emit(CodeWriter out) throws IOException {

--- a/src/main/java/com/squareup/javapoet/TypeName.java
+++ b/src/main/java/com/squareup/javapoet/TypeName.java
@@ -159,16 +159,15 @@ public class TypeName {
     throw new UnsupportedOperationException("cannot unbox " + this);
   }
 
-  @Override public boolean equals(Object o) {
+  @Override public final boolean equals(Object o) {
     if (this == o) return true;
     if (o == null) return false;
     if (getClass() != o.getClass()) return false;
-    return keyword.equals(((TypeName) o).keyword);
+    return toString().equals(o.toString());
   }
 
-  @Override public int hashCode() {
-    if (keyword == null) throw new AssertionError();
-    return keyword.hashCode();
+  @Override public final int hashCode() {
+    return toString().hashCode();
   }
 
   @Override public final String toString() {

--- a/src/main/java/com/squareup/javapoet/TypeVariableName.java
+++ b/src/main/java/com/squareup/javapoet/TypeVariableName.java
@@ -34,7 +34,6 @@ import static com.squareup.javapoet.Util.checkNotNull;
 public final class TypeVariableName extends TypeName {
   public final String name;
   public final List<TypeName> bounds;
-  private final int hashCode;
 
   private TypeVariableName(String name, List<TypeName> bounds) {
     this(name, bounds, new ArrayList<AnnotationSpec>());
@@ -44,7 +43,6 @@ public final class TypeVariableName extends TypeName {
     super(annotations);
     this.name = checkNotNull(name, "name == null");
     this.bounds = bounds;
-    this.hashCode = name.hashCode() ^ bounds.hashCode();
 
     for (TypeName bound : this.bounds) {
       checkArgument(!bound.isPrimitive() && bound != VOID, "invalid bound: %s", bound);
@@ -60,16 +58,6 @@ public final class TypeVariableName extends TypeName {
     List<TypeName> boundsNoObject = new ArrayList<>(bounds);
     boundsNoObject.remove(OBJECT);
     return new TypeVariableName(name, Collections.unmodifiableList(boundsNoObject));
-  }
-
-  @Override public boolean equals(Object o) {
-    return o instanceof TypeVariableName
-        && ((TypeVariableName) o).name.equals(name)
-        && ((TypeVariableName) o).bounds.equals(bounds);
-  }
-
-  @Override public int hashCode() {
-    return hashCode;
   }
 
   @Override CodeWriter emit(CodeWriter out) throws IOException {

--- a/src/main/java/com/squareup/javapoet/WildcardTypeName.java
+++ b/src/main/java/com/squareup/javapoet/WildcardTypeName.java
@@ -32,7 +32,6 @@ import static com.squareup.javapoet.Util.checkArgument;
 public final class WildcardTypeName extends TypeName {
   public final List<TypeName> upperBounds;
   public final List<TypeName> lowerBounds;
-  private final int hashCode;
 
   private WildcardTypeName(List<TypeName> upperBounds, List<TypeName> lowerBounds) {
     this(upperBounds, lowerBounds, new ArrayList<AnnotationSpec>());
@@ -43,7 +42,6 @@ public final class WildcardTypeName extends TypeName {
     super(annotations);
     this.upperBounds = Util.immutableList(upperBounds);
     this.lowerBounds = Util.immutableList(lowerBounds);
-    this.hashCode = upperBounds.hashCode() ^ lowerBounds.hashCode();
 
     checkArgument(this.upperBounds.size() == 1, "unexpected extends bounds: %s", upperBounds);
     for (TypeName upperBound : this.upperBounds) {
@@ -58,16 +56,6 @@ public final class WildcardTypeName extends TypeName {
 
   @Override public WildcardTypeName annotated(List<AnnotationSpec> annotations) {
     return new WildcardTypeName(upperBounds, lowerBounds, annotations);
-  }
-
-  @Override public boolean equals(Object o) {
-    return o instanceof WildcardTypeName
-        && ((WildcardTypeName) o).upperBounds.equals(upperBounds)
-        && ((WildcardTypeName) o).lowerBounds.equals(lowerBounds);
-  }
-
-  @Override public int hashCode() {
-    return hashCode;
   }
 
   @Override CodeWriter emit(CodeWriter out) throws IOException {

--- a/src/test/java/com/squareup/javapoet/AnnotatedTypeNameTest.java
+++ b/src/test/java/com/squareup/javapoet/AnnotatedTypeNameTest.java
@@ -17,6 +17,7 @@ package com.squareup.javapoet;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.util.List;
@@ -25,6 +26,7 @@ import org.junit.Test;
 public class AnnotatedTypeNameTest {
 
   private final static String NN = NeverNull.class.getCanonicalName();
+  private final AnnotationSpec NEVER_NULL = AnnotationSpec.builder(NeverNull.class).build();
 
   public @interface NeverNull {}
 
@@ -40,7 +42,7 @@ public class AnnotatedTypeNameTest {
     TypeName simpleString = TypeName.get(String.class);
     assertFalse(simpleString.isAnnotated());
     assertEquals(simpleString, TypeName.get(String.class));
-    TypeName annotated = simpleString.annotated(AnnotationSpec.builder(NeverNull.class).build());
+    TypeName annotated = simpleString.annotated(NEVER_NULL);
     assertTrue(annotated.isAnnotated());
     assertEquals(simpleString, annotated.annotated());
     assertFalse(annotated.annotated().isAnnotated());
@@ -48,24 +50,21 @@ public class AnnotatedTypeNameTest {
 
   @Test public void annotatedType() {
     String expected = "@" + NN + " java.lang.String";
-    AnnotationSpec annotation = AnnotationSpec.builder(NeverNull.class).build();
     TypeName type = TypeName.get(String.class);
-    String actual = type.annotated(annotation).toString();
+    String actual = type.annotated(NEVER_NULL).toString();
     assertEquals(expected, actual);
   }
 
   @Test public void annotatedParameterizedType() {
     String expected = "@" + NN + " java.util.List<java.lang.String>";
-    AnnotationSpec annotation = AnnotationSpec.builder(NeverNull.class).build();
     TypeName type = ParameterizedTypeName.get(List.class, String.class);
-    String actual = type.annotated(annotation).toString();
+    String actual = type.annotated(NEVER_NULL).toString();
     assertEquals(expected, actual);
   }
 
   @Test public void annotatedArgumentOfParameterizedType() {
     String expected = "java.util.List<@" + NN + " java.lang.String>";
-    AnnotationSpec annotation = AnnotationSpec.builder(NeverNull.class).build();
-    TypeName type = TypeName.get(String.class).annotated(annotation);
+    TypeName type = TypeName.get(String.class).annotated(NEVER_NULL);
     ClassName list = ClassName.get(List.class);
     String actual = ParameterizedTypeName.get(list, type).toString();
     assertEquals(expected, actual);
@@ -73,18 +72,34 @@ public class AnnotatedTypeNameTest {
 
   @Test public void annotatedWildcardTypeNameWithSuper() {
     String expected = "? super @" + NN + " java.lang.String";
-    AnnotationSpec annotation = AnnotationSpec.builder(NeverNull.class).build();
-    TypeName type = TypeName.get(String.class).annotated(annotation);
+    TypeName type = TypeName.get(String.class).annotated(NEVER_NULL);
     String actual = WildcardTypeName.supertypeOf(type).toString();
     assertEquals(expected, actual);
   }
 
   @Test public void annotatedWildcardTypeNameWithExtends() {
     String expected = "? extends @" + NN + " java.lang.String";
-    AnnotationSpec annotation = AnnotationSpec.builder(NeverNull.class).build();
-    TypeName type = TypeName.get(String.class).annotated(annotation);
+    TypeName type = TypeName.get(String.class).annotated(NEVER_NULL);
     String actual = WildcardTypeName.subtypeOf(type).toString();
     assertEquals(expected, actual);
   }
 
+  @Test public void annotatedEquivalence() {
+    annotatedEquivalence(TypeName.VOID);
+    annotatedEquivalence(ArrayTypeName.get(Object[].class));
+    annotatedEquivalence(ClassName.get(Object.class));
+    annotatedEquivalence(ParameterizedTypeName.get(List.class, Object.class));
+    annotatedEquivalence(TypeVariableName.get(Object.class));
+    annotatedEquivalence(WildcardTypeName.get(Object.class));
+  }
+
+  private void annotatedEquivalence(TypeName type) {
+    assertFalse(type.isAnnotated());
+    assertEquals(type, type);
+    assertEquals(type.annotated(NEVER_NULL), type.annotated(NEVER_NULL));
+    assertNotEquals(type, type.annotated(NEVER_NULL));
+    assertEquals(type.hashCode(), type.hashCode());
+    assertEquals(type.annotated(NEVER_NULL).hashCode(), type.annotated(NEVER_NULL).hashCode());
+    assertNotEquals(type.hashCode(), type.annotated(NEVER_NULL).hashCode());
+  }
 }


### PR DESCRIPTION
Made TypeName.equals() and TypeName.hashCode() final and respect attached annotations by using toString() representation. Removed all overridings in derived classes.

Fixes #400