### PR TITLE
Don't copy annotations in MethodSpec.overriding

### DIFF
--- a/src/main/java/com/squareup/javapoet/MethodSpec.java
+++ b/src/main/java/com/squareup/javapoet/MethodSpec.java
@@ -43,7 +43,6 @@ import static com.squareup.javapoet.Util.checkState;
 /** A generated constructor or method declaration. */
 public final class MethodSpec {
   static final String CONSTRUCTOR = "<init>";
-  static final ClassName OVERRIDE = ClassName.get(Override.class);
 
   public final String name;
   public final CodeBlock javadoc;
@@ -184,6 +183,10 @@ public final class MethodSpec {
    *
    * <p>This will copy its visibility modifiers, type parameters, return type, name, parameters, and
    * throws declarations. An {@link Override} annotation will be added.
+   *
+   * <p>Note that previous versions of this method had the undocumented behavior that it would copy
+   * annotations from the method and parameters of the overridden method.  This is no longer the
+   * case -- any annotations must be applied separately.
    */
   public static Builder overriding(ExecutableElement method) {
     checkNotNull(method, "method == null");
@@ -198,12 +201,7 @@ public final class MethodSpec {
     String methodName = method.getSimpleName().toString();
     MethodSpec.Builder methodBuilder = MethodSpec.methodBuilder(methodName);
 
-    methodBuilder.addAnnotation(OVERRIDE);
-    for (AnnotationMirror mirror : method.getAnnotationMirrors()) {
-      AnnotationSpec annotationSpec = AnnotationSpec.get(mirror);
-      if (annotationSpec.type.equals(OVERRIDE)) continue;
-      methodBuilder.addAnnotation(annotationSpec);
-    }
+    methodBuilder.addAnnotation(Override.class);
 
     modifiers = new LinkedHashSet<>(modifiers);
     modifiers.remove(Modifier.ABSTRACT);
@@ -224,9 +222,6 @@ public final class MethodSpec {
       Set<Modifier> parameterModifiers = parameter.getModifiers();
       ParameterSpec.Builder parameterBuilder = ParameterSpec.builder(type, name)
           .addModifiers(parameterModifiers.toArray(new Modifier[parameterModifiers.size()]));
-      for (AnnotationMirror mirror : parameter.getAnnotationMirrors()) {
-        parameterBuilder.addAnnotation(AnnotationSpec.get(mirror));
-      }
       methodBuilder.addParameter(parameterBuilder.build());
     }
     methodBuilder.varargs(method.isVarArgs());
@@ -246,6 +241,10 @@ public final class MethodSpec {
    *
    * <p>This will copy its visibility modifiers, type parameters, return type, name, parameters, and
    * throws declarations. An {@link Override} annotation will be added.
+   *
+   *<p>Note that previous versions of this method had the undocumented behavior that it would copy
+   * annotations from the method and parameters of the overridden method.  This is no longer the
+   * case -- any annotations must be applied separately.
    */
   public static Builder overriding(
       ExecutableElement method, DeclaredType enclosing, Types types) {

--- a/src/test/java/com/squareup/javapoet/MethodSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/MethodSpecTest.java
@@ -130,10 +130,9 @@ public final class MethodSpecTest {
     MethodSpec method = MethodSpec.overriding(methodElement).build();
     assertThat(method.toString()).isEqualTo(""
         + "@java.lang.Override\n"
-        + "@java.lang.Deprecated\n"
         + "protected <T extends java.lang.Runnable & java.io.Closeable> "
         + "java.lang.Runnable everything("
-        + "@com.squareup.javapoet.MethodSpecTest.Nullable java.lang.String arg0, "
+        + "java.lang.String arg0, "
         + "java.util.List<? extends T> arg1) "
         + "throws java.io.IOException, java.lang.SecurityException {\n"
         + "}\n");


### PR DESCRIPTION
…for the reasons cited in issue #482.