### PR TITLE
Allow TypeNames to be annotated twice

### DIFF
--- a/src/main/java/com/squareup/javapoet/ArrayTypeName.java
+++ b/src/main/java/com/squareup/javapoet/ArrayTypeName.java
@@ -41,7 +41,7 @@ public final class ArrayTypeName extends TypeName {
   }
 
   @Override public ArrayTypeName annotated(List<AnnotationSpec> annotations) {
-    return new ArrayTypeName(componentType, annotations);
+    return new ArrayTypeName(componentType, prependAnnotations(annotations));
   }
 
   @Override CodeWriter emit(CodeWriter out) throws IOException {

--- a/src/main/java/com/squareup/javapoet/ClassName.java
+++ b/src/main/java/com/squareup/javapoet/ClassName.java
@@ -55,7 +55,7 @@ public final class ClassName extends TypeName implements Comparable<ClassName> {
   }
 
   @Override public ClassName annotated(List<AnnotationSpec> annotations) {
-    return new ClassName(names, annotations);
+    return new ClassName(names, prependAnnotations(annotations));
   }
 
   /** Returns the package name, like {@code "java.util"} for {@code Map.Entry}. */

--- a/src/main/java/com/squareup/javapoet/ParameterizedTypeName.java
+++ b/src/main/java/com/squareup/javapoet/ParameterizedTypeName.java
@@ -49,7 +49,7 @@ public final class ParameterizedTypeName extends TypeName {
   }
 
   @Override public ParameterizedTypeName annotated(List<AnnotationSpec> annotations) {
-    return new ParameterizedTypeName(rawType, typeArguments, annotations);
+    return new ParameterizedTypeName(rawType, typeArguments, prependAnnotations(annotations));
   }
 
   @Override CodeWriter emit(CodeWriter out) throws IOException {

--- a/src/main/java/com/squareup/javapoet/TypeName.java
+++ b/src/main/java/com/squareup/javapoet/TypeName.java
@@ -110,7 +110,13 @@ public class TypeName {
 
   public TypeName annotated(List<AnnotationSpec> annotations) {
     Util.checkNotNull(annotations, "annotations == null");
-    return new TypeName(keyword, annotations);
+    return new TypeName(keyword, prependAnnotations(annotations));
+  }
+
+  protected final List<AnnotationSpec> prependAnnotations(List<AnnotationSpec> annotations) {
+    List<AnnotationSpec> allAnnotations = new ArrayList<>(annotations);
+    allAnnotations.addAll(this.annotations);
+    return allAnnotations;
   }
 
   public boolean isAnnotated() {

--- a/src/main/java/com/squareup/javapoet/WildcardTypeName.java
+++ b/src/main/java/com/squareup/javapoet/WildcardTypeName.java
@@ -55,7 +55,7 @@ public final class WildcardTypeName extends TypeName {
   }
 
   @Override public WildcardTypeName annotated(List<AnnotationSpec> annotations) {
-    return new WildcardTypeName(upperBounds, lowerBounds, annotations);
+    return new WildcardTypeName(upperBounds, lowerBounds, prependAnnotations(annotations));
   }
 
   @Override CodeWriter emit(CodeWriter out) throws IOException {

--- a/src/test/java/com/squareup/javapoet/AnnotatedTypeNameTest.java
+++ b/src/test/java/com/squareup/javapoet/AnnotatedTypeNameTest.java
@@ -44,14 +44,23 @@ public class AnnotatedTypeNameTest {
     assertEquals(simpleString, TypeName.get(String.class));
     TypeName annotated = simpleString.annotated(NEVER_NULL);
     assertTrue(annotated.isAnnotated());
-    assertEquals(simpleString, annotated.annotated());
-    assertFalse(annotated.annotated().isAnnotated());
+    assertEquals(annotated, annotated.annotated());
   }
 
   @Test public void annotatedType() {
     String expected = "@" + NN + " java.lang.String";
     TypeName type = TypeName.get(String.class);
     String actual = type.annotated(NEVER_NULL).toString();
+    assertEquals(expected, actual);
+  }
+
+  @Test public void annotatedTwice() {
+    String expected = "@java.lang.Override @" + NN + " java.lang.String";
+    TypeName type = TypeName.get(String.class);
+    String actual =
+        type.annotated(NEVER_NULL)
+            .annotated(AnnotationSpec.builder(Override.class).build())
+            .toString();
     assertEquals(expected, actual);
   }
 


### PR DESCRIPTION
I don't love that this requires each `TypeName` subclass needs to remember to combine the old and new annotations, but I don't see a good way to enforce that since `TypeName#annotated(List<AnnotationSpec>)` needs to be overridable to be able to return the right type. Open to suggestions.

One of the tests assumed that calling `annotatedTypeName.annotated()` would clear this test - I'm not sure if anyone relies on that functionality, but that would be a breaking change. I could add a `clearAnnotations()` method if you'd like.