### PR TITLE
Optimizations for TypeName#toString() and CodeWriter#emit(String)

### DIFF
--- a/src/main/java/com/squareup/javapoet/CodeWriter.java
+++ b/src/main/java/com/squareup/javapoet/CodeWriter.java
@@ -202,6 +202,10 @@ final class CodeWriter {
     emit(">");
   }
 
+  public CodeWriter emit(String s) throws IOException {
+    return emitAndIndent(s);
+  }
+
   public CodeWriter emit(String format, Object... args) throws IOException {
     return emit(CodeBlock.of(format, args));
   }

--- a/src/main/java/com/squareup/javapoet/TypeName.java
+++ b/src/main/java/com/squareup/javapoet/TypeName.java
@@ -90,6 +90,8 @@ public class TypeName {
   private final String keyword;
   public final List<AnnotationSpec> annotations;
 
+  private String cachedString;
+
   private TypeName(String keyword) {
     this(keyword, new ArrayList<AnnotationSpec>());
   }
@@ -200,12 +202,14 @@ public class TypeName {
   }
 
   @Override public final String toString() {
+    if (cachedString != null) return cachedString;
     try {
       StringBuilder result = new StringBuilder();
       CodeWriter codeWriter = new CodeWriter(result);
       emitAnnotations(codeWriter);
       emit(codeWriter);
-      return result.toString();
+      cachedString = result.toString();
+      return cachedString;
     } catch (IOException e) {
       throw new AssertionError();
     }


### PR DESCRIPTION
This PR includes optimizations for bottlenecks: `TypeName#toString()` and `CodeWriter#emit(String)`
Especially `TypeName#toString()` is related to `#equals()` and `#hashCode()`, meaning `TypeName` becomes suitable for `HashMap` keys.

## Benchmark

Given the following code:

```java
package com.squareup.javapoet;
import org.junit.Before;
import org.junit.Test;
import javax.lang.model.element.Modifier;
import java.util.Collections;
import static com.google.common.truth.Truth.assertThat;
public class PerformanceTest {
    JavaFile javaFile;
    @Before
    public void setUp() throws Exception {
        ClassName hoverboard = ClassName.get("com.mattel", "Hoverboard");
        ClassName namedBoards = ClassName.get("com.mattel", "Hoverboard", "Boards");
        ClassName list = ClassName.get("java.util", "List");
        ClassName arrayList = ClassName.get("java.util", "ArrayList");
        TypeName listOfHoverboards = ParameterizedTypeName.get(list, hoverboard);
        MethodSpec beyond = MethodSpec.methodBuilder("beyond")
                .returns(listOfHoverboards)
                .addStatement("$T result = new $T<>()", listOfHoverboards, arrayList)
                .addStatement("result.add($T.createNimbus(2000))", hoverboard)
                .addStatement("result.add($T.createNimbus(\"2001\"))", hoverboard)
                .addStatement("result.add($T.createNimbus($T.THUNDERBOLT))", hoverboard, namedBoards)
                .addStatement("$T.sort(result)", Collections.class)
                .addStatement("return result.isEmpty() $T.emptyList() : result", Collections.class)
                .build();

        MethodSpec m = MethodSpec.methodBuilder("z")
                .returns(String.class)
                .addStatement("return $S", "Hello, world!")
                .addModifiers(Modifier.PUBLIC).build();
        TypeSpec hello = TypeSpec.classBuilder("HelloWorld")
                .addMethod(beyond)
                .addMethod(MethodSpec.methodBuilder("a")
                        .returns(String.class)
                        .addStatement("return $S", "Hello, world!")
                        .addModifiers(Modifier.PUBLIC).build())
                .addMethod(MethodSpec.methodBuilder("b")
                        .returns(String.class)
                        .addStatement("return $S", "Hello, world!")
                        .addModifiers(Modifier.PUBLIC).build())
                .addMethod(MethodSpec.methodBuilder("c")
                        .returns(String.class)
                        .addStatement("return $S", "Hello, world!")
                        .addModifiers(Modifier.PUBLIC).build())
                .addMethod(MethodSpec.methodBuilder("d")
                        .returns(String.class)
                        .addStatement("return $S", "Hello, world!")
                        .addModifiers(Modifier.PUBLIC).build())
                .addMethod(MethodSpec.methodBuilder("d")
                        .returns(String.class)
                        .addStatement("return $S", "Hello, world!")
                        .addModifiers(Modifier.PUBLIC).build())
                .addMethod(MethodSpec.methodBuilder("f")
                        .returns(String.class)
                        .addStatement("return $S", "Hello, world!")
                        .addModifiers(Modifier.PUBLIC).build())
                .addMethod(MethodSpec.methodBuilder("g")
                        .returns(String.class)
                        .addStatement("return $S", "Hello, world!")
                        .addModifiers(Modifier.PUBLIC).build())
                .addMethod(MethodSpec.methodBuilder("h")
                        .returns(String.class)
                        .addStatement("return $S", "Hello, world!")
                        .addModifiers(Modifier.PUBLIC).build())
                .addMethod(MethodSpec.methodBuilder("i")
                        .returns(String.class)
                        .addStatement("return $S", "Hello, world!")
                        .addModifiers(Modifier.PUBLIC).build())
                .addMethod(MethodSpec.methodBuilder("j")
                        .returns(String.class)
                        .addStatement("return $S", "Hello, world!")
                        .addModifiers(Modifier.PUBLIC).build())
                .build();
        javaFile = JavaFile.builder("com.example.helloworld", hello)
                .addStaticImport(hoverboard, "createNimbus")
                .addStaticImport(namedBoards, "*")
                .addStaticImport(Collections.class, "*")
                .build();
    }

    @Test
    public void importStaticReadmeExample() {
        long t0 = System.currentTimeMillis();
        for(int i = 0; i < 10000; i++) {
            @SuppressWarnings("unused") String s = javaFile.toString();
        }
        System.out.println(System.currentTimeMillis() - t0);

        t0 = System.currentTimeMillis();
        for(int i = 0; i < 10000; i++) {
            @SuppressWarnings("unused") String s = javaFile.toString();
        }
        System.out.println(System.currentTimeMillis() - t0);

        t0 = System.currentTimeMillis();
        for(int i = 0; i < 10000; i++) {
            @SuppressWarnings("unused") String s = javaFile.toString();
        }
        System.out.println(System.currentTimeMillis() - t0);
    }
}
```

In my environment, Macbook Air 2014, the result is something like this (unit: milliseconds):

`HEAD`:
3565
1264
1194

(1) TypeName#toString() cache 2660602 :
3424
1013
998

(2) CodeWriter#emit(String) cdc51fd :
3339
1003
1012

(1) + (2):
3009
1245
740

I think it is worth merging. What do you think of it?