### PR TITLE
Fixes location for type annotation on qualified names.

### DIFF
--- a/src/main/java/com/squareup/javapoet/ClassName.java
+++ b/src/main/java/com/squareup/javapoet/ClassName.java
@@ -209,4 +209,22 @@ public final class ClassName extends TypeName implements Comparable<ClassName> {
   @Override CodeWriter emit(CodeWriter out) throws IOException {
     return out.emitAndIndent(out.lookupName(this));
   }
+
+  void toString(CodeWriter out) {
+    try {
+      String lookedupName = out.lookupName(this);
+      ClassName enclosingClassName = enclosingClassName();
+      if (canonicalName.equals(lookedupName) && enclosingClassName != null) {
+        enclosingClassName.emit(out);
+        out.emit(".");
+        emitAnnotations(out);
+        out.emit(simpleName());
+      } else {
+        emitAnnotations(out);
+        out.emitAndIndent(lookedupName);
+      }
+    } catch (IOException e) {
+      throw new AssertionError();
+    }
+  }
 }

--- a/src/main/java/com/squareup/javapoet/ParameterizedTypeName.java
+++ b/src/main/java/com/squareup/javapoet/ParameterizedTypeName.java
@@ -57,8 +57,17 @@ public final class ParameterizedTypeName extends TypeName {
   }
 
   @Override CodeWriter emit(CodeWriter out) throws IOException {
-    rawType.emitAnnotations(out);
-    rawType.emit(out);
+    String lookedupName = out.lookupName(rawType);
+    ClassName enclosingClassName = rawType.enclosingClassName();
+    if (rawType.canonicalName.equals(lookedupName) && enclosingClassName != null) {
+      enclosingClassName.emit(out);
+      out.emit(".");
+      emitAnnotations(out);
+      out.emit(rawType.simpleName());
+    } else {
+      emitAnnotations(out);
+      out.emitAndIndent(lookedupName);
+    }
     out.emitAndIndent("<");
     boolean firstParameter = true;
     for (TypeName parameter : typeArguments) {
@@ -68,6 +77,11 @@ public final class ParameterizedTypeName extends TypeName {
       firstParameter = false;
     }
     return out.emitAndIndent(">");
+  }
+
+  @Override void toString(CodeWriter out) throws IOException {
+    // annotations are handled by emit(out), see #431
+    emit(out);
   }
 
   /** Returns a parameterized type, applying {@code typeArguments} to {@code rawType}. */

--- a/src/main/java/com/squareup/javapoet/TypeName.java
+++ b/src/main/java/com/squareup/javapoet/TypeName.java
@@ -183,12 +183,16 @@ public class TypeName {
     try {
       StringBuilder result = new StringBuilder();
       CodeWriter codeWriter = new CodeWriter(result);
-      emitAnnotations(codeWriter);
-      emit(codeWriter);
+      toString(codeWriter);
       return result.toString();
     } catch (IOException e) {
       throw new AssertionError();
     }
+  }
+
+  void toString(CodeWriter out) throws IOException {
+    emitAnnotations(out);
+    emit(out);
   }
 
   CodeWriter emit(CodeWriter out) throws IOException {

--- a/src/test/java/com/squareup/javapoet/JavaFileTest.java
+++ b/src/test/java/com/squareup/javapoet/JavaFileTest.java
@@ -17,6 +17,7 @@ package com.squareup.javapoet;
 
 import java.util.Collections;
 import java.util.Date;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.lang.model.element.Modifier;
 import org.junit.Ignore;
@@ -24,6 +25,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import com.squareup.javapoet.AnnotatedTypeNameTest.TypeUseAnnotation;
 import static com.google.common.truth.Truth.assertThat;
 
 @RunWith(JUnit4.class)
@@ -486,6 +488,34 @@ public final class JavaFileTest {
         + "  @Component.Builder\n"
         + "  class Builder {\n"
         + "  }\n"
+        + "}\n");
+  }
+
+  // https://github.com/square/javapoet/issues/431
+  @Test public void annotatedNestedTypeInJavaFileWithImports() {
+    AnnotationSpec typeUseAnnotation = AnnotationSpec.builder(TypeUseAnnotation.class).build();
+    TypeName type = ParameterizedTypeName.get(Map.Entry.class, Byte.class, Byte.class) 
+        .annotated(typeUseAnnotation);
+    String source = JavaFile.builder("com.squareup.tacos",
+        TypeSpec.classBuilder("TestTypeAnnotationsOnQualifiedTypeNames")
+            .addField(type, "entry")
+            .addStaticBlock(CodeBlock.of("$T local;\n", type))
+            .build())
+        .build()
+        .toString();
+    assertThat(source).isEqualTo(""
+        + "package com.squareup.tacos;\n"
+        + "\n"
+        + "import com.squareup.javapoet.AnnotatedTypeNameTest;\n"
+        + "import java.lang.Byte;\n"
+        + "import java.util.Map;\n"
+        + "\n"
+        + "class TestTypeAnnotationsOnQualifiedTypeNames {\n"
+        + "  static {\n"
+        + "    @AnnotatedTypeNameTest.TypeUseAnnotation Map.Entry<Byte, Byte> local;\n"
+        + "  }\n"
+        + "\n"
+        + "  @AnnotatedTypeNameTest.TypeUseAnnotation Map.Entry<Byte, Byte> entry;\n"
         + "}\n");
   }
 


### PR DESCRIPTION
https://github.com/square/javapoet/issues/431

This solution overrides the `TypeName.toString()` in `ClassName` and `ParameterizedTypeName` - had to remove the final modifier from the former.