### PR TITLE
Simple fix for annotated qualified type names

### DIFF
--- a/src/main/java/com/squareup/javapoet/ClassName.java
+++ b/src/main/java/com/squareup/javapoet/ClassName.java
@@ -209,4 +209,22 @@ public final class ClassName extends TypeName implements Comparable<ClassName> {
   @Override CodeWriter emit(CodeWriter out) throws IOException {
     return out.emitAndIndent(out.lookupName(this));
   }
+
+  @Override CodeWriter toString(CodeWriter out) throws IOException {
+    // trivial case: import logic mangled the fully qualified class name
+    String lookedupName = out.lookupName(this);
+    if (!lookedupName.equals(canonicalName)) {
+      return super.toString(out);
+    }
+    ClassName enclosingClassName = enclosingClassName();
+    String packageName = packageName();
+    if (enclosingClassName != null) {
+      // "pack.age.name.Outer.Inner...@TA InnerMost"
+      enclosingClassName.emit(out).emit(".");
+    } else if (!packageName.isEmpty()) {
+      // "pack.age" + "." + "@TA Outer"
+      out.emit(packageName).emit(".");
+    }
+    return emitAnnotations(out).emit(simpleName());
+  }
 }

--- a/src/main/java/com/squareup/javapoet/ParameterizedTypeName.java
+++ b/src/main/java/com/squareup/javapoet/ParameterizedTypeName.java
@@ -49,7 +49,8 @@ public final class ParameterizedTypeName extends TypeName {
   }
 
   @Override public ParameterizedTypeName annotated(List<AnnotationSpec> annotations) {
-    return new ParameterizedTypeName(rawType, typeArguments, concatAnnotations(annotations));
+    ClassName annotatedRawType = rawType.annotated(annotations);
+    return new ParameterizedTypeName(annotatedRawType, typeArguments);
   }
 
   @Override public TypeName withoutAnnotations() {
@@ -57,17 +58,20 @@ public final class ParameterizedTypeName extends TypeName {
   }
 
   @Override CodeWriter emit(CodeWriter out) throws IOException {
-    rawType.emitAnnotations(out);
-    rawType.emit(out);
+    rawType.toString(out);
     out.emitAndIndent("<");
     boolean firstParameter = true;
     for (TypeName parameter : typeArguments) {
       if (!firstParameter) out.emitAndIndent(", ");
-      parameter.emitAnnotations(out);
-      parameter.emit(out);
+      parameter.toString(out);
       firstParameter = false;
     }
     return out.emitAndIndent(">");
+  }
+
+  @Override CodeWriter toString(CodeWriter out) throws IOException {
+    // annotations are handled by emit(out), see #431
+    return emit(out);
   }
 
   /** Returns a parameterized type, applying {@code typeArguments} to {@code rawType}. */

--- a/src/main/java/com/squareup/javapoet/TypeName.java
+++ b/src/main/java/com/squareup/javapoet/TypeName.java
@@ -184,12 +184,16 @@ public class TypeName {
     try {
       StringBuilder result = new StringBuilder();
       CodeWriter codeWriter = new CodeWriter(result);
-      emitAnnotations(codeWriter);
-      emit(codeWriter);
+      toString(codeWriter);
       return result.toString();
     } catch (IOException e) {
       throw new AssertionError();
     }
+  }
+
+  CodeWriter toString(CodeWriter out) throws IOException {
+    emitAnnotations(out);
+    return emit(out);
   }
 
   CodeWriter emit(CodeWriter out) throws IOException {

--- a/src/test/java/com/squareup/javapoet/AnnotatedTypeNameTest.java
+++ b/src/test/java/com/squareup/javapoet/AnnotatedTypeNameTest.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 import java.util.Map;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class AnnotatedTypeNameTest {
@@ -50,14 +49,14 @@ public class AnnotatedTypeNameTest {
   }
 
   @Test public void annotatedType() {
-    String expected = "@" + NN + " java.lang.String";
+    String expected = "java.lang.@" + NN + " String";
     TypeName type = TypeName.get(String.class);
     String actual = type.annotated(NEVER_NULL).toString();
     assertEquals(expected, actual);
   }
 
   @Test public void annotatedTwice() {
-    String expected = "@" + NN + " @java.lang.Override java.lang.String";
+    String expected = "java.lang.@" + NN + " @java.lang.Override String";
     TypeName type = TypeName.get(String.class);
     String actual =
         type.annotated(NEVER_NULL)
@@ -67,14 +66,14 @@ public class AnnotatedTypeNameTest {
   }
 
   @Test public void annotatedParameterizedType() {
-    String expected = "@" + NN + " java.util.List<java.lang.String>";
+    String expected = "java.util.@" + NN + " List<java.lang.String>";
     TypeName type = ParameterizedTypeName.get(List.class, String.class);
     String actual = type.annotated(NEVER_NULL).toString();
     assertEquals(expected, actual);
   }
 
   @Test public void annotatedArgumentOfParameterizedType() {
-    String expected = "java.util.List<@" + NN + " java.lang.String>";
+    String expected = "java.util.List<java.lang.@" + NN + " String>";
     TypeName type = TypeName.get(String.class).annotated(NEVER_NULL);
     ClassName list = ClassName.get(List.class);
     String actual = ParameterizedTypeName.get(list, type).toString();
@@ -118,8 +117,7 @@ public class AnnotatedTypeNameTest {
   // @Target(ElementType.TYPE_USE) requires Java 1.8
   public @interface TypeUseAnnotation {}
 
-  // https://github.com/square/javapoet/issues/431
-  @Ignore @Test public void annotatedNestedType() {
+  @Test public void annotatedNestedType() {
     String expected = "java.util.Map.@" + TypeUseAnnotation.class.getCanonicalName() + " Entry";
     AnnotationSpec typeUseAnnotation = AnnotationSpec.builder(TypeUseAnnotation.class).build();
     TypeName type = TypeName.get(Map.Entry.class).annotated(typeUseAnnotation);
@@ -127,13 +125,23 @@ public class AnnotatedTypeNameTest {
     assertEquals(expected, actual);
   }
 
-  // https://github.com/square/javapoet/issues/431
-  @Ignore @Test public void annotatedNestedParameterizedType() {
+  @Test public void annotatedNestedParameterizedType() {
     String expected = "java.util.Map.@" + TypeUseAnnotation.class.getCanonicalName()
         + " Entry<java.lang.Byte, java.lang.Byte>";
     AnnotationSpec typeUseAnnotation = AnnotationSpec.builder(TypeUseAnnotation.class).build();
     TypeName type = ParameterizedTypeName.get(Map.Entry.class, Byte.class, Byte.class)
         .annotated(typeUseAnnotation);
+    String actual = type.toString();
+    assertEquals(expected, actual);
+  }
+
+  @Test public void annotatedNestedParameterizedTypeExplicite() {
+    String a = TypeUseAnnotation.class.getCanonicalName();
+    String expected = "java.util.Map.@" + a + " Entry<java.lang.@" + a + " Byte, java.lang.Byte>";
+    AnnotationSpec typeUseAnnotation = AnnotationSpec.builder(TypeUseAnnotation.class).build();
+    ClassName raw = (ClassName) ClassName.get(Map.Entry.class).annotated(typeUseAnnotation);
+    TypeName annotatedByte = TypeName.BYTE.box().annotated(typeUseAnnotation); 
+    TypeName type = ParameterizedTypeName.get(raw, annotatedByte, TypeName.BYTE.box());
     String actual = type.toString();
     assertEquals(expected, actual);
   }


### PR DESCRIPTION
This PR changes the behaviour of annotating a `ParameterizedTypeName`: the annotations passed are collected by the underlying raw type. See https://github.com/square/javapoet/compare/master...sormuras:type_annotations_fix2?expand=1#diff-0286fc2b37521e485d3c5ef3c31fa073R52