### PR TITLE
JavaFile.skipImportsEntirely switch added.

### DIFF
--- a/src/test/java/com/squareup/javapoet/JavaFileTest.java
+++ b/src/test/java/com/squareup/javapoet/JavaFileTest.java
@@ -573,4 +573,20 @@ public final class JavaFileTest {
         + "  }\n"
         + "}\n");
   }
+
+  @Test public void skipImportsEntirely() {
+    assertThat(JavaFile.builder("readme", importStaticTypeSpec("Util"))
+        .addStaticImport(TimeUnit.SECONDS)
+        .skipImportsEntirely(true)
+        .build().toString()).isEqualTo(""
+        + "package readme;\n"
+        + "\n"
+        + "class Util {\n"
+        + "  public static long minutesToSeconds(long minutes) {\n"
+        + "    java.lang.System.gc();\n"
+        + "    return java.util.concurrent.TimeUnit.SECONDS.convert(minutes,"
+        + " java.util.concurrent.TimeUnit.MINUTES);\n"
+        + "  }\n"
+        + "}\n");
+  }
 }


### PR DESCRIPTION
Reasoning for having `JavaFile.skipImportsEntirely` switch:
- if there ever was an error in the internal import logic, the user could fall back to fully qualified type names immediatly, w/o having to wait for bug fix.
- eases testing the fix for #431 ...