### PR TITLE
Simple fix for annotated qualified type names 1

### DIFF
--- a/src/main/java/com/squareup/javapoet/ClassName.java
+++ b/src/main/java/com/squareup/javapoet/ClassName.java
@@ -209,4 +209,20 @@ public final class ClassName extends TypeName implements Comparable<ClassName> {
   @Override CodeWriter emit(CodeWriter out) throws IOException {
     return out.emitAndIndent(out.lookupName(this));
   }
+
+  @Override CodeWriter toString(CodeWriter out, Iterable<AnnotationSpec> annos) throws IOException {
+    // trivial case: no enclosing name available
+    ClassName enclosingClassName = enclosingClassName();
+    if (enclosingClassName == null) {
+      return super.toString(out, annos);
+    }
+    // trivial case: import logic mangled the fully qualified class name
+    String lookedupName = out.lookupName(this);
+    if (!lookedupName.equals(canonicalName)) {
+      return super.toString(out, annos);
+    }
+    // "pack.age.name.Outer.Inner...@TA InnerMost"
+    enclosingClassName.emit(out).emit(".");
+    return emitAnnotations(out, annos).emit(simpleName());
+  }
 }

--- a/src/main/java/com/squareup/javapoet/ParameterizedTypeName.java
+++ b/src/main/java/com/squareup/javapoet/ParameterizedTypeName.java
@@ -57,17 +57,20 @@ public final class ParameterizedTypeName extends TypeName {
   }
 
   @Override CodeWriter emit(CodeWriter out) throws IOException {
-    rawType.emitAnnotations(out);
-    rawType.emit(out);
+    rawType.toString(out, annotations); // awkward: use our annotations with the raw type...
     out.emitAndIndent("<");
     boolean firstParameter = true;
     for (TypeName parameter : typeArguments) {
       if (!firstParameter) out.emitAndIndent(", ");
-      parameter.emitAnnotations(out);
-      parameter.emit(out);
+      parameter.toString(out, parameter.annotations);
       firstParameter = false;
     }
     return out.emitAndIndent(">");
+  }
+
+  @Override CodeWriter toString(CodeWriter out, Iterable<AnnotationSpec> annos) throws IOException {
+    // annotations are handled by emit(out), see #431
+    return emit(out);
   }
 
   /** Returns a parameterized type, applying {@code typeArguments} to {@code rawType}. */

--- a/src/main/java/com/squareup/javapoet/TypeName.java
+++ b/src/main/java/com/squareup/javapoet/TypeName.java
@@ -183,12 +183,16 @@ public class TypeName {
     try {
       StringBuilder result = new StringBuilder();
       CodeWriter codeWriter = new CodeWriter(result);
-      emitAnnotations(codeWriter);
-      emit(codeWriter);
+      toString(codeWriter, annotations);
       return result.toString();
     } catch (IOException e) {
       throw new AssertionError();
     }
+  }
+
+  CodeWriter toString(CodeWriter out, Iterable<AnnotationSpec> annos) throws IOException {
+    emitAnnotations(out, annos);
+    return emit(out);
   }
 
   CodeWriter emit(CodeWriter out) throws IOException {
@@ -197,7 +201,11 @@ public class TypeName {
   }
 
   CodeWriter emitAnnotations(CodeWriter out) throws IOException {
-    for (AnnotationSpec annotation : annotations) {
+    return emitAnnotations(out, annotations);
+  }
+
+  CodeWriter emitAnnotations(CodeWriter out, Iterable<AnnotationSpec> specs) throws IOException {
+    for (AnnotationSpec annotation : specs) {
       annotation.emit(out, true);
       out.emit(" ");
     }

--- a/src/test/java/com/squareup/javapoet/AnnotatedTypeNameTest.java
+++ b/src/test/java/com/squareup/javapoet/AnnotatedTypeNameTest.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 import java.util.Map;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class AnnotatedTypeNameTest {
@@ -118,8 +117,7 @@ public class AnnotatedTypeNameTest {
   // @Target(ElementType.TYPE_USE) requires Java 1.8
   public @interface TypeUseAnnotation {}
 
-  // https://github.com/square/javapoet/issues/431
-  @Ignore @Test public void annotatedNestedType() {
+  @Test public void annotatedNestedType() {
     String expected = "java.util.Map.@" + TypeUseAnnotation.class.getCanonicalName() + " Entry";
     AnnotationSpec typeUseAnnotation = AnnotationSpec.builder(TypeUseAnnotation.class).build();
     TypeName type = TypeName.get(Map.Entry.class).annotated(typeUseAnnotation);
@@ -127,8 +125,7 @@ public class AnnotatedTypeNameTest {
     assertEquals(expected, actual);
   }
 
-  // https://github.com/square/javapoet/issues/431
-  @Ignore @Test public void annotatedNestedParameterizedType() {
+  @Test public void annotatedNestedParameterizedType() {
     String expected = "java.util.Map.@" + TypeUseAnnotation.class.getCanonicalName()
         + " Entry<java.lang.Byte, java.lang.Byte>";
     AnnotationSpec typeUseAnnotation = AnnotationSpec.builder(TypeUseAnnotation.class).build();


### PR DESCRIPTION
Caveat: `ParameterizedTypeName` _projects_ its annotations to the underlying rawtype. See _awkward_ comment at https://github.com/square/javapoet/compare/master...sormuras:annotations_on_qualified_names_fix?expand=1#diff-0286fc2b37521e485d3c5ef3c31fa073R60