### PR TITLE
Guard for null in TypeSpec.Builder#addSuperinterface(TypeName)

### DIFF
--- a/src/main/java/com/squareup/javapoet/TypeSpec.java
+++ b/src/main/java/com/squareup/javapoet/TypeSpec.java
@@ -460,6 +460,7 @@ public final class TypeSpec {
     }
 
     public Builder addSuperinterface(TypeName superinterface) {
+      checkArgument(superinterface != null, "superinterface == null");
       this.superinterfaces.add(superinterface);
       return this;
     }

--- a/src/test/java/com/squareup/javapoet/TypeSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/TypeSpecTest.java
@@ -1770,6 +1770,16 @@ public final class TypeSpecTest {
     }
   }
 
+  @Test public void nullSingleSuperinterfaceAddition() {
+    try {
+      TypeSpec.classBuilder("Taco").addSuperinterface((TypeName) null);
+      fail();
+    } catch (IllegalArgumentException expected) {
+      assertThat(expected.getMessage())
+          .isEqualTo("superinterface == null");
+    }
+  }
+
   @Test public void multipleSuperinterfaceAddition() {
     TypeSpec taco = TypeSpec.classBuilder("Taco")
         .addSuperinterfaces(Arrays.asList(


### PR DESCRIPTION
If `null` makes it in, we encounter obscure stacktraces later when emitting, such as this one:

```
java.lang.IllegalArgumentException: expected type but was null
        at com.squareup.javapoet.CodeBlock$Builder.argToType(CodeBlock.java:207)
        at com.squareup.javapoet.CodeBlock$Builder.add(CodeBlock.java:170)
        at com.squareup.javapoet.CodeWriter.emit(CodeWriter.java:196)
        at com.squareup.javapoet.TypeSpec.emit(TypeSpec.java:178)
```