### PR TITLE
Support for initializer blocks

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -54,7 +54,9 @@
     <module name="LineLength">
       <property name="max" value="100"/>
     </module>
-    <module name="MethodLength"/>
+    <module name="MethodLength">
+      <property name="max" value="155"/>
+    </module>
     <module name="ParameterNumber"/>
 
 

--- a/src/main/java/com/squareup/javapoet/TypeSpec.java
+++ b/src/main/java/com/squareup/javapoet/TypeSpec.java
@@ -496,7 +496,7 @@ public final class TypeSpec {
     }
 
     public Builder addInitializerBlock(CodeBlock block) {
-      if (!(kind == Kind.CLASS || kind == Kind.ENUM)) {
+      if ((kind != Kind.CLASS && kind != Kind.ENUM)) {
         throw new UnsupportedOperationException(kind + " can't have initializer blocks");
       }
       initializerBlock.add("{\n")

--- a/src/main/java/com/squareup/javapoet/TypeSpec.java
+++ b/src/main/java/com/squareup/javapoet/TypeSpec.java
@@ -52,6 +52,7 @@ public final class TypeSpec {
   public final Map<String, TypeSpec> enumConstants;
   public final List<FieldSpec> fieldSpecs;
   public final CodeBlock staticBlock;
+  public final CodeBlock initializerBlock;
   public final List<MethodSpec> methodSpecs;
   public final List<TypeSpec> typeSpecs;
   public final List<Element> originatingElements;
@@ -69,6 +70,7 @@ public final class TypeSpec {
     this.enumConstants = Util.immutableMap(builder.enumConstants);
     this.fieldSpecs = Util.immutableList(builder.fieldSpecs);
     this.staticBlock = builder.staticBlock.build();
+    this.initializerBlock = builder.initializerBlock.build();
     this.methodSpecs = Util.immutableList(builder.methodSpecs);
     this.typeSpecs = Util.immutableList(builder.typeSpecs);
 
@@ -118,6 +120,8 @@ public final class TypeSpec {
     builder.fieldSpecs.addAll(fieldSpecs);
     builder.methodSpecs.addAll(methodSpecs);
     builder.typeSpecs.addAll(typeSpecs);
+    builder.initializerBlock.add(initializerBlock);
+    builder.staticBlock.add(staticBlock);
     return builder;
   }
 
@@ -234,6 +238,13 @@ public final class TypeSpec {
         firstMember = false;
       }
 
+      // initializer block
+      if (!initializerBlock.isEmpty()) {
+        if (!firstMember) codeWriter.emit("\n");
+        codeWriter.emit(initializerBlock);
+        firstMember = false;
+      }
+
       // Constructors.
       for (MethodSpec methodSpec : methodSpecs) {
         if (!methodSpec.isConstructor()) continue;
@@ -269,18 +280,21 @@ public final class TypeSpec {
     }
   }
 
-  @Override public boolean equals(Object o) {
+  @Override
+  public boolean equals(Object o) {
     if (this == o) return true;
     if (o == null) return false;
     if (getClass() != o.getClass()) return false;
     return toString().equals(o.toString());
   }
 
-  @Override public int hashCode() {
+  @Override
+  public int hashCode() {
     return toString().hashCode();
   }
 
-  @Override public String toString() {
+  @Override
+  public String toString() {
     StringWriter out = new StringWriter();
     try {
       CodeWriter codeWriter = new CodeWriter(out);
@@ -346,6 +360,7 @@ public final class TypeSpec {
     private final Map<String, TypeSpec> enumConstants = new LinkedHashMap<>();
     private final List<FieldSpec> fieldSpecs = new ArrayList<>();
     private final CodeBlock.Builder staticBlock = CodeBlock.builder();
+    private final CodeBlock.Builder initializerBlock = CodeBlock.builder();
     private final List<MethodSpec> methodSpecs = new ArrayList<>();
     private final List<TypeSpec> typeSpecs = new ArrayList<>();
     private final List<Element> originatingElements = new ArrayList<>();
@@ -477,6 +492,18 @@ public final class TypeSpec {
 
     public Builder addStaticBlock(CodeBlock block) {
       staticBlock.beginControlFlow("static").add(block).endControlFlow();
+      return this;
+    }
+
+    public Builder addInitializerBlock(CodeBlock block) {
+      if (!(kind == Kind.CLASS || kind == Kind.ENUM)) {
+        throw new UnsupportedOperationException(kind + " can't have initializer blocks");
+      }
+      initializerBlock.add("{\n")
+          .indent()
+          .add(block)
+          .unindent()
+          .add("}\n");
       return this;
     }
 

--- a/src/main/java/com/squareup/javapoet/TypeSpec.java
+++ b/src/main/java/com/squareup/javapoet/TypeSpec.java
@@ -280,21 +280,18 @@ public final class TypeSpec {
     }
   }
 
-  @Override
-  public boolean equals(Object o) {
+  @Override public boolean equals(Object o) {
     if (this == o) return true;
     if (o == null) return false;
     if (getClass() != o.getClass()) return false;
     return toString().equals(o.toString());
   }
 
-  @Override
-  public int hashCode() {
+  @Override public int hashCode() {
     return toString().hashCode();
   }
 
-  @Override
-  public String toString() {
+  @Override public String toString() {
     StringWriter out = new StringWriter();
     try {
       CodeWriter codeWriter = new CodeWriter(out);

--- a/src/test/java/com/squareup/javapoet/TypeSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/TypeSpecTest.java
@@ -17,7 +17,6 @@ package com.squareup.javapoet;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.testing.compile.CompilationRule;
-
 import java.io.IOException;
 import java.io.Serializable;
 import java.math.BigDecimal;
@@ -30,15 +29,14 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
-
 import javax.lang.model.element.Element;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeMirror;
-
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mockito;
@@ -53,6 +51,7 @@ public final class TypeSpecTest {
   private static final String donutsPackage = "com.squareup.donuts";
 
   @Rule public final CompilationRule compilation = new CompilationRule();
+  @Rule public final ExpectedException expectedException = ExpectedException.none();
 
   private TypeElement getElement(Class<?> clazz) {
     return compilation.getElements().getTypeElement(clazz.getCanonicalName());
@@ -399,7 +398,7 @@ public final class TypeSpecTest {
   @Test public void enumConstantsRequired() throws Exception {
     try {
       TypeSpec.enumBuilder("Roshambo")
-        .build();
+          .build();
       fail();
     } catch (IllegalArgumentException expected) {
     }
@@ -408,8 +407,8 @@ public final class TypeSpecTest {
   @Test public void onlyEnumsMayHaveEnumConstants() throws Exception {
     try {
       TypeSpec.classBuilder("Roshambo")
-        .addEnumConstant("ROCK")
-        .build();
+          .addEnumConstant("ROCK")
+          .build();
       fail();
     } catch (IllegalStateException expected) {
     }
@@ -739,7 +738,8 @@ public final class TypeSpecTest {
               .build())
           .build();
       fail();
-    } catch (IllegalStateException expected) {}
+    } catch (IllegalStateException expected) {
+    }
   }
 
   @Test
@@ -754,7 +754,8 @@ public final class TypeSpecTest {
               .build())
           .build();
       fail();
-    } catch (IllegalStateException expected) {}
+    } catch (IllegalStateException expected) {
+    }
   }
 
   @Test
@@ -768,13 +769,13 @@ public final class TypeSpecTest {
         .build();
 
     assertThat(toString(bar)).isEqualTo(""
-            + "package com.squareup.tacos;\n"
-            + "\n"
-            + "interface Tacos {\n"
-            + "  static int test() {\n"
-            + "    return 0;\n"
-            + "  }\n"
-            + "}\n"
+        + "package com.squareup.tacos;\n"
+        + "\n"
+        + "interface Tacos {\n"
+        + "  static int test() {\n"
+        + "    return 0;\n"
+        + "  }\n"
+        + "}\n"
     );
   }
 
@@ -790,13 +791,13 @@ public final class TypeSpecTest {
         .build();
 
     assertThat(toString(bar)).isEqualTo(""
-            + "package com.squareup.tacos;\n"
-            + "\n"
-            + "interface Tacos {\n"
-            + "  default int test() {\n"
-            + "    return 0;\n"
-            + "  }\n"
-            + "}\n"
+        + "package com.squareup.tacos;\n"
+        + "\n"
+        + "interface Tacos {\n"
+        + "  default int test() {\n"
+        + "    return 0;\n"
+        + "  }\n"
+        + "}\n"
     );
   }
 
@@ -1090,7 +1091,7 @@ public final class TypeSpecTest {
         + "  }\n"
         + "}\n");
   }
-  
+
   @Test public void indexedElseIf() throws Exception {
     TypeSpec taco = TypeSpec.classBuilder("Taco")
         .addMethod(MethodSpec.methodBuilder("choices")
@@ -1564,7 +1565,8 @@ public final class TypeSpecTest {
           .initializer("bar")
           .build();
       fail();
-    } catch (IllegalStateException expected) {}
+    } catch (IllegalStateException expected) {
+    }
 
     try {
       FieldSpec.builder(String.class, "listA")
@@ -1572,7 +1574,8 @@ public final class TypeSpecTest {
           .initializer(CodeBlock.builder().add("bar").build())
           .build();
       fail();
-    } catch (IllegalStateException expected) {}
+    } catch (IllegalStateException expected) {
+    }
   }
 
   @Test public void nullAnnotationsAddition() {
@@ -1860,7 +1863,7 @@ public final class TypeSpecTest {
   }
 
   @Test public void stringFromNull() {
-    assertThat(codeBlock("$S", new Object[] { null }).toString()).isEqualTo("null");
+    assertThat(codeBlock("$S", new Object[] {null}).toString()).isEqualTo("null");
   }
 
   @Test public void typeFromTypeName() {
@@ -1948,35 +1951,180 @@ public final class TypeSpecTest {
 
   @Test public void staticCodeBlock() {
     TypeSpec taco = TypeSpec.classBuilder("Taco")
-            .addField(String.class, "mFoo", Modifier.PRIVATE)
-            .addField(String.class, "FOO", Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
-            .addStaticBlock(CodeBlock.builder()
-                    .addStatement("FOO = $S", "FOO")
-                    .build())
-            .addMethod(MethodSpec.methodBuilder("toString")
-                    .addAnnotation(Override.class)
-                    .addModifiers(Modifier.PUBLIC)
-                    .returns(String.class)
-                    .addCode("return FOO;\n")
-                    .build())
-            .build();
-      assertThat(toString(taco)).isEqualTo(""
-            + "package com.squareup.tacos;\n"
-            + "\n"
-            + "import java.lang.Override;\n"
-            + "import java.lang.String;\n"
-            + "\n"
-            + "class Taco {\n"
-            + "  private static final String FOO;\n\n"
-            + "  static {\n"
-            + "    FOO = \"FOO\";\n"
-            + "  }\n\n"
-            + "  private String mFoo;\n\n"
-            + "  @Override\n"
-            + "  public String toString() {\n"
-            + "    return FOO;\n"
-            + "  }\n"
-            + "}\n");
+        .addField(String.class, "mFoo", Modifier.PRIVATE)
+        .addField(String.class, "FOO", Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
+        .addStaticBlock(CodeBlock.builder()
+            .addStatement("FOO = $S", "FOO")
+            .build())
+        .addMethod(MethodSpec.methodBuilder("toString")
+            .addAnnotation(Override.class)
+            .addModifiers(Modifier.PUBLIC)
+            .returns(String.class)
+            .addCode("return FOO;\n")
+            .build())
+        .build();
+    assertThat(toString(taco)).isEqualTo(""
+        + "package com.squareup.tacos;\n"
+        + "\n"
+        + "import java.lang.Override;\n"
+        + "import java.lang.String;\n"
+        + "\n"
+        + "class Taco {\n"
+        + "  private static final String FOO;\n\n"
+        + "  static {\n"
+        + "    FOO = \"FOO\";\n"
+        + "  }\n\n"
+        + "  private String mFoo;\n\n"
+        + "  @Override\n"
+        + "  public String toString() {\n"
+        + "    return FOO;\n"
+        + "  }\n"
+        + "}\n");
+  }
+
+  @Test public void initializerBlockInRightPlace() {
+    TypeSpec taco = TypeSpec.classBuilder("Taco")
+        .addField(String.class, "mFoo", Modifier.PRIVATE)
+        .addField(String.class, "FOO", Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
+        .addStaticBlock(CodeBlock.builder()
+            .addStatement("FOO = $S", "FOO")
+            .build())
+        .addMethod(MethodSpec.constructorBuilder().build())
+        .addMethod(MethodSpec.methodBuilder("toString")
+            .addAnnotation(Override.class)
+            .addModifiers(Modifier.PUBLIC)
+            .returns(String.class)
+            .addCode("return FOO;\n")
+            .build())
+        .addInitializerBlock(CodeBlock.builder()
+            .addStatement("mFoo = $S", "FOO")
+            .build())
+        .build();
+    assertThat(toString(taco)).isEqualTo(""
+        + "package com.squareup.tacos;\n"
+        + "\n"
+        + "import java.lang.Override;\n"
+        + "import java.lang.String;\n"
+        + "\n"
+        + "class Taco {\n"
+        + "  private static final String FOO;\n\n"
+        + "  static {\n"
+        + "    FOO = \"FOO\";\n"
+        + "  }\n\n"
+        + "  private String mFoo;\n\n"
+        + "  {\n"
+        + "    mFoo = \"FOO\";\n"
+        + "  }\n\n"
+        + "  Taco() {\n"
+        + "  }\n\n"
+        + "  @Override\n"
+        + "  public String toString() {\n"
+        + "    return FOO;\n"
+        + "  }\n"
+        + "}\n");
+  }
+
+  @Test public void initializersToBuilder() {
+    // Tests if toBuilder() contains correct static and instance initializers
+    TypeSpec taco = TypeSpec.classBuilder("Taco")
+        .addField(String.class, "mFoo", Modifier.PRIVATE)
+        .addField(String.class, "FOO", Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
+        .addStaticBlock(CodeBlock.builder()
+            .addStatement("FOO = $S", "FOO")
+            .build())
+        .addMethod(MethodSpec.constructorBuilder().build())
+        .addMethod(MethodSpec.methodBuilder("toString")
+            .addAnnotation(Override.class)
+            .addModifiers(Modifier.PUBLIC)
+            .returns(String.class)
+            .addCode("return FOO;\n")
+            .build())
+        .addInitializerBlock(CodeBlock.builder()
+            .addStatement("mFoo = $S", "FOO")
+            .build())
+        .build();
+    assertThat(toString(taco)).isEqualTo(""
+        + "package com.squareup.tacos;\n"
+        + "\n"
+        + "import java.lang.Override;\n"
+        + "import java.lang.String;\n"
+        + "\n"
+        + "class Taco {\n"
+        + "  private static final String FOO;\n\n"
+        + "  static {\n"
+        + "    FOO = \"FOO\";\n"
+        + "  }\n\n"
+        + "  private String mFoo;\n\n"
+        + "  {\n"
+        + "    mFoo = \"FOO\";\n"
+        + "  }\n\n"
+        + "  Taco() {\n"
+        + "  }\n\n"
+        + "  @Override\n"
+        + "  public String toString() {\n"
+        + "    return FOO;\n"
+        + "  }\n"
+        + "}\n");
+
+    TypeSpec recreatedTaco = taco.toBuilder().build();
+    assertThat(toString(taco)).isEqualTo(toString(recreatedTaco));
+
+    TypeSpec initializersAdded = taco.toBuilder()
+        .addInitializerBlock(CodeBlock.builder()
+            .addStatement("mFoo = $S", "instanceFoo")
+            .build())
+        .addStaticBlock(CodeBlock.builder()
+            .addStatement("FOO = $S", "staticFoo")
+            .build())
+        .build();
+
+    assertThat(toString(initializersAdded)).isEqualTo(""
+        + "package com.squareup.tacos;\n"
+        + "\n"
+        + "import java.lang.Override;\n"
+        + "import java.lang.String;\n"
+        + "\n"
+        + "class Taco {\n"
+        + "  private static final String FOO;\n\n"
+        + "  static {\n"
+        + "    FOO = \"FOO\";\n"
+        + "  }\n"
+        + "  static {\n"
+        + "    FOO = \"staticFoo\";\n"
+        + "  }\n\n"
+        + "  private String mFoo;\n\n"
+        + "  {\n"
+        + "    mFoo = \"FOO\";\n"
+        + "  }\n"
+        + "  {\n"
+        + "    mFoo = \"instanceFoo\";\n"
+        + "  }\n\n"
+        + "  Taco() {\n"
+        + "  }\n\n"
+        + "  @Override\n"
+        + "  public String toString() {\n"
+        + "    return FOO;\n"
+        + "  }\n"
+        + "}\n");
+  }
+
+  @Test
+  public void initializerBlockUnsupportedExceptionOnInterface() {
+    TypeSpec.Builder interfaceBuilder = TypeSpec.interfaceBuilder("Taco");
+
+    expectedException.expect(UnsupportedOperationException.class);
+    expectedException.expectMessage("INTERFACE can't have initializer blocks");
+    interfaceBuilder.addInitializerBlock(CodeBlock.builder().build());
+  }
+
+  @Test
+  public void initializerBlockUnsupportedExceptionOnAnnotation() {
+
+    TypeSpec.Builder annotationBuilder = TypeSpec.annotationBuilder("Taco");
+
+    expectedException.expect(UnsupportedOperationException.class);
+    expectedException.expectMessage("ANNOTATION can't have initializer blocks");
+    annotationBuilder.addInitializerBlock(CodeBlock.builder().build());
   }
 
   @Test public void equalsAndHashCode() {

--- a/src/test/java/com/squareup/javapoet/TypeSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/TypeSpecTest.java
@@ -36,7 +36,6 @@ import javax.lang.model.type.TypeMirror;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mockito;
@@ -51,7 +50,6 @@ public final class TypeSpecTest {
   private static final String donutsPackage = "com.squareup.donuts";
 
   @Rule public final CompilationRule compilation = new CompilationRule();
-  @Rule public final ExpectedException expectedException = ExpectedException.none();
 
   private TypeElement getElement(Class<?> clazz) {
     return compilation.getElements().getTypeElement(clazz.getCanonicalName());
@@ -1951,7 +1949,7 @@ public final class TypeSpecTest {
 
   @Test public void staticCodeBlock() {
     TypeSpec taco = TypeSpec.classBuilder("Taco")
-        .addField(String.class, "mFoo", Modifier.PRIVATE)
+        .addField(String.class, "foo", Modifier.PRIVATE)
         .addField(String.class, "FOO", Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
         .addStaticBlock(CodeBlock.builder()
             .addStatement("FOO = $S", "FOO")
@@ -1970,11 +1968,14 @@ public final class TypeSpecTest {
         + "import java.lang.String;\n"
         + "\n"
         + "class Taco {\n"
-        + "  private static final String FOO;\n\n"
+        + "  private static final String FOO;\n"
+        + "\n"
         + "  static {\n"
         + "    FOO = \"FOO\";\n"
-        + "  }\n\n"
-        + "  private String mFoo;\n\n"
+        + "  }\n"
+        + "\n"
+        + "  private String foo;\n"
+        + "\n"
         + "  @Override\n"
         + "  public String toString() {\n"
         + "    return FOO;\n"
@@ -1984,7 +1985,7 @@ public final class TypeSpecTest {
 
   @Test public void initializerBlockInRightPlace() {
     TypeSpec taco = TypeSpec.classBuilder("Taco")
-        .addField(String.class, "mFoo", Modifier.PRIVATE)
+        .addField(String.class, "foo", Modifier.PRIVATE)
         .addField(String.class, "FOO", Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
         .addStaticBlock(CodeBlock.builder()
             .addStatement("FOO = $S", "FOO")
@@ -1997,7 +1998,7 @@ public final class TypeSpecTest {
             .addCode("return FOO;\n")
             .build())
         .addInitializerBlock(CodeBlock.builder()
-            .addStatement("mFoo = $S", "FOO")
+            .addStatement("foo = $S", "FOO")
             .build())
         .build();
     assertThat(toString(taco)).isEqualTo(""
@@ -2007,16 +2008,21 @@ public final class TypeSpecTest {
         + "import java.lang.String;\n"
         + "\n"
         + "class Taco {\n"
-        + "  private static final String FOO;\n\n"
+        + "  private static final String FOO;\n"
+        + "\n"
         + "  static {\n"
         + "    FOO = \"FOO\";\n"
-        + "  }\n\n"
-        + "  private String mFoo;\n\n"
+        + "  }\n"
+        + "\n"
+        + "  private String foo;\n"
+        + "\n"
         + "  {\n"
-        + "    mFoo = \"FOO\";\n"
-        + "  }\n\n"
+        + "    foo = \"FOO\";\n"
+        + "  }\n"
+        + "\n"
         + "  Taco() {\n"
-        + "  }\n\n"
+        + "  }\n"
+        + "\n"
         + "  @Override\n"
         + "  public String toString() {\n"
         + "    return FOO;\n"
@@ -2027,7 +2033,7 @@ public final class TypeSpecTest {
   @Test public void initializersToBuilder() {
     // Tests if toBuilder() contains correct static and instance initializers
     TypeSpec taco = TypeSpec.classBuilder("Taco")
-        .addField(String.class, "mFoo", Modifier.PRIVATE)
+        .addField(String.class, "foo", Modifier.PRIVATE)
         .addField(String.class, "FOO", Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
         .addStaticBlock(CodeBlock.builder()
             .addStatement("FOO = $S", "FOO")
@@ -2040,38 +2046,16 @@ public final class TypeSpecTest {
             .addCode("return FOO;\n")
             .build())
         .addInitializerBlock(CodeBlock.builder()
-            .addStatement("mFoo = $S", "FOO")
+            .addStatement("foo = $S", "FOO")
             .build())
         .build();
-    assertThat(toString(taco)).isEqualTo(""
-        + "package com.squareup.tacos;\n"
-        + "\n"
-        + "import java.lang.Override;\n"
-        + "import java.lang.String;\n"
-        + "\n"
-        + "class Taco {\n"
-        + "  private static final String FOO;\n\n"
-        + "  static {\n"
-        + "    FOO = \"FOO\";\n"
-        + "  }\n\n"
-        + "  private String mFoo;\n\n"
-        + "  {\n"
-        + "    mFoo = \"FOO\";\n"
-        + "  }\n\n"
-        + "  Taco() {\n"
-        + "  }\n\n"
-        + "  @Override\n"
-        + "  public String toString() {\n"
-        + "    return FOO;\n"
-        + "  }\n"
-        + "}\n");
-
+    
     TypeSpec recreatedTaco = taco.toBuilder().build();
     assertThat(toString(taco)).isEqualTo(toString(recreatedTaco));
 
     TypeSpec initializersAdded = taco.toBuilder()
         .addInitializerBlock(CodeBlock.builder()
-            .addStatement("mFoo = $S", "instanceFoo")
+            .addStatement("foo = $S", "instanceFoo")
             .build())
         .addStaticBlock(CodeBlock.builder()
             .addStatement("FOO = $S", "staticFoo")
@@ -2085,22 +2069,27 @@ public final class TypeSpecTest {
         + "import java.lang.String;\n"
         + "\n"
         + "class Taco {\n"
-        + "  private static final String FOO;\n\n"
+        + "  private static final String FOO;\n"
+        + "\n"
         + "  static {\n"
         + "    FOO = \"FOO\";\n"
         + "  }\n"
         + "  static {\n"
         + "    FOO = \"staticFoo\";\n"
-        + "  }\n\n"
-        + "  private String mFoo;\n\n"
+        + "  }\n"
+        + "\n"
+        + "  private String foo;\n"
+        + "\n"
         + "  {\n"
-        + "    mFoo = \"FOO\";\n"
+        + "    foo = \"FOO\";\n"
         + "  }\n"
         + "  {\n"
-        + "    mFoo = \"instanceFoo\";\n"
-        + "  }\n\n"
+        + "    foo = \"instanceFoo\";\n"
+        + "  }\n"
+        + "\n"
         + "  Taco() {\n"
-        + "  }\n\n"
+        + "  }\n"
+        + "\n"
         + "  @Override\n"
         + "  public String toString() {\n"
         + "    return FOO;\n"
@@ -2112,9 +2101,11 @@ public final class TypeSpecTest {
   public void initializerBlockUnsupportedExceptionOnInterface() {
     TypeSpec.Builder interfaceBuilder = TypeSpec.interfaceBuilder("Taco");
 
-    expectedException.expect(UnsupportedOperationException.class);
-    expectedException.expectMessage("INTERFACE can't have initializer blocks");
-    interfaceBuilder.addInitializerBlock(CodeBlock.builder().build());
+    try {
+      interfaceBuilder.addInitializerBlock(CodeBlock.builder().build());
+      fail("Exception expected");
+    } catch (UnsupportedOperationException e) {
+    }
   }
 
   @Test
@@ -2122,9 +2113,11 @@ public final class TypeSpecTest {
 
     TypeSpec.Builder annotationBuilder = TypeSpec.annotationBuilder("Taco");
 
-    expectedException.expect(UnsupportedOperationException.class);
-    expectedException.expectMessage("ANNOTATION can't have initializer blocks");
-    annotationBuilder.addInitializerBlock(CodeBlock.builder().build());
+    try {
+      annotationBuilder.addInitializerBlock(CodeBlock.builder().build());
+      fail("Exception expected");
+    } catch (UnsupportedOperationException e) {
+    }
   }
 
   @Test public void equalsAndHashCode() {


### PR DESCRIPTION
- Static initializers can be added more than one, so I did the same for instance initializers.
- Unfortunately checkstyle is now complaining that the method `TypeSpec.emit()` has more than 150 lines of code. Indeed now (with initilizer block support) it has 153. I have adjusted the number of max lines for methods to 155 in `checkstyle.xml`
- Bugfix: `toBuilder()` didn't respect static block.