### PR TITLE
Centralized IOException handling in CodeWriter

### DIFF
--- a/src/main/java/com/squareup/javapoet/AnnotationSpec.java
+++ b/src/main/java/com/squareup/javapoet/AnnotationSpec.java
@@ -15,8 +15,6 @@
  */
 package com.squareup.javapoet;
 
-import java.io.IOException;
-import java.io.StringWriter;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Array;
 import java.lang.reflect.Method;
@@ -50,7 +48,7 @@ public final class AnnotationSpec {
     this.members = Util.immutableMultimap(builder.members);
   }
 
-  void emit(CodeWriter codeWriter, boolean inline) throws IOException {
+  void emit(CodeWriter codeWriter, boolean inline) {
     String whitespace = inline ? "" : "\n";
     String memberSeparator = inline ? ", " : ",\n";
     if (members.isEmpty()) {
@@ -85,7 +83,7 @@ public final class AnnotationSpec {
   }
 
   private void emitAnnotationValues(CodeWriter codeWriter, String whitespace,
-      String memberSeparator, List<CodeBlock> values) throws IOException {
+      String memberSeparator, List<CodeBlock> values) {
     if (values.size() == 1) {
       codeWriter.indent(2);
       codeWriter.emit(values.get(0));
@@ -185,14 +183,10 @@ public final class AnnotationSpec {
   }
 
   @Override public String toString() {
-    StringWriter out = new StringWriter();
-    try {
-      CodeWriter codeWriter = new CodeWriter(out);
-      codeWriter.emit("$L", this);
-      return out.toString();
-    } catch (IOException e) {
-      throw new AssertionError();
-    }
+    StringBuilder out = new StringBuilder();
+    CodeWriter codeWriter = new CodeWriter(out);
+    codeWriter.emit("$L", this);
+    return out.toString();
   }
 
   public static final class Builder {

--- a/src/main/java/com/squareup/javapoet/ArrayTypeName.java
+++ b/src/main/java/com/squareup/javapoet/ArrayTypeName.java
@@ -15,7 +15,6 @@
  */
 package com.squareup.javapoet;
 
-import java.io.IOException;
 import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
@@ -44,7 +43,7 @@ public final class ArrayTypeName extends TypeName {
     return new ArrayTypeName(componentType, annotations);
   }
 
-  @Override CodeWriter emit(CodeWriter out) throws IOException {
+  @Override CodeWriter emit(CodeWriter out) {
     return emitAnnotations(out).emit("$T[]", componentType);
   }
 

--- a/src/main/java/com/squareup/javapoet/ClassName.java
+++ b/src/main/java/com/squareup/javapoet/ClassName.java
@@ -15,7 +15,6 @@
  */
 package com.squareup.javapoet;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -202,7 +201,7 @@ public final class ClassName extends TypeName implements Comparable<ClassName> {
     return canonicalName.compareTo(o.canonicalName);
   }
 
-  @Override CodeWriter emit(CodeWriter out) throws IOException {
+  @Override CodeWriter emit(CodeWriter out) {
     return emitAnnotations(out).emitAndIndent(out.lookupName(this));
   }
 }

--- a/src/main/java/com/squareup/javapoet/CodeBlock.java
+++ b/src/main/java/com/squareup/javapoet/CodeBlock.java
@@ -15,8 +15,6 @@
  */
 package com.squareup.javapoet;
 
-import java.io.IOException;
-import java.io.StringWriter;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
@@ -81,13 +79,9 @@ public final class CodeBlock {
   }
 
   @Override public String toString() {
-    StringWriter out = new StringWriter();
-    try {
-      new CodeWriter(out).emit(this);
-      return out.toString();
-    } catch (IOException e) {
-      throw new AssertionError();
-    }
+    StringBuilder out = new StringBuilder();
+    new CodeWriter(out).emit(this);
+    return out.toString();
   }
 
   public static Builder builder() {

--- a/src/main/java/com/squareup/javapoet/FieldSpec.java
+++ b/src/main/java/com/squareup/javapoet/FieldSpec.java
@@ -15,8 +15,6 @@
  */
 package com.squareup.javapoet;
 
-import java.io.IOException;
-import java.io.StringWriter;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -53,7 +51,7 @@ public final class FieldSpec {
     return modifiers.contains(modifier);
   }
 
-  void emit(CodeWriter codeWriter, Set<Modifier> implicitModifiers) throws IOException {
+  void emit(CodeWriter codeWriter, Set<Modifier> implicitModifiers) {
     codeWriter.emitJavadoc(javadoc);
     codeWriter.emitAnnotations(annotations, false);
     codeWriter.emitModifiers(modifiers, implicitModifiers);
@@ -77,14 +75,10 @@ public final class FieldSpec {
   }
 
   @Override public String toString() {
-    StringWriter out = new StringWriter();
-    try {
-      CodeWriter codeWriter = new CodeWriter(out);
-      emit(codeWriter, Collections.<Modifier>emptySet());
-      return out.toString();
-    } catch (IOException e) {
-      throw new AssertionError();
-    }
+    StringBuilder out = new StringBuilder();
+    CodeWriter codeWriter = new CodeWriter(out);
+    emit(codeWriter, Collections.<Modifier>emptySet());
+    return out.toString();
   }
 
   public static Builder builder(TypeName type, String name, Modifier... modifiers) {

--- a/src/main/java/com/squareup/javapoet/JavaFile.java
+++ b/src/main/java/com/squareup/javapoet/JavaFile.java
@@ -71,6 +71,14 @@ public final class JavaFile {
   }
 
   public void writeTo(Appendable out) throws IOException {
+    try {
+      writeToUnchecked(out);
+    } catch (CodeWriter.EmitRuntimeException e) {
+      throw (IOException) e.getCause();
+    }
+  }
+
+  private void writeToUnchecked(Appendable out) {
     // First pass: emit the entire class, just to collect the types we'll need to import.
     CodeWriter importsCollector = new CodeWriter(NULL_APPENDABLE, indent, staticImports);
     emit(importsCollector);
@@ -123,7 +131,7 @@ public final class JavaFile {
     }
   }
 
-  private void emit(CodeWriter codeWriter) throws IOException {
+  private void emit(CodeWriter codeWriter) {
     codeWriter.pushPackage(packageName);
 
     if (!fileComment.isEmpty()) {
@@ -170,13 +178,9 @@ public final class JavaFile {
   }
 
   @Override public String toString() {
-    try {
-      StringBuilder result = new StringBuilder();
-      writeTo(result);
-      return result.toString();
-    } catch (IOException e) {
-      throw new AssertionError();
-    }
+    StringBuilder result = new StringBuilder();
+    writeToUnchecked(result);
+    return result.toString();
   }
 
   public JavaFileObject toJavaFileObject() {

--- a/src/main/java/com/squareup/javapoet/MethodSpec.java
+++ b/src/main/java/com/squareup/javapoet/MethodSpec.java
@@ -15,8 +15,6 @@
  */
 package com.squareup.javapoet;
 
-import java.io.IOException;
-import java.io.StringWriter;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -82,8 +80,7 @@ public final class MethodSpec {
         && TypeName.arrayComponent(parameters.get(parameters.size() - 1).type) != null;
   }
 
-  void emit(CodeWriter codeWriter, String enclosingName, Set<Modifier> implicitModifiers)
-      throws IOException {
+  void emit(CodeWriter codeWriter, String enclosingName, Set<Modifier> implicitModifiers) {
     codeWriter.emitJavadoc(javadoc);
     codeWriter.emitAnnotations(annotations, false);
     codeWriter.emitModifiers(modifiers, implicitModifiers);
@@ -161,14 +158,10 @@ public final class MethodSpec {
   }
 
   @Override public String toString() {
-    StringWriter out = new StringWriter();
-    try {
-      CodeWriter codeWriter = new CodeWriter(out);
-      emit(codeWriter, "Constructor", Collections.<Modifier>emptySet());
-      return out.toString();
-    } catch (IOException e) {
-      throw new AssertionError();
-    }
+    StringBuilder out = new StringBuilder();
+    CodeWriter codeWriter = new CodeWriter(out);
+    emit(codeWriter, "Constructor", Collections.<Modifier>emptySet());
+    return out.toString();
   }
 
   public static Builder methodBuilder(String name) {

--- a/src/main/java/com/squareup/javapoet/ParameterSpec.java
+++ b/src/main/java/com/squareup/javapoet/ParameterSpec.java
@@ -15,8 +15,6 @@
  */
 package com.squareup.javapoet;
 
-import java.io.IOException;
-import java.io.StringWriter;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -46,7 +44,7 @@ public final class ParameterSpec {
     return modifiers.contains(modifier);
   }
 
-  void emit(CodeWriter codeWriter, boolean varargs) throws IOException {
+  void emit(CodeWriter codeWriter, boolean varargs) {
     codeWriter.emitAnnotations(annotations, true);
     codeWriter.emitModifiers(modifiers);
     if (varargs) {
@@ -68,14 +66,10 @@ public final class ParameterSpec {
   }
 
   @Override public String toString() {
-    StringWriter out = new StringWriter();
-    try {
-      CodeWriter codeWriter = new CodeWriter(out);
-      emit(codeWriter, false);
-      return out.toString();
-    } catch (IOException e) {
-      throw new AssertionError();
-    }
+    StringBuilder out = new StringBuilder();
+    CodeWriter codeWriter = new CodeWriter(out);
+    emit(codeWriter, false);
+    return out.toString();
   }
 
   public static Builder builder(TypeName type, String name, Modifier... modifiers) {

--- a/src/main/java/com/squareup/javapoet/ParameterizedTypeName.java
+++ b/src/main/java/com/squareup/javapoet/ParameterizedTypeName.java
@@ -15,7 +15,6 @@
  */
 package com.squareup.javapoet;
 
-import java.io.IOException;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
@@ -52,7 +51,7 @@ public final class ParameterizedTypeName extends TypeName {
     return new ParameterizedTypeName(rawType, typeArguments, annotations);
   }
 
-  @Override CodeWriter emit(CodeWriter out) throws IOException {
+  @Override CodeWriter emit(CodeWriter out) {
     emitAnnotations(out);
     rawType.emit(out);
     out.emitAndIndent("<");

--- a/src/main/java/com/squareup/javapoet/TypeName.java
+++ b/src/main/java/com/squareup/javapoet/TypeName.java
@@ -15,7 +15,6 @@
  */
 package com.squareup.javapoet;
 
-import java.io.IOException;
 import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -171,21 +170,17 @@ public class TypeName {
   }
 
   @Override public final String toString() {
-    try {
-      StringBuilder result = new StringBuilder();
-      emit(new CodeWriter(result));
-      return result.toString();
-    } catch (IOException e) {
-      throw new AssertionError();
-    }
+    StringBuilder result = new StringBuilder();
+    emit(new CodeWriter(result));
+    return result.toString();
   }
 
-  CodeWriter emit(CodeWriter out) throws IOException {
+  CodeWriter emit(CodeWriter out) {
     if (keyword == null) throw new AssertionError();
     return emitAnnotations(out).emitAndIndent(keyword);
   }
 
-  CodeWriter emitAnnotations(CodeWriter out) throws IOException {
+  CodeWriter emitAnnotations(CodeWriter out) {
     for (AnnotationSpec annotation : annotations) {
       annotation.emit(out, true);
       out.emit(" ");

--- a/src/main/java/com/squareup/javapoet/TypeSpec.java
+++ b/src/main/java/com/squareup/javapoet/TypeSpec.java
@@ -15,8 +15,6 @@
  */
 package com.squareup.javapoet;
 
-import java.io.IOException;
-import java.io.StringWriter;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -125,8 +123,7 @@ public final class TypeSpec {
     return builder;
   }
 
-  void emit(CodeWriter codeWriter, String enumName, Set<Modifier> implicitModifiers)
-      throws IOException {
+  void emit(CodeWriter codeWriter, String enumName, Set<Modifier> implicitModifiers) {
     // Nested classes interrupt wrapped line indentation. Stash the current wrapping state and put
     // it back afterwards when this type is complete.
     int previousStatementLine = codeWriter.statementLine;
@@ -292,14 +289,10 @@ public final class TypeSpec {
   }
 
   @Override public String toString() {
-    StringWriter out = new StringWriter();
-    try {
-      CodeWriter codeWriter = new CodeWriter(out);
-      emit(codeWriter, null, Collections.<Modifier>emptySet());
-      return out.toString();
-    } catch (IOException e) {
-      throw new AssertionError();
-    }
+    StringBuilder out = new StringBuilder();
+    CodeWriter codeWriter = new CodeWriter(out);
+    emit(codeWriter, null, Collections.<Modifier>emptySet());
+    return out.toString();
   }
 
   private enum Kind {

--- a/src/main/java/com/squareup/javapoet/TypeVariableName.java
+++ b/src/main/java/com/squareup/javapoet/TypeVariableName.java
@@ -15,7 +15,6 @@
  */
 package com.squareup.javapoet;
 
-import java.io.IOException;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -60,7 +59,7 @@ public final class TypeVariableName extends TypeName {
     return new TypeVariableName(name, Collections.unmodifiableList(boundsNoObject));
   }
 
-  @Override CodeWriter emit(CodeWriter out) throws IOException {
+  @Override CodeWriter emit(CodeWriter out) {
     return emitAnnotations(out).emitAndIndent(name);
   }
 

--- a/src/main/java/com/squareup/javapoet/WildcardTypeName.java
+++ b/src/main/java/com/squareup/javapoet/WildcardTypeName.java
@@ -15,7 +15,6 @@
  */
 package com.squareup.javapoet;
 
-import java.io.IOException;
 import java.lang.reflect.Type;
 import java.lang.reflect.WildcardType;
 import java.util.ArrayList;
@@ -58,7 +57,7 @@ public final class WildcardTypeName extends TypeName {
     return new WildcardTypeName(upperBounds, lowerBounds, annotations);
   }
 
-  @Override CodeWriter emit(CodeWriter out) throws IOException {
+  @Override CodeWriter emit(CodeWriter out) {
     emitAnnotations(out);
     if (lowerBounds.size() == 1) {
       return out.emit("? super $T", lowerBounds.get(0));


### PR DESCRIPTION
Removing all `throws IOException` from `emit()`-related methods and clear the exception handling from many `toString()` implementations.

