### PR TITLE
$X or custom CodeBlock supplier.

### DIFF
--- a/src/main/java/com/squareup/javapoet/CodeWriter.java
+++ b/src/main/java/com/squareup/javapoet/CodeWriter.java
@@ -245,6 +245,11 @@ final class CodeWriter {
           typeName.emit(this);
           break;
 
+        case "$X":
+          CodeBlock.Supplier supplier = (CodeBlock.Supplier) codeBlock.args.get(a++);
+          emit(supplier.get());
+          break;
+
         case "$$":
           emitAndIndent("$");
           break;

--- a/src/test/java/com/squareup/javapoet/CodeBlockTest.java
+++ b/src/test/java/com/squareup/javapoet/CodeBlockTest.java
@@ -188,4 +188,13 @@ public final class CodeBlockTest {
       assertThat(expected).hasMessage("statement exit $] has no matching statement enter $[");
     }
   }
+
+  @Test public void extension() {
+    CodeBlock.Supplier x = new CodeBlock.Supplier() {
+      @Override public CodeBlock get() {
+        return CodeBlock.builder().add("$T.$L()", System.class, "gc").build();
+      }};
+    CodeBlock block = CodeBlock.builder().add("$X", x).build();
+    assertThat(block.toString()).isEqualTo("java.lang.System.gc()");
+  }
 }


### PR DESCRIPTION
Clutching at straws, seeing `$R` vanish... enter `$X`!

With this generic extension point, JavaPoet provides the tool to implement custom acceleration implementations. Entire #388 (with #317) won't be part of JavaPoet, but at users project scope, it is 100% available.

What do you fellow poets think?