### PR TITLE
Adding addPackageName method

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,7 @@
         <configuration>
           <source>${java.version}</source>
           <target>${java.version}</target>
+          <encoding>${project.build.sourceEncoding}</encoding>
         </configuration>
       </plugin>
 

--- a/src/main/java/com/squareup/javapoet/JavaFile.java
+++ b/src/main/java/com/squareup/javapoet/JavaFile.java
@@ -204,6 +204,11 @@ public final class JavaFile {
     return new Builder(packageName, typeSpec);
   }
 
+  public static Builder builder(TypeSpec typeSpec) {
+    checkNotNull(typeSpec, "typeSpec == null");
+    return new Builder(typeSpec);
+  }
+
   public Builder toBuilder() {
     Builder builder = new Builder(packageName, typeSpec);
     builder.fileComment.add(fileComment);
@@ -213,7 +218,7 @@ public final class JavaFile {
   }
 
   public static final class Builder {
-    private final String packageName;
+    private String packageName;
     private final TypeSpec typeSpec;
     private final CodeBlock.Builder fileComment = CodeBlock.builder();
     private final Set<String> staticImports = new TreeSet<>();
@@ -225,8 +230,18 @@ public final class JavaFile {
       this.typeSpec = typeSpec;
     }
 
+    private Builder(TypeSpec typeSpec) {
+      this.packageName = "";
+      this.typeSpec = typeSpec;
+    }
+
     public Builder addFileComment(String format, Object... args) {
       this.fileComment.add(format, args);
+      return this;
+    }
+
+    public Builder addPackageName(String packageName) {
+      this.packageName = packageName;
       return this;
     }
 

--- a/src/test/java/com/squareup/javapoet/JavaFileTest.java
+++ b/src/test/java/com/squareup/javapoet/JavaFileTest.java
@@ -511,6 +511,53 @@ public final class JavaFileTest {
         + "}\n");
   }
 
+  @Test public void noPackage() throws Exception {
+	    String source = JavaFile.builder(
+	        TypeSpec.classBuilder("HelloWorld")
+	            .addMethod(MethodSpec.methodBuilder("main")
+	                .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+	                .addParameter(String[].class, "args")
+	                .addCode("$T.out.println($S);\n", System.class, "Hello World!")
+	                .build())
+	            .build())
+	        .build()
+	        .toString();
+	    assertThat(source).isEqualTo(""
+	        + "import java.lang.String;\n"
+	        + "import java.lang.System;\n"
+	        + "\n"
+	        + "class HelloWorld {\n"
+	        + "  public static void main(String[] args) {\n"
+	        + "    System.out.println(\"Hello World!\");\n"
+	        + "  }\n"
+	        + "}\n");
+	  }
+
+  @Test public void addPackage() throws Exception {
+	    String source = JavaFile.builder(
+	        TypeSpec.classBuilder("HelloWorld")
+	            .addMethod(MethodSpec.methodBuilder("main")
+	                .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+	                .addParameter(String[].class, "args")
+	                .addCode("$T.out.println($S);\n", System.class, "Hello World!")
+	                .build())
+	            .build())
+	            .addPackageName("com.example.helloworld")	
+	        .build()
+	        .toString();
+	    assertThat(source).isEqualTo(""
+            + "package com.example.helloworld;\n"
+            + "\n"	    		
+	        + "import java.lang.String;\n"
+	        + "import java.lang.System;\n"
+	        + "\n"
+	        + "class HelloWorld {\n"
+	        + "  public static void main(String[] args) {\n"
+	        + "    System.out.println(\"Hello World!\");\n"
+	        + "  }\n"
+	        + "}\n");
+	  }
+
   @Test public void defaultPackageTypesAreNotImported() throws Exception {
     String source = JavaFile.builder("hello",
           TypeSpec.classBuilder("World").addSuperinterface(ClassName.get("", "Test")).build())


### PR DESCRIPTION
Adding addPackageName method and write the tests for this new method. Also adding the encoding on maven-compiler-plugin.

Now you can:

```java
JavaFile javaFile = JavaFile.builder("com.example.helloworld", helloWorld)
    .build();
```

Or:

```java
JavaFile javaFile = JavaFile.builder(helloWorld)
    .addPackageName("com.example.helloworld")
    .build();
```
