### PR TITLE
ClassName.canonical and TypeName.binary()

### DIFF
--- a/src/main/java/com/squareup/javapoet/ClassName.java
+++ b/src/main/java/com/squareup/javapoet/ClassName.java
@@ -37,7 +37,8 @@ public final class ClassName extends TypeName implements Comparable<ClassName> {
 
   /** From top to bottom. This will be ["java.util", "Map", "Entry"] for {@link Map.Entry}. */
   final List<String> names;
-  final String canonicalName;
+  /** @see Class#getCanonicalName() */
+  public final String canonicalName;
 
   private ClassName(List<String> names) {
     this(names, new ArrayList<AnnotationSpec>());
@@ -49,7 +50,7 @@ public final class ClassName extends TypeName implements Comparable<ClassName> {
       checkArgument(SourceVersion.isName(names.get(i)), "part '%s' is keyword", names.get(i));
     }
     this.names = Util.immutableList(names);
-    this.canonicalName = names.get(0).isEmpty()
+    this.canonicalName = packageName().isEmpty()
         ? Util.join(".", names.subList(1, names.size()))
         : Util.join(".", names);
   }

--- a/src/main/java/com/squareup/javapoet/TypeName.java
+++ b/src/main/java/com/squareup/javapoet/TypeName.java
@@ -34,6 +34,7 @@ import javax.lang.model.type.NoType;
 import javax.lang.model.type.PrimitiveType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.Elements;
 import javax.lang.model.util.SimpleTypeVisitor7;
 
 /**
@@ -166,6 +167,10 @@ public class TypeName {
     if (this.equals(BOXED_FLOAT)) return FLOAT;
     if (this.equals(BOXED_DOUBLE)) return DOUBLE;
     throw new UnsupportedOperationException("cannot unbox " + this);
+  }
+
+  public final TypeMirror toTypeMirror(Elements elements) {
+    return elements.getTypeElement(toString()).asType();
   }
 
   @Override public final boolean equals(Object o) {

--- a/src/test/java/com/squareup/javapoet/TypeNameTest.java
+++ b/src/test/java/com/squareup/javapoet/TypeNameTest.java
@@ -21,10 +21,10 @@ import static org.junit.Assert.assertNotEquals;
 
 import java.io.Serializable;
 import java.lang.reflect.Method;
-import java.rmi.server.UID;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 import org.junit.Test;
 
 public class TypeNameTest {
@@ -70,8 +70,8 @@ public class TypeNameTest {
   @Test public void equalsAndHashCodeParameterizedTypeName() {
     assertEqualsHashCodeAndToString(ParameterizedTypeName.get(Object.class),
         ParameterizedTypeName.get(Object.class));
-    assertEqualsHashCodeAndToString(ParameterizedTypeName.get(Set.class, UID.class),
-        ParameterizedTypeName.get(Set.class, UID.class));
+    assertEqualsHashCodeAndToString(ParameterizedTypeName.get(Set.class, UUID.class),
+        ParameterizedTypeName.get(Set.class, UUID.class));
     assertNotEquals(ClassName.get(List.class), ParameterizedTypeName.get(List.class,
         String.class));
   }
@@ -98,5 +98,4 @@ public class TypeNameTest {
     assertThat(a.equals(b)).isTrue();
     assertThat(a.hashCode()).isEqualTo(b.hashCode());
   }
-
 }

--- a/src/test/java/com/squareup/javapoet/TypeSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/TypeSpecTest.java
@@ -2168,4 +2168,14 @@ public final class TypeSpecTest {
     assertThat(TypeSpec.enumBuilder(className).addEnumConstant("A").build().name).isEqualTo("Example");
     assertThat(TypeSpec.annotationBuilder(className).build().name).isEqualTo("Example");
   }
+
+  @Test public void toTypeMirror() {
+    TypeName typeName = ClassName.get("java.lang", "String");
+    String expected = "java.lang.String";
+    assertThat(typeName.toTypeMirror(compilation.getElements()).toString()).isEqualTo(expected);
+    // typeName = ParameterizedTypeName.get(Set.class, String.class);
+    // expected = "java.util.Set<java.lang.String>";
+    // assertThat(typeName.toTypeMirror(compilation.getElements()).toString()).isEqualTo(expected);
+    // NPE in typeName.toTypeMirror() ...
+  }
 }


### PR DESCRIPTION
 * Published immutable `ClassName.canonicalName` and `ClassName.binaryName` fields.
 * Made `TypeName` report its binary name, which can be used in `Class.forName(className)` calls.

The test looks like:
```java
assertEquals("void", TypeName.VOID.binary());
assertEquals("int", TypeName.INT.binary());
assertEquals("java.lang.Object", TypeName.OBJECT.binary());
assertEquals("java.lang.Thread$State", TypeName.get(Thread.State.class).binary());
assertEquals("[java.util.Map$Entry;", TypeName.get(Map.Entry[].class).binary());
assertEquals("[[[Z", TypeName.get(boolean[][][].class).binary());
assertEquals("java.util.List", ParameterizedTypeName.get(List.class, String.class).binary());
assertEquals("java.util.Set", ParameterizedTypeName.get(Set.class, UUID.class).binary());
```

* `TypeVariableName.binary()` and `WildcardTypeName.binary()` ~~should~~ throw `UnsupportedOperationException`!