### PR TITLE
fix dependency versions to test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,8 +22,8 @@
 
     <java.version>1.7</java.version>
     <junit.version>4.12</junit.version>
-    <truth.version>0.25</truth.version>
-    <compile-testing.version>0.6</compile-testing.version>
+    <truth.version>0.28</truth.version>
+    <compile-testing.version>0.9</compile-testing.version>
   </properties>
 
   <scm>
@@ -54,13 +54,13 @@
     <dependency>
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
-      <version>1.0-SNAPSHOT</version>
+      <version>${truth.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.testing.compile</groupId>
       <artifactId>compile-testing</artifactId>
-      <version>1.0-SNAPSHOT</version>
+      <version>${compile-testing.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
I couldn't build the head of JavaPoet with truth 1.0-SNAPSHOT and compile-testing 1.0-SNAPSHOT.