### PR TITLE
CodeBlock: add support for character literals with $C

### DIFF
--- a/src/main/java/com/squareup/javapoet/CodeBlock.java
+++ b/src/main/java/com/squareup/javapoet/CodeBlock.java
@@ -42,6 +42,8 @@ import static com.squareup.javapoet.Util.checkArgument;
  *       for names may be strings (actually any {@linkplain CharSequence character sequence}),
  *       {@linkplain ParameterSpec parameters}, {@linkplain FieldSpec fields}, {@linkplain
  *       MethodSpec methods}, and {@linkplain TypeSpec types}.
+ *   <li>{@code $C} escapes the value as a <em>character</em>, wraps it with single quotes, and
+ *       emits that. Arguments for characters must be {@linkplain Character characters}.
  *   <li>{@code $S} escapes the value as a <em>string</em>, wraps it with double quotes, and emits
  *       that. For example, {@code 6" sandwich} is emitted {@code "6\" sandwich"}.
  *   <li>{@code $T} emits a <em>type</em> reference. Types will be imported if possible. Arguments
@@ -169,6 +171,9 @@ public final class CodeBlock {
           case 'L':
             this.args.add(argToLiteral(args[index]));
             break;
+          case 'C':
+            this.args.add(argToCharacter(args[index]));
+            break;
           case 'S':
             this.args.add(argToString(args[index]));
             break;
@@ -211,6 +216,16 @@ public final class CodeBlock {
 
     private Object argToLiteral(Object o) {
       return o;
+    }
+
+    private Character argToCharacter(Object o) {
+      Character character;
+      try {
+        character = (Character) o;
+      } catch (ClassCastException e) {
+        throw new IllegalArgumentException("expected character but was " + o, e);
+      }
+      return character;
     }
 
     private String argToString(Object o) {

--- a/src/main/java/com/squareup/javapoet/CodeWriter.java
+++ b/src/main/java/com/squareup/javapoet/CodeWriter.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Modifier;
 
+import static com.squareup.javapoet.Util.characterLiteralWithoutSingleQuotes;
 import static com.squareup.javapoet.Util.checkArgument;
 import static com.squareup.javapoet.Util.checkNotNull;
 import static com.squareup.javapoet.Util.checkState;
@@ -219,6 +220,11 @@ final class CodeWriter {
 
         case "$N":
           emitAndIndent((String) codeBlock.args.get(a++));
+          break;
+
+        case "$C":
+          Character character = (Character) codeBlock.args.get(a++);
+          emitAndIndent(String.format("'%s'", characterLiteralWithoutSingleQuotes(character)));
           break;
 
         case "$S":

--- a/src/test/java/com/squareup/javapoet/CodeBlockTest.java
+++ b/src/test/java/com/squareup/javapoet/CodeBlockTest.java
@@ -91,6 +91,11 @@ public final class CodeBlockTest {
     CodeBlock block = CodeBlock.builder().add("$1L", "taco").build();
     assertThat(block.toString()).isEqualTo("taco");
   }
+
+  @Test public void characterFormatCanBeIndexed() {
+    CodeBlock block = CodeBlock.builder().add("$1C", 't').build();
+    assertThat(block.toString()).isEqualTo("'t'");
+  }
   
   @Test public void stringFormatCanBeIndexed() {
     CodeBlock block = CodeBlock.builder().add("$1S", "taco").build();


### PR DESCRIPTION
Character literals are escaped and wrapped in single quotes.
The CodeBlock documentation is updated.

An argument is a character only if it can be casted to
Character, otherwise an IllegalArgumentException is
thrown wrapping the ClassCastException for more information.

In case this PR is merged README should be updated after 
release with a $C for Characters section.