### PR TITLE
Add support for named arguments to CodeBlock

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,38 @@ MethodSpec byteToHex = MethodSpec.methodBuilder("byteToHex")
     .build();
 ```
 
+### Code block format strings
+Code blocks may specify the values for their placeholders in a few
+ways. Only one style may be used for each addition to a code block.
+
+#### Relative Arguments
+Pass an argument value for each placeholder in the format string to `CodeBlock.add`
+
+In each example, we generate code to say "I ate 3 tacos"
+
+```java
+CodeBlock.builder().add("I ate $L $L", 3, "tacos")
+```
+
+#### Positional Arguments
+Place an integer index after the placeholder in the format string to specify which argument to use.
+
+```java
+CodeBlock.builder().add("I ate $L1 $L0", "tacos", 3)
+```
+
+#### Named Arguments
+Use the syntax `$argumentName:X` where X is the formatc haracter and
+call `CodeBlock.addNamed` with a map containing all argument keys in the
+format string.
+
+```java
+Map<String, Object> map = new HashMap<>();
+map.put("food", "tacos");
+map.put("count", 3);
+CodeBlock.builder().addNamed("I ate $count:L $food:L", map)
+```
+
 ### Methods
 
 All of the above methods have a code body. Use `Modifiers.ABSTRACT` to get a method without any

--- a/README.md
+++ b/README.md
@@ -422,7 +422,7 @@ CodeBlock.builder().add("I ate $2L $1L", "tacos", 3)
 #### Named Arguments
 Use the syntax `$argumentName:X` where X is the format character and
 call `CodeBlock.addNamed` with a map containing all argument keys in the
-format string.
+format string. Argument names must begin with a lowercase character.
 
 ```java
 Map<String, Object> map = new LinkedHashMap<>();

--- a/README.md
+++ b/README.md
@@ -166,10 +166,10 @@ public static void main(String[] args) throws Exception {
       .addMethod(whatsMyName("eminem"))
       .addMethod(whatsMyName("marshallMathers"))
       .build();
-      
+
   JavaFile javaFile = JavaFile.builder("com.example.helloworld", helloWorld)
       .build();
-      
+
   javaFile.writeTo(System.out);
 }
 
@@ -210,15 +210,15 @@ MethodSpec today = MethodSpec.methodBuilder("today")
     .returns(Date.class)
     .addStatement("return new $T()", Date.class)
     .build();
-    
+
 TypeSpec helloWorld = TypeSpec.classBuilder("HelloWorld")
     .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
     .addMethod(today)
     .build();
-    
+
 JavaFile javaFile = JavaFile.builder("com.example.helloworld", helloWorld)
     .build();
-    
+
 javaFile.writeTo(System.out);
 ```
 
@@ -387,7 +387,7 @@ MethodSpec hexDigit = MethodSpec.methodBuilder("hexDigit")
     .returns(char.class)
     .addStatement("return (char) (i < 10 ? i + '0' : i - 10 + 'a')")
     .build();
-    
+
 MethodSpec byteToHex = MethodSpec.methodBuilder("byteToHex")
     .addParameter(int.class, "b")
     .returns(String.class)
@@ -412,19 +412,20 @@ CodeBlock.builder().add("I ate $L $L", 3, "tacos")
 ```
 
 #### Positional Arguments
-Place an integer index after the placeholder in the format string to specify which argument to use.
+Place an integer index (1-based) before the placeholder in the format string to specify which
+argument to use.
 
 ```java
-CodeBlock.builder().add("I ate $L1 $L0", "tacos", 3)
+CodeBlock.builder().add("I ate $2L $1L", "tacos", 3)
 ```
 
 #### Named Arguments
-Use the syntax `$argumentName:X` where X is the formatc haracter and
+Use the syntax `$argumentName:X` where X is the format character and
 call `CodeBlock.addNamed` with a map containing all argument keys in the
 format string.
 
 ```java
-Map<String, Object> map = new HashMap<>();
+Map<String, Object> map = new LinkedHashMap<>();
 map.put("food", "tacos");
 map.put("count", 3);
 CodeBlock.builder().addNamed("I ate $count:L $food:L", map)
@@ -439,7 +440,7 @@ body. This is only legal if the enclosing class is either abstract or an interfa
 MethodSpec flux = MethodSpec.methodBuilder("flux")
     .addModifiers(Modifier.ABSTRACT, Modifier.PROTECTED)
     .build();
-    
+
 TypeSpec helloWorld = TypeSpec.classBuilder("HelloWorld")
     .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
     .addMethod(flux)
@@ -472,7 +473,7 @@ MethodSpec flux = MethodSpec.constructorBuilder()
     .addParameter(String.class, "greeting")
     .addStatement("this.$N = $N", "greeting", "greeting")
     .build();
-    
+
 TypeSpec helloWorld = TypeSpec.classBuilder("HelloWorld")
     .addModifiers(Modifier.PUBLIC)
     .addField(String.class, "greeting", Modifier.PRIVATE, Modifier.FINAL)
@@ -529,7 +530,7 @@ Like parameters, fields can be created either with builders or by using convenie
 FieldSpec android = FieldSpec.builder(String.class, "android")
     .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
     .build();
-    
+
 TypeSpec helloWorld = TypeSpec.classBuilder("HelloWorld")
     .addModifiers(Modifier.PUBLIC)
     .addField(android)

--- a/src/main/java/com/squareup/javapoet/CodeBlock.java
+++ b/src/main/java/com/squareup/javapoet/CodeBlock.java
@@ -122,11 +122,11 @@ public final class CodeBlock {
      * Adds code using named arguments.
      *
      * <p> Named arguments specify their name after the '$' followed by : and the corresponding
-     * type character. For example, to refer to the class {@link java.lang.String} with the argument
-     * name 'text' use a format string containing {@code $text:S} and include the key 'text' with
-     * value {@link java.lang.String} in the argument map.
+     * type character. For example, to refer to the type {@link java.lang.Integer} with the argument
+     * name 'clazz' use a format string containing {@code $clazz:T} and include the key 'clazz' with
+     * value {@code java.lang.Integer.class} in the argument map.
      */
-    public Builder addNamed(String format, Map<String, Object> arguments) {
+    public Builder addNamed(String format, Map<String, ?> arguments) {
       int p = 0;
 
       while (p < format.length()) {
@@ -161,13 +161,13 @@ public final class CodeBlock {
       return this;
     }
 
-    /**f
+    /**
      * Add code with positional or relative arguments.
      *
      * <p> Relative arguments map 1-1 with the placeholders in the format string.
      *
      * <p> Positional arguments use an index after the placeholder to identify which argument
-     * index to use. For example, for a literal to reference the 3rd argument: "$L2" (0 based index)
+     * index to use. For example, for a literal to reference the 3rd argument: "$3L" (1 based index)
      *
      * <p> Mixing relative and positional arguments in a call to add is invalid and will result
      * in an error.
@@ -249,8 +249,7 @@ public final class CodeBlock {
       return c == '$' || c == '>' || c == '<' || c == '[' || c == ']';
     }
 
-    private void addArgument(String format, char c, Object arg1) {
-      Object arg = arg1;
+    private void addArgument(String format, char c, Object arg) {
       switch (c) {
         case 'N':
           this.args.add(argToName(arg));

--- a/src/main/java/com/squareup/javapoet/CodeBlock.java
+++ b/src/main/java/com/squareup/javapoet/CodeBlock.java
@@ -20,6 +20,9 @@ import java.io.StringWriter;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import javax.lang.model.element.Element;
 import javax.lang.model.type.TypeMirror;
 
@@ -56,6 +59,9 @@ import static com.squareup.javapoet.Util.checkArgument;
  * </ul>
  */
 public final class CodeBlock {
+  private static final Pattern NAMED_ARGUMENT =
+      Pattern.compile("\\$(?<argumentName>[\\w_]+):(?<typeChar>[\\w]).*", Pattern.DOTALL);
+
   /** A heterogeneous list containing string literals and value placeholders. */
   final List<String> formatParts;
   final List<Object> args;
@@ -112,9 +118,64 @@ public final class CodeBlock {
     private Builder() {
     }
 
+    /**
+     * Adds code using named arguments.
+     *
+     * <p> Named arguments specify their name after the '$' followed by : and the corresponding
+     * type character. For example, to refer to the class {@link java.lang.String} with the argument
+     * name 'text' use a format string containing {@code $text:S} and include the key 'text' with
+     * value {@link java.lang.String} in the argument map.
+     */
+    public Builder addNamed(String format, Map<String, Object> arguments) {
+      int p = 0;
+
+      while (p < format.length()) {
+        int nextP = format.indexOf("$", p);
+        if (nextP == -1) {
+          formatParts.add(format.substring(p, format.length()));
+          break;
+        }
+
+        if (p != nextP) {
+          formatParts.add(format.substring(p, nextP));
+          p = nextP;
+        }
+        Matcher matcher = NAMED_ARGUMENT.matcher(format.subSequence(p, format.length()));
+        if (matcher.matches()) {
+          String argumentName = matcher.group("argumentName");
+          checkArgument(arguments.containsKey(argumentName), "Missing named argument for $%s",
+              argumentName);
+          char formatChar = matcher.group("typeChar").charAt(0);
+          addArgument(format, formatChar, arguments.get(argumentName));
+          formatParts.add("$" + formatChar);
+          p += matcher.regionStart() + argumentName.length() + 3;
+        } else {
+          checkArgument(p < format.length() - 1, "dangling $ at end");
+          checkArgument(isNoArgPlaceholder(format.charAt(p + 1)),
+              "unknown format $%s at %s in '%s'", format.charAt(p + 1), p + 1, format);
+          formatParts.add(format.substring(p, p + 2));
+          p += 2;
+        }
+      }
+
+      return this;
+    }
+
+    /**f
+     * Add code with positional or relative arguments.
+     *
+     * <p> Relative arguments map 1-1 with the placeholders in the format string.
+     *
+     * <p> Positional arguments use an index after the placeholder to identify which argument
+     * index to use. For example, for a literal to reference the 3rd argument: "$L2" (0 based index)
+     *
+     * <p> Mixing relative and positional arguments in a call to add is invalid and will result
+     * in an error.
+     */
     public Builder add(String format, Object... args) {
       boolean hasRelative = false;
       boolean hasIndexed = false;
+
       int relativeParameterCount = 0;
       int[] indexedParameterCount = new int[args.length];
 
@@ -139,7 +200,7 @@ public final class CodeBlock {
         int indexEnd = p - 1;
 
         // If 'c' doesn't take an argument, we're done.
-        if (c == '$' || c == '>' || c == '<' || c == '[' || c == ']') {
+        if (isNoArgPlaceholder(c)) {
           checkArgument(indexStart == indexEnd, "$$, $>, $<, $[ and $] may not have an index");
           formatParts.add("$" + c);
           continue;
@@ -162,23 +223,7 @@ public final class CodeBlock {
             index + 1, format.substring(indexStart - 1, indexEnd + 1), args.length);
         checkArgument(!hasIndexed || !hasRelative, "cannot mix indexed and positional parameters");
 
-        switch (c) {
-          case 'N':
-            this.args.add(argToName(args[index]));
-            break;
-          case 'L':
-            this.args.add(argToLiteral(args[index]));
-            break;
-          case 'S':
-            this.args.add(argToString(args[index]));
-            break;
-          case 'T':
-            this.args.add(argToType(args[index]));
-            break;
-          default:
-            throw new IllegalArgumentException(
-                String.format("invalid format string: '%s'", format));
-        }
+        addArgument(format, c, args[index]);
 
         formatParts.add("$" + c);
       }
@@ -198,6 +243,31 @@ public final class CodeBlock {
         checkArgument(unused.isEmpty(), "unused argument%s: %s", s, Util.join(", ", unused));
       }
       return this;
+    }
+
+    private boolean isNoArgPlaceholder(char c) {
+      return c == '$' || c == '>' || c == '<' || c == '[' || c == ']';
+    }
+
+    private void addArgument(String format, char c, Object arg1) {
+      Object arg = arg1;
+      switch (c) {
+        case 'N':
+          this.args.add(argToName(arg));
+          break;
+        case 'L':
+          this.args.add(argToLiteral(arg));
+          break;
+        case 'S':
+          this.args.add(argToString(arg));
+          break;
+        case 'T':
+          this.args.add(argToType(arg));
+          break;
+        default:
+          throw new IllegalArgumentException(
+              String.format("invalid format string: '%s'", format));
+      }
     }
 
     private String argToName(Object o) {

--- a/src/main/java/com/squareup/javapoet/CodeBlock.java
+++ b/src/main/java/com/squareup/javapoet/CodeBlock.java
@@ -61,7 +61,7 @@ import static com.squareup.javapoet.Util.checkArgument;
 public final class CodeBlock {
   private static final Pattern NAMED_ARGUMENT =
       Pattern.compile("\\$(?<argumentName>[\\w_]+):(?<typeChar>[\\w]).*", Pattern.DOTALL);
-  private static final Pattern LOWERCASE = Pattern.compile("[a-z]+");
+  private static final Pattern LOWERCASE = Pattern.compile("[a-z]+[\\w_]*");
 
   /** A heterogeneous list containing string literals and value placeholders. */
   final List<String> formatParts;

--- a/src/main/java/com/squareup/javapoet/CodeBlock.java
+++ b/src/main/java/com/squareup/javapoet/CodeBlock.java
@@ -61,6 +61,7 @@ import static com.squareup.javapoet.Util.checkArgument;
 public final class CodeBlock {
   private static final Pattern NAMED_ARGUMENT =
       Pattern.compile("\\$(?<argumentName>[\\w_]+):(?<typeChar>[\\w]).*", Pattern.DOTALL);
+  private static final Pattern LOWERCASE = Pattern.compile("[a-z]+");
 
   /** A heterogeneous list containing string literals and value placeholders. */
   final List<String> formatParts;
@@ -122,12 +123,19 @@ public final class CodeBlock {
      * Adds code using named arguments.
      *
      * <p> Named arguments specify their name after the '$' followed by : and the corresponding
-     * type character. For example, to refer to the type {@link java.lang.Integer} with the argument
+     * type character. Argument names must start with a lowercase character.
+     *
+     * <p> For example, to refer to the type {@link java.lang.Integer} with the argument
      * name 'clazz' use a format string containing {@code $clazz:T} and include the key 'clazz' with
      * value {@code java.lang.Integer.class} in the argument map.
      */
     public Builder addNamed(String format, Map<String, ?> arguments) {
       int p = 0;
+
+      for (String argument : arguments.keySet()) {
+        checkArgument(LOWERCASE.matcher(argument).matches(),
+            "argument '%s' must start with a lowercase character", argument);
+      }
 
       while (p < format.length()) {
         int nextP = format.indexOf("$", p);

--- a/src/test/java/com/squareup/javapoet/CodeBlockTest.java
+++ b/src/test/java/com/squareup/javapoet/CodeBlockTest.java
@@ -15,6 +15,8 @@
  */
 package com.squareup.javapoet;
 
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertThat;
@@ -45,7 +47,7 @@ public final class CodeBlockTest {
       assertThat(exp).hasMessage("$$, $>, $<, $[ and $] may not have an index");
     }
   }
-  
+
   @Test public void deindentCannotBeIndexed() {
     try {
       CodeBlock.builder().add("$1<", "taco").build();
@@ -54,7 +56,7 @@ public final class CodeBlockTest {
       assertThat(exp).hasMessage("$$, $>, $<, $[ and $] may not have an index");
     }
   }
-  
+
   @Test public void dollarSignEscapeCannotBeIndexed() {
     try {
       CodeBlock.builder().add("$1$", "taco").build();
@@ -63,7 +65,7 @@ public final class CodeBlockTest {
       assertThat(exp).hasMessage("$$, $>, $<, $[ and $] may not have an index");
     }
   }
- 
+
   @Test public void statementBeginningCannotBeIndexed() {
     try {
       CodeBlock.builder().add("$1[", "taco").build();
@@ -72,7 +74,7 @@ public final class CodeBlockTest {
       assertThat(exp).hasMessage("$$, $>, $<, $[ and $] may not have an index");
     }
   }
-  
+
   @Test public void statementEndingCannotBeIndexed() {
     try {
       CodeBlock.builder().add("$1]", "taco").build();
@@ -81,27 +83,82 @@ public final class CodeBlockTest {
       assertThat(exp).hasMessage("$$, $>, $<, $[ and $] may not have an index");
     }
   }
-  
+
   @Test public void nameFormatCanBeIndexed() {
     CodeBlock block = CodeBlock.builder().add("$1N", "taco").build();
     assertThat(block.toString()).isEqualTo("taco");
   }
-  
+
   @Test public void literalFormatCanBeIndexed() {
     CodeBlock block = CodeBlock.builder().add("$1L", "taco").build();
     assertThat(block.toString()).isEqualTo("taco");
   }
-  
+
   @Test public void stringFormatCanBeIndexed() {
     CodeBlock block = CodeBlock.builder().add("$1S", "taco").build();
     assertThat(block.toString()).isEqualTo("\"taco\"");
   }
-  
+
   @Test public void typeFormatCanBeIndexed() {
     CodeBlock block = CodeBlock.builder().add("$1T", String.class).build();
     assertThat(block.toString()).isEqualTo("java.lang.String");
   }
-  
+
+  @Test public void simpleNamedArgument() {
+    Map<String, Object> map = new HashMap<>();
+    map.put("text", "taco");
+    CodeBlock block = CodeBlock.builder().addNamed("$text:S", map).build();
+    assertThat(block.toString()).isEqualTo("\"taco\"");
+  }
+
+  @Test public void repeatedNamedArgument() {
+    Map<String, Object> map = new HashMap<>();
+    map.put("text", "tacos");
+    CodeBlock block = CodeBlock.builder()
+        .addNamed("\"I like \" + $text:S + \". Do you like \" + $text:S + \"?\"", map)
+        .build();
+    assertThat(block.toString()).isEqualTo(
+        "\"I like \" + \"tacos\" + \". Do you like \" + \"tacos\" + \"?\"");
+  }
+
+  @Test public void namedAndNoArgFormat() {
+    Map<String, Object> map = new HashMap<>();
+    map.put("text", "tacos");
+    CodeBlock block = CodeBlock.builder()
+        .addNamed("$>\n$text:L for $$3.50", map).build();
+    assertThat(block.toString()).isEqualTo("\n  tacos for $3.50");
+  }
+
+  @Test public void missingNamedArgument() {
+    try {
+      Map<String, Object> map = new HashMap<>();
+      CodeBlock block = CodeBlock.builder().addNamed("$text:S", map).build();
+      fail();
+    } catch(IllegalArgumentException expected) {
+      assertThat(expected).hasMessage("Missing named argument for $text");
+    }
+  }
+
+  @Test public void multipleNamedArguments() {
+    Map<String, Object> map = new HashMap<>();
+    map.put("pipe", System.class);
+    map.put("text", "tacos");
+
+    CodeBlock block = CodeBlock.builder()
+        .addNamed("$pipe:T.out.println(\"Let's eat some $text:L\");", map)
+        .build();
+
+    assertThat(block.toString()).isEqualTo(
+        "java.lang.System.out.println(\"Let's eat some tacos\");");
+  }
+
+  @Test public void namedNewline() {
+    Map<String, Object> map = new HashMap<>();
+    map.put("clazz", Integer.class);
+    CodeBlock block = CodeBlock.builder().addNamed("$clazz:T\n", map).build();
+    assertThat(block.toString()).isEqualTo("java.lang.Integer\n");
+  }
+
   @Test public void indexTooHigh() {
     try {
       CodeBlock.builder().add("$2T", String.class).build();
@@ -110,7 +167,7 @@ public final class CodeBlockTest {
       assertThat(expected).hasMessage("index 2 for '$2T' not in range (received 1 arguments)");
     }
   }
-  
+
   @Test public void indexIsZero() {
     try {
       CodeBlock.builder().add("$0T", String.class).build();
@@ -119,7 +176,7 @@ public final class CodeBlockTest {
       assertThat(expected).hasMessage("index 0 for '$0T' not in range (received 1 arguments)");
     }
   }
-  
+
   @Test public void indexIsNegative() {
     try {
       CodeBlock.builder().add("$-1T", String.class).build();
@@ -128,7 +185,7 @@ public final class CodeBlockTest {
       assertThat(expected).hasMessage("invalid format string: '$-1T'");
     }
   }
-  
+
   @Test public void indexWithoutFormatType() {
     try {
       CodeBlock.builder().add("$1", String.class).build();
@@ -137,7 +194,7 @@ public final class CodeBlockTest {
       assertThat(expected).hasMessage("dangling format characters in '$1'");
     }
   }
-  
+
   @Test public void indexWithoutFormatTypeNotAtStringEnd() {
     try {
       CodeBlock.builder().add("$1 taco", String.class).build();
@@ -146,7 +203,7 @@ public final class CodeBlockTest {
       assertThat(expected).hasMessage("invalid format string: '$1 taco'");
     }
   }
-  
+
   @Test public void formatIndicatorAlone() {
     try {
       CodeBlock.builder().add("$", String.class).build();
@@ -155,7 +212,7 @@ public final class CodeBlockTest {
       assertThat(expected).hasMessage("dangling format characters in '$'");
     }
   }
-  
+
   @Test public void formatIndicatorWithoutIndexOrFormatType() {
     try {
       CodeBlock.builder().add("$ tacoString", String.class).build();
@@ -164,7 +221,7 @@ public final class CodeBlockTest {
       assertThat(expected).hasMessage("invalid format string: '$ tacoString'");
     }
   }
-  
+
   @Test public void sameIndexCanBeUsedWithDifferentFormats() {
     CodeBlock block = CodeBlock.builder()
         .add("$1T.out.println($1S)", ClassName.get(System.class))

--- a/src/test/java/com/squareup/javapoet/CodeBlockTest.java
+++ b/src/test/java/com/squareup/javapoet/CodeBlockTest.java
@@ -15,7 +15,7 @@
  */
 package com.squareup.javapoet;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import org.junit.Test;
 
@@ -105,14 +105,14 @@ public final class CodeBlockTest {
   }
 
   @Test public void simpleNamedArgument() {
-    Map<String, Object> map = new HashMap<>();
+    Map<String, Object> map = new LinkedHashMap<>();
     map.put("text", "taco");
     CodeBlock block = CodeBlock.builder().addNamed("$text:S", map).build();
     assertThat(block.toString()).isEqualTo("\"taco\"");
   }
 
   @Test public void repeatedNamedArgument() {
-    Map<String, Object> map = new HashMap<>();
+    Map<String, Object> map = new LinkedHashMap<>();
     map.put("text", "tacos");
     CodeBlock block = CodeBlock.builder()
         .addNamed("\"I like \" + $text:S + \". Do you like \" + $text:S + \"?\"", map)
@@ -122,7 +122,7 @@ public final class CodeBlockTest {
   }
 
   @Test public void namedAndNoArgFormat() {
-    Map<String, Object> map = new HashMap<>();
+    Map<String, Object> map = new LinkedHashMap<>();
     map.put("text", "tacos");
     CodeBlock block = CodeBlock.builder()
         .addNamed("$>\n$text:L for $$3.50", map).build();
@@ -131,7 +131,7 @@ public final class CodeBlockTest {
 
   @Test public void missingNamedArgument() {
     try {
-      Map<String, Object> map = new HashMap<>();
+      Map<String, Object> map = new LinkedHashMap<>();
       CodeBlock block = CodeBlock.builder().addNamed("$text:S", map).build();
       fail();
     } catch(IllegalArgumentException expected) {
@@ -140,7 +140,7 @@ public final class CodeBlockTest {
   }
 
   @Test public void multipleNamedArguments() {
-    Map<String, Object> map = new HashMap<>();
+    Map<String, Object> map = new LinkedHashMap<>();
     map.put("pipe", System.class);
     map.put("text", "tacos");
 
@@ -153,10 +153,21 @@ public final class CodeBlockTest {
   }
 
   @Test public void namedNewline() {
-    Map<String, Object> map = new HashMap<>();
+    Map<String, Object> map = new LinkedHashMap<>();
     map.put("clazz", Integer.class);
     CodeBlock block = CodeBlock.builder().addNamed("$clazz:T\n", map).build();
     assertThat(block.toString()).isEqualTo("java.lang.Integer\n");
+  }
+
+  @Test public void danglingNamed() {
+    Map<String, Object> map = new LinkedHashMap<>();
+    map.put("clazz", Integer.class);
+    try {
+      CodeBlock.builder().addNamed("$clazz:T$", map).build();
+      fail();
+    } catch(IllegalArgumentException expected) {
+      assertThat(expected).hasMessage("dangling $ at end");
+    }
   }
 
   @Test public void indexTooHigh() {

--- a/src/test/java/com/squareup/javapoet/CodeBlockTest.java
+++ b/src/test/java/com/squareup/javapoet/CodeBlockTest.java
@@ -132,10 +132,21 @@ public final class CodeBlockTest {
   @Test public void missingNamedArgument() {
     try {
       Map<String, Object> map = new LinkedHashMap<>();
-      CodeBlock block = CodeBlock.builder().addNamed("$text:S", map).build();
+      CodeBlock.builder().addNamed("$text:S", map).build();
       fail();
     } catch(IllegalArgumentException expected) {
       assertThat(expected).hasMessage("Missing named argument for $text");
+    }
+  }
+
+  @Test public void lowerCaseNamed() {
+    try {
+      Map<String, Object> map = new LinkedHashMap<>();
+      map.put("Text", "tacos");
+      CodeBlock block = CodeBlock.builder().addNamed("$Text:S", map).build();
+      fail();
+    } catch(IllegalArgumentException expected) {
+      assertThat(expected).hasMessage("argument 'Text' must start with a lowercase character");
     }
   }
 


### PR DESCRIPTION
Relative and positional arguments are fine for small statements, but
larger code blocks benefit from having named arguments.

https://github.com/square/javapoet/issues/518