### PR TITLE
Static import refactored.

### DIFF
--- a/src/main/java/com/squareup/javapoet/JavaFile.java
+++ b/src/main/java/com/squareup/javapoet/JavaFile.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import javax.annotation.processing.Filer;
+import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.Modifier;
 import javax.tools.JavaFileObject;
@@ -75,9 +76,10 @@ public final class JavaFile {
     CodeWriter importsCollector = new CodeWriter(NULL_APPENDABLE, indent, staticImports);
     emit(importsCollector);
     Map<String, ClassName> suggestedImports = importsCollector.suggestedImports();
+    Set<String> suggestedStaticImports = importsCollector.suggestedStaticImports();
 
     // Second pass: write the code, taking advantage of the imports.
-    CodeWriter codeWriter = new CodeWriter(out, indent, suggestedImports, staticImports);
+    CodeWriter codeWriter = new CodeWriter(out, indent, suggestedImports, suggestedStaticImports);
     emit(codeWriter);
   }
 
@@ -135,8 +137,8 @@ public final class JavaFile {
       codeWriter.emit("\n");
     }
 
-    if (!staticImports.isEmpty()) {
-      for (String signature : staticImports) {
+    if (!codeWriter.staticImports().isEmpty()) {
+      for (String signature : codeWriter.staticImports()) {
         codeWriter.emit("import static $L;\n", signature);
       }
       codeWriter.emit("\n");
@@ -244,6 +246,7 @@ public final class JavaFile {
       checkArgument(names.length > 0, "names array is empty");
       for (String name : names) {
         checkArgument(name != null, "null entry in names array: %s", Arrays.toString(names));
+        checkArgument(!SourceVersion.isKeyword(name), "keyword %s can not be imported", name);
         staticImports.add(className.canonicalName + "." + name);
       }
       return this;

--- a/src/test/java/com/squareup/javapoet/JavaFileImportStaticTest.java
+++ b/src/test/java/com/squareup/javapoet/JavaFileImportStaticTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.javapoet;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeNotNull;
+
+import java.util.Arrays;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class) public class JavaFileImportStaticTest {
+
+  private static Object[] args(Object... args) {
+    return args;
+  }
+
+  @Parameters(name = "{index}: {0}") public static Iterable<Object[]> data() {
+    MethodSpec tan = MethodSpec.methodBuilder("tan").build();
+    return Arrays.asList(new Object[][] {
+        { "abs(-5)", "$T.abs(-5)", args(Math.class) },
+        { "E", "$T.E", args(Math.class) },
+        { "E", "$T\n.E", args(Math.class) },
+        { "E", "$T \n.E", args(Math.class) },
+        { "PI", "$T.$N", args(Math.class, "PI") },
+        { "PI", "$T\n.$N", args(Math.class, "PI") },
+        { "PI=PI", "$T . $N = PI", args(Math.class, "PI") },
+        { "PI=PI", "PI = $T . $N", args(Math.class, "PI") },
+        { "PI=PI", "PI = \n $T \t . \n\t \n\t $N", args(Math.class, "PI") },
+        { "tan()", "$T.$N()", args(Math.class, tan) },
+        { "sin(42.1)", "$T.$L($L)", args(Math.class, "sin", 42.1) },
+        { "cos(E+9.9)", "$1T$2L$3L($1T$2NE+$4L$2L$4L)", args(Math.class, ".", "cos", 011) }
+    });
+  }
+
+  private final String expected;
+  private final String format;
+  private final Object[] args;
+
+  public JavaFileImportStaticTest(String expected, String format, Object... args) {
+    this.expected = expected;
+    this.format = format;
+    this.args = args;
+  }
+
+  @Test public void statementMatchesExpectation() {
+    String source = JavaFile.builder("com.squareup.tacos",
+        TypeSpec.classBuilder("Taco")
+            .addStaticBlock(CodeBlock.of(format + ";", args))
+            .build())
+        .addStaticImport(Math.class, "*")
+        .build()
+        .toString();
+    assertTrue(source.contains("import static java.lang.Math.*;"));
+    int indexOfStaticInit = source.indexOf("static {\n") + "static {\n".length();
+    String actual = source.substring(indexOfStaticInit, source.indexOf(";", indexOfStaticInit));
+    assumeNotNull(expected);
+    assertEquals(expected, actual.replaceAll("\\s", ""));
+  }
+}

--- a/src/test/java/com/squareup/javapoet/JavaFileTest.java
+++ b/src/test/java/com/squareup/javapoet/JavaFileTest.java
@@ -19,7 +19,6 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
 import javax.lang.model.element.Modifier;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -48,7 +47,9 @@ public final class JavaFileTest {
         .build();
     JavaFile example = JavaFile.builder("com.example.helloworld", hello)
         .addStaticImport(hoverboard, "createNimbus")
+        .addStaticImport(Math.class, "*")
         .addStaticImport(namedBoards, "*")
+        .addStaticImport(Thread.class, "currentThread")
         .addStaticImport(Collections.class, "*")
         .build();
     assertThat(example.toString()).isEqualTo(""
@@ -72,29 +73,6 @@ public final class JavaFileTest {
         + "    return result.isEmpty() emptyList() : result;\n"
         + "  }\n"
         + "}\n");
-  }
-  @Test public void importStaticForCrazyFormatsWorks() {
-    MethodSpec method = MethodSpec.methodBuilder("method").build();
-    JavaFile.builder("com.squareup.tacos",
-        TypeSpec.classBuilder("Taco")
-            .addStaticBlock(CodeBlock.builder()
-                .addStatement("$T", Runtime.class)
-                .addStatement("$T.a()", Runtime.class)
-                .addStatement("$T.X", Runtime.class)
-                .addStatement("$T$T", Runtime.class, Runtime.class)
-                .addStatement("$T.$T", Runtime.class, Runtime.class)
-                .addStatement("$1T$1T", Runtime.class)
-                .addStatement("$1T$2L$1T", Runtime.class, "?")
-                .addStatement("$1T$2L$2S$1T", Runtime.class, "?")
-                .addStatement("$1T$2L$2S$1T$3N$1T", Runtime.class, "?", method)
-                .addStatement("$T$L", Runtime.class, "?")
-                .addStatement("$T$S", Runtime.class, "?")
-                .addStatement("$T$N", Runtime.class, method)
-                .build())
-            .build())
-        .addStaticImport(Runtime.class, "*")
-        .build()
-        .toString(); // don't look at the generated code...
   }
 
   @Test public void importStaticMixed() {
@@ -135,7 +113,6 @@ public final class JavaFileTest {
         + "}\n");
   }
 
-  @Ignore("addStaticImport doesn't support members with $L")
   @Test public void importStaticDynamic() {
     JavaFile source = JavaFile.builder("com.squareup.tacos",
         TypeSpec.classBuilder("Taco")


### PR DESCRIPTION
# Motivation
Current `JavaFile//addStaticImport` implementation "doesn't support members with $L". See https://github.com/square/javapoet/commit/4dd534906a1e8aa8b15883706878a45fdb1437da

## Features
* `$T.$L` and many (all ?) other cases are now supported
* It does not fail on intentional white spaces either, like `"$T . $N = PI"`
* Auto-skips unused `import static` requests

##  Implementation outline
* Hooked into `lookup(ClassName)` and `emitAndIndent(String)` now.
* When a potential hit for a static import is detected, `lookup` returns an empty string and the `ClassName` instance is remembered as deferred.
* While there's a deferred `ClassName`, all strings (coming from any accelerator like `$L`, `$N`, ...) emitted via `emitAndIndent(String)` are gathered and analyzed for a wildcard or perfect match.
* Depending on the match result: if hit, emit  only the member part or emit the deferred class name.
