### PR TITLE
Literal conversion clean up.

### DIFF
--- a/src/main/java/com/squareup/javapoet/CodeWriter.java
+++ b/src/main/java/com/squareup/javapoet/CodeWriter.java
@@ -19,7 +19,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
-import java.util.Formatter;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -35,6 +34,7 @@ import static com.squareup.javapoet.Util.checkArgument;
 import static com.squareup.javapoet.Util.checkNotNull;
 import static com.squareup.javapoet.Util.checkState;
 import static com.squareup.javapoet.Util.join;
+import static com.squareup.javapoet.Util.stringLiteralWithDoubleQuotes;
 
 /**
  * Converts a {@link JavaFile} to a string suitable to both human- and javac-consumption. This
@@ -225,7 +225,7 @@ final class CodeWriter {
           String string = (String) codeBlock.args.get(a++);
           // Emit null as a literal null: no quotes.
           emitAndIndent(string != null
-              ? stringLiteral(string)
+              ? stringLiteralWithDoubleQuotes(string, indent)
               : "null");
           break;
 
@@ -475,52 +475,5 @@ final class CodeWriter {
     Map<String, ClassName> result = new LinkedHashMap<>(importableTypes);
     result.keySet().removeAll(referencedNames);
     return result;
-  }
-
-  /** Returns the string literal representing {@code data}, including wrapping quotes. */
-  String stringLiteral(String value) {
-    return stringLiteral(value, indent);
-  }
-
-  static String stringLiteral(String value, String indent) {
-    StringBuilder result = new StringBuilder();
-    result.append('"');
-    for (int i = 0; i < value.length(); i++) {
-      char c = value.charAt(i);
-      switch (c) {
-        case '"':
-          result.append("\\\"");
-          break;
-        case '\\':
-          result.append("\\\\");
-          break;
-        case '\b':
-          result.append("\\b");
-          break;
-        case '\t':
-          result.append("\\t");
-          break;
-        case '\n':
-          result.append("\\n");
-          if (i + 1 < value.length()) {
-            result.append("\"\n").append(indent).append(indent).append("+ \"");
-          }
-          break;
-        case '\f':
-          result.append("\\f");
-          break;
-        case '\r':
-          result.append("\\r");
-          break;
-        default:
-          if (Character.isISOControl(c)) {
-            new Formatter(result).format("\\u%04x", (int) c);
-          } else {
-            result.append(c);
-          }
-      }
-    }
-    result.append('"');
-    return result.toString();
   }
 }

--- a/src/test/java/com/squareup/javapoet/AnnotationSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/AnnotationSpecTest.java
@@ -62,7 +62,7 @@ public final class AnnotationSpecTest {
 
     double f() default 10.0;
 
-    char[] g() default {0, 0xCAFE, 'z', '€', '"', '\'', '\t', '\n'};
+    char[] g() default {0, 0xCAFE, 'z', '€', 'ℕ', '"', '\'', '\t', '\n'};
 
     boolean h() default true;
 
@@ -318,6 +318,7 @@ public final class AnnotationSpecTest {
         + "        '쫾',\n"
         + "        'z',\n"
         + "        '€',\n"
+        + "        'ℕ',\n"
         + "        '\"',\n"
         + "        '\\'',\n"
         + "        '\\t',\n"

--- a/src/test/java/com/squareup/javapoet/UtilTest.java
+++ b/src/test/java/com/squareup/javapoet/UtilTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.javapoet;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class UtilTest {
+  @Test public void characterLiteral() {
+    assertEquals("a", Util.characterLiteralWithoutSingleQuotes('a'));
+    assertEquals("b", Util.characterLiteralWithoutSingleQuotes('b'));
+    assertEquals("c", Util.characterLiteralWithoutSingleQuotes('c'));
+    assertEquals("%", Util.characterLiteralWithoutSingleQuotes('%'));
+    // common escapes
+    assertEquals("\\b", Util.characterLiteralWithoutSingleQuotes('\b'));
+    assertEquals("\\t", Util.characterLiteralWithoutSingleQuotes('\t'));
+    assertEquals("\\n", Util.characterLiteralWithoutSingleQuotes('\n'));
+    assertEquals("\\f", Util.characterLiteralWithoutSingleQuotes('\f'));
+    assertEquals("\\r", Util.characterLiteralWithoutSingleQuotes('\r'));
+    assertEquals("\"", Util.characterLiteralWithoutSingleQuotes('"'));
+    assertEquals("\\'", Util.characterLiteralWithoutSingleQuotes('\''));
+    assertEquals("\\", Util.characterLiteralWithoutSingleQuotes('\\'));
+    // octal escapes
+    assertEquals("\\u0000", Util.characterLiteralWithoutSingleQuotes('\0'));
+    assertEquals("\\u0007", Util.characterLiteralWithoutSingleQuotes('\7'));
+    assertEquals("?", Util.characterLiteralWithoutSingleQuotes('\77'));
+    assertEquals("\\u007f", Util.characterLiteralWithoutSingleQuotes('\177'));
+    assertEquals("¿", Util.characterLiteralWithoutSingleQuotes('\277'));
+    assertEquals("ÿ", Util.characterLiteralWithoutSingleQuotes('\377'));
+    // unicode escapes
+    assertEquals("\\u0000", Util.characterLiteralWithoutSingleQuotes('\u0000'));
+    assertEquals("\\u0001", Util.characterLiteralWithoutSingleQuotes('\u0001'));
+    assertEquals("\\u0002", Util.characterLiteralWithoutSingleQuotes('\u0002'));
+    assertEquals("€", Util.characterLiteralWithoutSingleQuotes('\u20AC'));
+    assertEquals("☃", Util.characterLiteralWithoutSingleQuotes('\u2603'));
+    assertEquals("♠", Util.characterLiteralWithoutSingleQuotes('\u2660'));
+    assertEquals("♣", Util.characterLiteralWithoutSingleQuotes('\u2663'));
+    assertEquals("♥", Util.characterLiteralWithoutSingleQuotes('\u2665'));
+    assertEquals("♦", Util.characterLiteralWithoutSingleQuotes('\u2666'));
+    assertEquals("✵", Util.characterLiteralWithoutSingleQuotes('\u2735'));
+    assertEquals("✺", Util.characterLiteralWithoutSingleQuotes('\u273A'));
+    assertEquals("／", Util.characterLiteralWithoutSingleQuotes('\uFF0F'));
+  }
+
+  @Test public void stringLiteral() {
+    stringLiteral("abc");
+    stringLiteral("♦♥♠♣");
+    stringLiteral("€\\t@\\t$", "€\t@\t$", " ");
+    stringLiteral("abc();\\n\"\n  + \"def();", "abc();\ndef();", " ");
+  }
+
+  void stringLiteral(String string) {
+    stringLiteral(string, string, " ");
+  }
+
+  void stringLiteral(String expected, String value, String indent) {
+    assertEquals("\"" + expected + "\"", Util.stringLiteralWithDoubleQuotes(value, indent));
+  }
+}


### PR DESCRIPTION
`Character` and `String` literal conversion refactored.
Made `AnnotationSpec.Builder.addMemberForValue(String format, Object value)` public.
Removed redundant public modifiers from package private Util methods.
Added `UtilTest` class.