### PR TITLE
Defines `ParameterSpec.get(VariableElement)`, `ParameterSpec.getAll(ExecutableElement)`, and `AnnotationSpec.getAll(VariableElement)`

### DIFF
--- a/src/main/java/com/squareup/javapoet/AnnotationSpec.java
+++ b/src/main/java/com/squareup/javapoet/AnnotationSpec.java
@@ -31,6 +31,7 @@ import java.util.Objects;
 
 import static com.squareup.javapoet.Util.characterLiteralWithoutSingleQuotes;
 import static com.squareup.javapoet.Util.checkNotNull;
+import static com.squareup.javapoet.Util.immutableList;
 
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.AnnotationValue;
@@ -154,6 +155,17 @@ public final class AnnotationSpec {
       value.accept(visitor, name);
     }
     return builder.build();
+  }
+
+  /**
+   * Returns all annotation specs from the provided element.
+   */
+  public static Iterable<AnnotationSpec> getAll(VariableElement element) {
+    List<AnnotationSpec> annotations = new ArrayList<AnnotationSpec>();
+    for (AnnotationMirror annotationMirror : element.getAnnotationMirrors()) {
+      annotations.add(get(annotationMirror));
+    }
+    return immutableList(annotations);
   }
 
   public static Builder builder(ClassName type) {

--- a/src/main/java/com/squareup/javapoet/MethodSpec.java
+++ b/src/main/java/com/squareup/javapoet/MethodSpec.java
@@ -28,7 +28,6 @@ import javax.lang.model.SourceVersion;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeParameterElement;
-import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.ExecutableType;
 import javax.lang.model.type.TypeMirror;
@@ -212,16 +211,7 @@ public final class MethodSpec {
     }
 
     methodBuilder.returns(TypeName.get(method.getReturnType()));
-
-    List<? extends VariableElement> parameters = method.getParameters();
-    for (VariableElement parameter : parameters) {
-      TypeName type = TypeName.get(parameter.asType());
-      String name = parameter.getSimpleName().toString();
-      Set<Modifier> parameterModifiers = parameter.getModifiers();
-      ParameterSpec.Builder parameterBuilder = ParameterSpec.builder(type, name)
-          .addModifiers(parameterModifiers.toArray(new Modifier[parameterModifiers.size()]));
-      methodBuilder.addParameter(parameterBuilder.build());
-    }
+    methodBuilder.addParameters(ParameterSpec.getAll(method));
     methodBuilder.varargs(method.isVarArgs());
 
     for (TypeMirror thrownType : method.getThrownTypes()) {

--- a/src/main/java/com/squareup/javapoet/MethodSpec.java
+++ b/src/main/java/com/squareup/javapoet/MethodSpec.java
@@ -211,7 +211,7 @@ public final class MethodSpec {
     }
 
     methodBuilder.returns(TypeName.get(method.getReturnType()));
-    methodBuilder.addParameters(ParameterSpec.getAll(method));
+    methodBuilder.addParameters(ParameterSpec.getAll(method, false)); // Excludes parameter annotations.
     methodBuilder.varargs(method.isVarArgs());
 
     for (TypeMirror thrownType : method.getThrownTypes()) {

--- a/src/main/java/com/squareup/javapoet/MethodSpec.java
+++ b/src/main/java/com/squareup/javapoet/MethodSpec.java
@@ -211,7 +211,8 @@ public final class MethodSpec {
     }
 
     methodBuilder.returns(TypeName.get(method.getReturnType()));
-    methodBuilder.addParameters(ParameterSpec.getAll(method, false)); // Excludes parameter annotations.
+    // Explicitly excludes parameter annotations.
+    methodBuilder.addParameters(ParameterSpec.getAll(method, false));
     methodBuilder.varargs(method.isVarArgs());
 
     for (TypeMirror thrownType : method.getThrownTypes()) {

--- a/src/main/java/com/squareup/javapoet/ParameterSpec.java
+++ b/src/main/java/com/squareup/javapoet/ParameterSpec.java
@@ -82,27 +82,38 @@ public final class ParameterSpec {
     }
   }
 
+  public static Iterable<ParameterSpec> getAll(ExecutableElement element) {
+    return getAll(element, true);
+  }
+
   /**
    * Returns all param specs from the provided element.
    */
-  public static Iterable<ParameterSpec> getAll(ExecutableElement element) {
+  static Iterable<ParameterSpec> getAll(ExecutableElement element, boolean includeAnnotations) {
     List<ParameterSpec> parameters = new ArrayList<ParameterSpec>();
     for (VariableElement variableElement : element.getParameters()) {
-      parameters.add(get(variableElement));
+      parameters.add(get(variableElement, includeAnnotations));
     }
     return immutableList(parameters);
+  }
+
+  public static ParameterSpec get(VariableElement element) {
+    return get(element, true);
   }
 
   /**
    * Returns a param spec from the provided element.
    */
-  public static ParameterSpec get(VariableElement element) {
+  static ParameterSpec get(VariableElement element, boolean includeAnnotations) {
       TypeName type = TypeName.get(element.asType());
       String name = element.getSimpleName().toString();
       Set<Modifier> parameterModifiers = element.getModifiers();
-      return ParameterSpec.builder(type, name)
-        .addModifiers(parameterModifiers.toArray(new Modifier[parameterModifiers.size()]))
-        .build();
+      ParameterSpec.Builder builder = ParameterSpec.builder(type, name)
+        .addModifiers(parameterModifiers.toArray(new Modifier[parameterModifiers.size()]));
+      if (includeAnnotations) {
+        builder.addAnnotations(AnnotationSpec.getAll(element));
+      }
+      return builder.build();
   }
 
   public static Builder builder(TypeName type, String name, Modifier... modifiers) {

--- a/src/main/java/com/squareup/javapoet/ParameterSpec.java
+++ b/src/main/java/com/squareup/javapoet/ParameterSpec.java
@@ -22,11 +22,15 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import javax.lang.model.SourceVersion;
-import javax.lang.model.element.Modifier;
 
 import static com.squareup.javapoet.Util.checkArgument;
 import static com.squareup.javapoet.Util.checkNotNull;
+import static com.squareup.javapoet.Util.immutableList;
+
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.VariableElement;
 
 /** A generated parameter declaration. */
 public final class ParameterSpec {
@@ -76,6 +80,29 @@ public final class ParameterSpec {
     } catch (IOException e) {
       throw new AssertionError();
     }
+  }
+
+  /**
+   * Returns all param specs from the provided element.
+   */
+  public static Iterable<ParameterSpec> getAll(ExecutableElement element) {
+    List<ParameterSpec> parameters = new ArrayList<ParameterSpec>();
+    for (VariableElement variableElement : element.getParameters()) {
+      parameters.add(get(variableElement));
+    }
+    return immutableList(parameters);
+  }
+
+  /**
+   * Returns a param spec from the provided element.
+   */
+  public static ParameterSpec get(VariableElement element) {
+      TypeName type = TypeName.get(element.asType());
+      String name = element.getSimpleName().toString();
+      Set<Modifier> parameterModifiers = element.getModifiers();
+      return ParameterSpec.builder(type, name)
+        .addModifiers(parameterModifiers.toArray(new Modifier[parameterModifiers.size()]))
+        .build();
   }
 
   public static Builder builder(TypeName type, String name, Modifier... modifiers) {


### PR DESCRIPTION
This PR encapsulates a few bits of functionality present in `MethodSpec.overriding` that should be accessible via the public API. I wanted to submit this for review, and determine if there are particular unit tests you'd like me to include.

Thanks!
