### PR TITLE
Always write UTF-8.

### DIFF
--- a/src/main/java/com/squareup/javapoet/JavaFile.java
+++ b/src/main/java/com/squareup/javapoet/JavaFile.java
@@ -39,6 +39,7 @@ import javax.tools.SimpleJavaFileObject;
 
 import static com.squareup.javapoet.Util.checkArgument;
 import static com.squareup.javapoet.Util.checkNotNull;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /** A Java file containing a single top level class. */
 public final class JavaFile {
@@ -81,7 +82,7 @@ public final class JavaFile {
     emit(codeWriter);
   }
 
-  /** Writes this to {@code directory} the standard directory structure. */
+  /** Writes this to {@code directory} as UTF-8 using the standard directory structure. */
   public void writeTo(Path directory) throws IOException {
     checkArgument(Files.notExists(directory) || Files.isDirectory(directory),
         "path %s exists but is not a directory.", directory);
@@ -94,12 +95,12 @@ public final class JavaFile {
     }
 
     Path outputPath = outputDirectory.resolve(typeSpec.name + ".java");
-    try (Writer writer = new OutputStreamWriter(Files.newOutputStream(outputPath))) {
+    try (Writer writer = new OutputStreamWriter(Files.newOutputStream(outputPath), UTF_8)) {
       writeTo(writer);
     }
   }
 
-  /** Writes this to {@code directory} the standard directory structure. */
+  /** Writes this to {@code directory} as UTF-8 using the standard directory structure. */
   public void writeTo(File directory) throws IOException {
     writeTo(directory.toPath());
   }
@@ -190,7 +191,7 @@ public final class JavaFile {
         return JavaFile.this.toString();
       }
       @Override public InputStream openInputStream() throws IOException {
-        return new ByteArrayInputStream(getCharContent(true).getBytes());
+        return new ByteArrayInputStream(getCharContent(true).getBytes(UTF_8));
       }
       @Override public long getLastModified() {
         return lastModified;

--- a/src/main/java/com/squareup/javapoet/Util.java
+++ b/src/main/java/com/squareup/javapoet/Util.java
@@ -15,8 +15,6 @@
  */
 package com.squareup.javapoet;
 
-import static java.lang.Character.isISOControl;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -27,6 +25,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import javax.lang.model.element.Modifier;
+
+import static java.lang.Character.isISOControl;
 
 /**
  * Like Guava, but worse and standalone. This makes it easier to mix JavaPoet with libraries that

--- a/src/test/java/com/squareup/javapoet/FileWritingTest.java
+++ b/src/test/java/com/squareup/javapoet/FileWritingTest.java
@@ -33,6 +33,7 @@ import org.junit.runners.JUnit4;
 import org.mockito.Mockito;
 
 import static com.google.common.truth.Truth.assertThat;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.fail;
 
 @RunWith(JUnit4.class)
@@ -194,6 +195,25 @@ public final class FileWritingTest {
         + "\tpublic static void main(String[] args) {\n"
         + "\t\tSystem.out.println(\"Hello World!\");\n"
         + "\t}\n"
+        + "}\n");
+  }
+
+  /**
+   * This test confirms that JavaPoet ignores the host charset and always uses UTF-8. The host
+   * charset is customized with {@code -Dfile.encoding=ISO-8859-1}.
+   */
+  @Test public void fileIsUtf8() throws IOException {
+    JavaFile javaFile = JavaFile.builder("foo", TypeSpec.classBuilder("Taco").build())
+        .addFileComment("Pi\u00f1ata\u00a1")
+        .build();
+    javaFile.writeTo(fsRoot);
+
+    Path fooPath = fsRoot.resolve(fs.getPath("foo", "Taco.java"));
+    assertThat(new String(Files.readAllBytes(fooPath), UTF_8)).isEqualTo(""
+        + "// Pi\u00f1ata\u00a1\n"
+        + "package foo;\n"
+        + "\n"
+        + "class Taco {\n"
         + "}\n");
   }
 }


### PR DESCRIPTION
Sometimes the system default charset is not UTF-8 and this is sad.
We always want UTF-8, and we want to encourage anyone doing tools
to use UTF-8.

Closes: https://github.com/square/javapoet/pull/474