### PR TITLE
Fixed the name clash when implementing/extending classes

### DIFF
--- a/src/main/java/com/squareup/javapoet/TypeSpec.java
+++ b/src/main/java/com/squareup/javapoet/TypeSpec.java
@@ -149,6 +149,7 @@ public final class TypeSpec {
     codeWriter.statementLine = -1;
 
     try {
+      codeWriter.pushType(this);
       if (enumName != null) {
         codeWriter.emitJavadoc(javadoc);
         codeWriter.emitAnnotations(annotations, false);
@@ -213,7 +214,7 @@ public final class TypeSpec {
         codeWriter.emit(" {\n");
       }
 
-      codeWriter.pushType(this);
+      //codeWriter.pushType(this);
       codeWriter.indent();
       boolean firstMember = true;
       for (Iterator<Map.Entry<String, TypeSpec>> i = enumConstants.entrySet().iterator();
@@ -285,13 +286,14 @@ public final class TypeSpec {
       }
 
       codeWriter.unindent();
-      codeWriter.popType();
+      //codeWriter.popType();
 
       codeWriter.emit("}");
       if (enumName == null && anonymousTypeArguments == null) {
         codeWriter.emit("\n"); // If this type isn't also a value, include a trailing newline.
       }
     } finally {
+      codeWriter.popType();
       codeWriter.statementLine = previousStatementLine;
     }
   }

--- a/src/main/java/com/squareup/javapoet/TypeSpec.java
+++ b/src/main/java/com/squareup/javapoet/TypeSpec.java
@@ -214,7 +214,6 @@ public final class TypeSpec {
         codeWriter.emit(" {\n");
       }
 
-      //codeWriter.pushType(this);
       codeWriter.indent();
       boolean firstMember = true;
       for (Iterator<Map.Entry<String, TypeSpec>> i = enumConstants.entrySet().iterator();
@@ -286,7 +285,6 @@ public final class TypeSpec {
       }
 
       codeWriter.unindent();
-      //codeWriter.popType();
 
       codeWriter.emit("}");
       if (enumName == null && anonymousTypeArguments == null) {

--- a/src/test/java/com/squareup/javapoet/TypeSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/TypeSpecTest.java
@@ -622,6 +622,25 @@ public final class TypeSpecTest {
         + "}\n");
   }
 
+  @Test public void classImplementsExtendsSameName() throws Exception {
+    ClassName javapoetTaco = ClassName.get(tacosPackage, "Taco");
+    ClassName tacoBellTaco = ClassName.get("com.taco.bell", "Taco");
+    ClassName fishTaco = ClassName.get("org.fish.taco", "Taco");
+    TypeSpec typeSpec = TypeSpec.classBuilder("Taco")
+            .superclass(fishTaco)
+            .addSuperinterface(ParameterizedTypeName.get(ClassName.get(Comparable.class), javapoetTaco))
+            .addSuperinterface(tacoBellTaco)
+            .build();
+    assertThat(toString(typeSpec)).isEqualTo(""
+            + "package com.squareup.tacos;\n"
+            + "\n"
+            + "import java.lang.Comparable;\n"
+            + "\n"
+            + "class Taco extends org.fish.taco.Taco "
+            + "implements Comparable<Taco>, com.taco.bell.Taco {\n"
+            + "}\n");
+  }
+
   @Test public void enumImplements() throws Exception {
     TypeSpec typeSpec = TypeSpec.enumBuilder("Food")
         .addSuperinterface(Serializable.class)


### PR DESCRIPTION
Fixed the name clash that arises in this instance (https://github.com/square/javapoet/issues/470):

    TypeSpec ts = TypeSpec.interfaceBuilder("Example")
        .addSuperInterface(ClassName.get("org.pack", "Example")).build();
    System.out.println(JavaFile.Builder("com.ex", ts).build().toString());

Which prints the non-compiling:

    package com.ex;

    import org.pack.Example;

    interface Example extends Example {
    }

It now qualifies org.pack.Example properly:
`interface Example extends org.pack.Example {`

