### PR TITLE
make JavaFile#writeTo(Filer) thread-safe

### DIFF
--- a/src/main/java/com/squareup/javapoet/JavaFile.java
+++ b/src/main/java/com/squareup/javapoet/JavaFile.java
@@ -104,14 +104,20 @@ public final class JavaFile {
     writeTo(directory.toPath());
   }
 
-  /** Writes this to {@code filer}. */
-  public void writeTo(Filer filer) throws IOException {
-    String fileName = packageName.isEmpty()
+  private JavaFileObject createFilerSourceFile(Filer filer) throws IOException {
+    String fqName = packageName.isEmpty()
         ? typeSpec.name
         : packageName + "." + typeSpec.name;
     List<Element> originatingElements = typeSpec.originatingElements;
-    JavaFileObject filerSourceFile = filer.createSourceFile(fileName,
-        originatingElements.toArray(new Element[originatingElements.size()]));
+    synchronized (JavaFile.class) {
+      return filer.createSourceFile(fqName,
+              originatingElements.toArray(new Element[originatingElements.size()]));
+    }
+  }
+
+  /** Writes this to {@code filer}. */
+  public void writeTo(Filer filer) throws IOException {
+    JavaFileObject filerSourceFile = createFilerSourceFile(filer);
     try (Writer writer = filerSourceFile.openWriter()) {
       writeTo(writer);
     } catch (Exception e) {


### PR DESCRIPTION
Parallel execution for `JavaPoet#writeTo(Filer)` makes annotation processing faster, but unfortunately `JavaFile#writeTo(Filer)` is not thread safe because `Filer#createSourceFile()` isn't.

This pull-request makes `JavaFile#writeTo(Filer)` thread-safe to synchronize calls of `Filer#createSourceFile()`.

NOTE: testing this PR is difficult, but I' made sure it works on my annotation processing library: https://github.com/gfx/Android-Orma/pull/230