### PR TITLE
Check kind state when adding super class. #502

### DIFF
--- a/src/main/java/com/squareup/javapoet/TypeSpec.java
+++ b/src/main/java/com/squareup/javapoet/TypeSpec.java
@@ -434,6 +434,7 @@ public final class TypeSpec {
     }
 
     public Builder superclass(TypeName superclass) {
+      checkState(this.kind == Kind.CLASS, "only classes have super classes, not " + this.kind);
       checkState(this.superclass == ClassName.OBJECT,
           "superclass already set to " + this.superclass);
       checkArgument(!superclass.isPrimitive(), "superclass may not be a primitive");

--- a/src/test/java/com/squareup/javapoet/TypeSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/TypeSpecTest.java
@@ -2014,6 +2014,24 @@ public final class TypeSpecTest {
     }
   }
 
+  @Test public void superClassOnlyValidForClasses() {
+    try {
+      TypeSpec.annotationBuilder("A").superclass(ClassName.get(Object.class));
+      fail();
+    } catch (IllegalStateException expected) {
+    }
+    try {
+      TypeSpec.enumBuilder("E").superclass(ClassName.get(Object.class));
+      fail();
+    } catch (IllegalStateException expected) {
+    }
+    try {
+      TypeSpec.interfaceBuilder("I").superclass(ClassName.get(Object.class));
+      fail();
+    } catch (IllegalStateException expected) {
+    }
+  }
+
   @Test public void invalidSuperClass() {
     try {
       TypeSpec.classBuilder("foo")


### PR DESCRIPTION
`superclass` needs `Kind.CLASS`

Closes #502.