### PR TITLE
Rollback support for retaining parameter annotations.

### DIFF
--- a/src/main/java/com/squareup/javapoet/AnnotationSpec.java
+++ b/src/main/java/com/squareup/javapoet/AnnotationSpec.java
@@ -30,7 +30,6 @@ import java.util.Map;
 import java.util.Objects;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.AnnotationValue;
-import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
@@ -39,7 +38,6 @@ import javax.lang.model.util.SimpleAnnotationValueVisitor7;
 
 import static com.squareup.javapoet.Util.characterLiteralWithoutSingleQuotes;
 import static com.squareup.javapoet.Util.checkNotNull;
-import static com.squareup.javapoet.Util.immutableList;
 
 /** A generated annotation on a declaration. */
 public final class AnnotationSpec {
@@ -155,15 +153,6 @@ public final class AnnotationSpec {
       value.accept(visitor, name);
     }
     return builder.build();
-  }
-
-  /** Returns all annotations on {@code element}. */
-  static List<AnnotationSpec> annotationsOf(Element element) {
-    List<AnnotationSpec> result = new ArrayList<>();
-    for (AnnotationMirror annotationMirror : element.getAnnotationMirrors()) {
-      result.add(get(annotationMirror));
-    }
-    return immutableList(result);
   }
 
   public static Builder builder(ClassName type) {

--- a/src/main/java/com/squareup/javapoet/ParameterSpec.java
+++ b/src/main/java/com/squareup/javapoet/ParameterSpec.java
@@ -85,7 +85,6 @@ public final class ParameterSpec {
     String name = element.getSimpleName().toString();
     return ParameterSpec.builder(type, name)
         .addModifiers(element.getModifiers())
-        .addAnnotations(AnnotationSpec.annotationsOf(element))
         .build();
   }
 

--- a/src/test/java/com/squareup/javapoet/MethodSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/MethodSpecTest.java
@@ -131,8 +131,9 @@ public final class MethodSpecTest {
     assertThat(method.toString()).isEqualTo(""
         + "@java.lang.Override\n"
         + "protected <T extends java.lang.Runnable & java.io.Closeable> java.lang.Runnable "
-        + "everything(@com.squareup.javapoet.MethodSpecTest.Nullable java.lang.String arg0,\n"
-        + "    java.util.List<? extends T> arg1) throws java.io.IOException, java.lang.SecurityException {\n"
+        + "everything(java.lang.String arg0,\n"
+        + "    java.util.List<? extends T> arg1) throws java.io.IOException, "
+        + "java.lang.SecurityException {\n"
         + "}\n");
   }
 


### PR DESCRIPTION
We recently merged this because it was demanded, but looking through our
history we've had vocal users complaining about this exact kind of
behavior.

https://github.com/square/javapoet/pull/487/files