### PR TITLE
add TypeName#unboxIfPossible()

### DIFF
--- a/src/main/java/com/squareup/javapoet/TypeName.java
+++ b/src/main/java/com/squareup/javapoet/TypeName.java
@@ -156,6 +156,20 @@ public class TypeName {
    * @throws UnsupportedOperationException if this type isn't eligible for unboxing.
    */
   public TypeName unbox() {
+    TypeName unboxed = unboxIfPossible();
+    if (keyword != null || this != unboxed) {
+      return unboxed;
+    } else {
+      throw new UnsupportedOperationException("cannot unbox " + this);
+    }
+  }
+
+  /**
+   * Returns an unboxed type if this is a boxed primitive type (like {@code int} for {@code
+   * Integer}) or {@code Void}. Returns this type if it is already unboxed. Otherwise returns
+   * this as is.
+   */
+  public TypeName unboxIfPossible() {
     if (keyword != null) return this; // Already unboxed.
     if (this.equals(BOXED_VOID)) return VOID;
     if (this.equals(BOXED_BOOLEAN)) return BOOLEAN;
@@ -166,7 +180,7 @@ public class TypeName {
     if (this.equals(BOXED_CHAR)) return CHAR;
     if (this.equals(BOXED_FLOAT)) return FLOAT;
     if (this.equals(BOXED_DOUBLE)) return DOUBLE;
-    throw new UnsupportedOperationException("cannot unbox " + this);
+    return this;
   }
 
   @Override public final boolean equals(Object o) {

--- a/src/test/java/com/squareup/javapoet/AbstractTypesTest.java
+++ b/src/test/java/com/squareup/javapoet/AbstractTypesTest.java
@@ -246,6 +246,15 @@ public abstract class AbstractTypesTest {
     }
   }
 
+  @Test public void unboxIfPossible() throws Exception {
+    assertThat(TypeName.INT).isEqualTo(TypeName.INT.unbox());
+    assertThat(TypeName.VOID).isEqualTo(TypeName.VOID.unbox());
+    assertThat(ClassName.get(Integer.class).unbox()).isEqualTo(TypeName.INT.unbox());
+    assertThat(ClassName.get(Void.class).unbox()).isEqualTo(TypeName.VOID.unbox());
+    assertThat(TypeName.OBJECT.unboxIfPossible()).isEqualTo(TypeName.OBJECT);
+    assertThat(ClassName.get(String.class)).isEqualTo(ClassName.get(String.class));
+  }
+
   private static class DeclaredTypeAsErrorType implements ErrorType {
     private final DeclaredType declaredType;
 


### PR DESCRIPTION
Sometimes I need an `unbox()` variation that doesn't throw UnsupportedOperationException. Here is an example: https://github.com/gfx/Android-Orma/blob/v2.3.5/processor/src/main/java/com/github/gfx/android/orma/processor/util/Types.java#L241-L263

I think it is a common need so I make this pull-request. Can you review it please?