### PR TITLE
Support anonymous inner classes in ClassName#get

### DIFF
--- a/src/main/java/com/squareup/javapoet/ClassName.java
+++ b/src/main/java/com/squareup/javapoet/ClassName.java
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;

--- a/src/main/java/com/squareup/javapoet/ClassName.java
+++ b/src/main/java/com/squareup/javapoet/ClassName.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
@@ -49,9 +50,9 @@ public final class ClassName extends TypeName implements Comparable<ClassName> {
       checkArgument(SourceVersion.isName(names.get(i)), "part '%s' is keyword", names.get(i));
     }
     this.names = Util.immutableList(names);
-    this.canonicalName = names.get(0).isEmpty()
+    this.canonicalName = (names.get(0).isEmpty()
         ? Util.join(".", names.subList(1, names.size()))
-        : Util.join(".", names);
+        : Util.join(".", names)).replace(".$", "$");
   }
 
   @Override public ClassName annotated(List<AnnotationSpec> annotations) {
@@ -141,7 +142,16 @@ public final class ClassName extends TypeName implements Comparable<ClassName> {
     checkArgument(!clazz.isArray(), "array types cannot be represented as a ClassName");
     List<String> names = new ArrayList<>();
     while (true) {
-      names.add(clazz.getSimpleName());
+      if (clazz.isAnonymousClass()) {
+        int lastDot = clazz.getName().lastIndexOf('.');
+        if (lastDot != -1) {
+          String anonClassName = clazz.getName().substring(lastDot + 1);
+          int lastDollar = anonClassName.lastIndexOf('$');
+          names.add(anonClassName.substring(lastDollar));
+        }
+      } else {
+        names.add(clazz.getSimpleName());
+      }
       Class<?> enclosing = clazz.getEnclosingClass();
       if (enclosing == null) break;
       clazz = enclosing;

--- a/src/test/java/com/squareup/javapoet/ClassNameTest.java
+++ b/src/test/java/com/squareup/javapoet/ClassNameTest.java
@@ -16,16 +16,13 @@
 package com.squareup.javapoet;
 
 import com.google.testing.compile.CompilationRule;
-
+import java.util.Map;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.util.Elements;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-
-import java.util.Map;
-
-import javax.lang.model.element.TypeElement;
-import javax.lang.model.util.Elements;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/com/squareup/javapoet/ClassNameTest.java
+++ b/src/test/java/com/squareup/javapoet/ClassNameTest.java
@@ -16,13 +16,16 @@
 package com.squareup.javapoet;
 
 import com.google.testing.compile.CompilationRule;
-import java.util.Map;
-import javax.lang.model.element.TypeElement;
-import javax.lang.model.util.Elements;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+
+import java.util.Map;
+
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.util.Elements;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
@@ -107,6 +110,12 @@ public final class ClassNameTest {
         .isEqualTo("java.lang.Object");
     assertThat(ClassName.get(OuterClass.InnerClass.class).toString())
         .isEqualTo("com.squareup.javapoet.ClassNameTest.OuterClass.InnerClass");
+    try {
+      assertThat((ClassName.get(new Object() {}.getClass())).toString())
+          .isEqualTo("com.squareup.javapoet.ClassNameTest$1");
+    } catch (IllegalArgumentException e) {
+      fail();
+    }
   }
 
   @Test public void peerClass() {

--- a/src/test/java/com/squareup/javapoet/ClassNameTest.java
+++ b/src/test/java/com/squareup/javapoet/ClassNameTest.java
@@ -107,12 +107,8 @@ public final class ClassNameTest {
         .isEqualTo("java.lang.Object");
     assertThat(ClassName.get(OuterClass.InnerClass.class).toString())
         .isEqualTo("com.squareup.javapoet.ClassNameTest.OuterClass.InnerClass");
-    try {
-      assertThat((ClassName.get(new Object() {}.getClass())).toString())
-          .isEqualTo("com.squareup.javapoet.ClassNameTest$1");
-    } catch (IllegalArgumentException e) {
-      fail();
-    }
+    assertThat((ClassName.get(new Object() {}.getClass())).toString())
+        .isEqualTo("com.squareup.javapoet.ClassNameTest$1");
   }
 
   @Test public void peerClass() {


### PR DESCRIPTION
ClassName#get incorrectly used Class#getSimpleName for anonymous inner classes, which is an empty string.
With this change it falls back to using Class#getName for anonymous classes and taking the compiler generated name for the class.

`mvn clean verify` passed, signed the CLA.