### PR TITLE
Public CodeWriter with Builder

### DIFF
--- a/src/main/java/com/squareup/javapoet/AnnotationSpec.java
+++ b/src/main/java/com/squareup/javapoet/AnnotationSpec.java
@@ -187,7 +187,7 @@ public final class AnnotationSpec {
   @Override public String toString() {
     StringWriter out = new StringWriter();
     try {
-      CodeWriter codeWriter = new CodeWriter(out);
+      CodeWriter codeWriter = CodeWriter.builder(out).build();
       codeWriter.emit("$L", this);
       return out.toString();
     } catch (IOException e) {

--- a/src/main/java/com/squareup/javapoet/CodeBlock.java
+++ b/src/main/java/com/squareup/javapoet/CodeBlock.java
@@ -83,7 +83,7 @@ public final class CodeBlock {
   @Override public String toString() {
     StringWriter out = new StringWriter();
     try {
-      new CodeWriter(out).emit(this);
+      CodeWriter.builder(out).build().emit(this);
       return out.toString();
     } catch (IOException e) {
       throw new AssertionError();

--- a/src/main/java/com/squareup/javapoet/CodeWriter.java
+++ b/src/main/java/com/squareup/javapoet/CodeWriter.java
@@ -40,7 +40,7 @@ import static com.squareup.javapoet.Util.stringLiteralWithDoubleQuotes;
  * Converts a {@link JavaFile} to a string suitable to both human- and javac-consumption. This
  * honors imports, indentation, and deferred variable names.
  */
-final class CodeWriter {
+public final class CodeWriter {
   /** Sentinel value that indicates that no user-provided package has been set. */
   private static final String NO_PACKAGE = new String();
 
@@ -66,20 +66,11 @@ final class CodeWriter {
    */
   int statementLine = -1;
 
-  CodeWriter(Appendable out) {
-    this(out, "  ", Collections.<String>emptySet());
-  }
-
-  CodeWriter(Appendable out, String indent, Set<String> staticImports) {
-    this(out, indent, Collections.<String, ClassName>emptyMap(), staticImports);
-  }
-
-  CodeWriter(Appendable out, String indent, Map<String, ClassName> importedTypes,
-      Set<String> staticImports) {
-    this.out = checkNotNull(out, "out == null");
-    this.indent = checkNotNull(indent, "indent == null");
-    this.importedTypes = checkNotNull(importedTypes, "importedTypes == null");
-    this.staticImports = checkNotNull(staticImports, "staticImports == null");
+  private CodeWriter(Builder builder) {
+    this.out = builder.out;
+    this.indent = builder.indent;
+    this.importedTypes = builder.importedTypes;
+    this.staticImports = builder.staticImports;
     this.staticImportClassNames = new LinkedHashSet<>();
     for (String signature : staticImports) {
       staticImportClassNames.add(signature.substring(0, signature.lastIndexOf('.')));
@@ -483,5 +474,40 @@ final class CodeWriter {
     Map<String, ClassName> result = new LinkedHashMap<>(importableTypes);
     result.keySet().removeAll(referencedNames);
     return result;
+  }
+
+  public static Builder builder(Appendable out) {
+    checkNotNull(out, "packageName == null");
+    return new Builder(out);
+  }
+
+  public static final class Builder {
+    private final Appendable out;
+    private String indent = "  ";
+    private Map<String, ClassName> importedTypes = Collections.<String, ClassName>emptyMap();
+    private Set<String> staticImports = Collections.<String>emptySet();
+
+    private Builder(Appendable out) {
+      this.out = checkNotNull(out, "out == null");
+    }
+
+    public Builder setImportedTypes(Map<String, ClassName> importedTypes) {
+      this.importedTypes = checkNotNull(importedTypes, "importedTypes == null");
+      return this;
+    }
+
+    public Builder setStaticImports(Set<String> staticImports) {
+      this.staticImports = checkNotNull(staticImports, "staticImports == null");
+      return this;
+    }
+
+    public Builder indent(String indent) {
+      this.indent = checkNotNull(indent, "indent == null");
+      return this;
+    }
+
+    public CodeWriter build() {
+      return new CodeWriter(this);
+    }
   }
 }

--- a/src/main/java/com/squareup/javapoet/FieldSpec.java
+++ b/src/main/java/com/squareup/javapoet/FieldSpec.java
@@ -79,7 +79,7 @@ public final class FieldSpec {
   @Override public String toString() {
     StringWriter out = new StringWriter();
     try {
-      CodeWriter codeWriter = new CodeWriter(out);
+      CodeWriter codeWriter = CodeWriter.builder(out).build();
       emit(codeWriter, Collections.<Modifier>emptySet());
       return out.toString();
     } catch (IOException e) {

--- a/src/main/java/com/squareup/javapoet/JavaFile.java
+++ b/src/main/java/com/squareup/javapoet/JavaFile.java
@@ -72,12 +72,12 @@ public final class JavaFile {
 
   public void writeTo(Appendable out) throws IOException {
     // First pass: emit the entire class, just to collect the types we'll need to import.
-    CodeWriter importsCollector = new CodeWriter(NULL_APPENDABLE, indent, staticImports);
+    CodeWriter importsCollector = CodeWriter.builder(NULL_APPENDABLE).indent(indent).setStaticImports(staticImports).build();
     emit(importsCollector);
     Map<String, ClassName> suggestedImports = importsCollector.suggestedImports();
 
     // Second pass: write the code, taking advantage of the imports.
-    CodeWriter codeWriter = new CodeWriter(out, indent, suggestedImports, staticImports);
+    CodeWriter codeWriter = CodeWriter.builder(out).indent(indent).setImportedTypes(suggestedImports).setStaticImports(staticImports).build();
     emit(codeWriter);
   }
 

--- a/src/main/java/com/squareup/javapoet/JavaFile.java
+++ b/src/main/java/com/squareup/javapoet/JavaFile.java
@@ -72,12 +72,14 @@ public final class JavaFile {
 
   public void writeTo(Appendable out) throws IOException {
     // First pass: emit the entire class, just to collect the types we'll need to import.
-    CodeWriter importsCollector = CodeWriter.builder(NULL_APPENDABLE).indent(indent).setStaticImports(staticImports).build();
+    CodeWriter importsCollector = CodeWriter.builder(NULL_APPENDABLE).indent(indent)
+        .setStaticImports(staticImports).build();
     emit(importsCollector);
     Map<String, ClassName> suggestedImports = importsCollector.suggestedImports();
 
     // Second pass: write the code, taking advantage of the imports.
-    CodeWriter codeWriter = CodeWriter.builder(out).indent(indent).setImportedTypes(suggestedImports).setStaticImports(staticImports).build();
+    CodeWriter codeWriter = CodeWriter.builder(out).indent(indent)
+        .setImportedTypes(suggestedImports).setStaticImports(staticImports).build();
     emit(codeWriter);
   }
 

--- a/src/main/java/com/squareup/javapoet/MethodSpec.java
+++ b/src/main/java/com/squareup/javapoet/MethodSpec.java
@@ -163,7 +163,7 @@ public final class MethodSpec {
   @Override public String toString() {
     StringWriter out = new StringWriter();
     try {
-      CodeWriter codeWriter = new CodeWriter(out);
+      CodeWriter codeWriter = CodeWriter.builder(out).build();
       emit(codeWriter, "Constructor", Collections.<Modifier>emptySet());
       return out.toString();
     } catch (IOException e) {

--- a/src/main/java/com/squareup/javapoet/ParameterSpec.java
+++ b/src/main/java/com/squareup/javapoet/ParameterSpec.java
@@ -70,7 +70,7 @@ public final class ParameterSpec {
   @Override public String toString() {
     StringWriter out = new StringWriter();
     try {
-      CodeWriter codeWriter = new CodeWriter(out);
+      CodeWriter codeWriter = CodeWriter.builder(out).build();
       emit(codeWriter, false);
       return out.toString();
     } catch (IOException e) {

--- a/src/main/java/com/squareup/javapoet/TypeName.java
+++ b/src/main/java/com/squareup/javapoet/TypeName.java
@@ -208,7 +208,7 @@ public class TypeName {
     if (result == null) {
       try {
         StringBuilder resultBuilder = new StringBuilder();
-        CodeWriter codeWriter = new CodeWriter(resultBuilder);
+        CodeWriter codeWriter = CodeWriter.builder(resultBuilder).build();
         emitAnnotations(codeWriter);
         emit(codeWriter);
         result = resultBuilder.toString();

--- a/src/main/java/com/squareup/javapoet/TypeSpec.java
+++ b/src/main/java/com/squareup/javapoet/TypeSpec.java
@@ -310,7 +310,7 @@ public final class TypeSpec {
   @Override public String toString() {
     StringWriter out = new StringWriter();
     try {
-      CodeWriter codeWriter = new CodeWriter(out);
+      CodeWriter codeWriter = CodeWriter.builder(out).build();
       emit(codeWriter, null, Collections.<Modifier>emptySet());
       return out.toString();
     } catch (IOException e) {


### PR DESCRIPTION
So I need to generate snippets of code, not entire JavaFiles. Unfortunately CodeWriter and its constructor are package-private. I can somewhat lamely get away with doing this by calling CodeBlock::toString which takes care of instantiating the writer for me but that doesn't let me control indentation (per #198 ) and it's generally not what that method is for. As I need non-default indentation I am currently having to do this via reflection which is... suboptimal :) Here I've made CodeWriter public and as is apparently idiomatic made a simple Builder for it. I looked over its public methods and, to me, they look sane to expose. Notable of course is the lack of defensive copying of the import Set and Map but that is unchanged from the existing code.

