### PR TITLE
Improve test on TypeName

### DIFF
--- a/src/test/java/com/squareup/javapoet/TypeNameTest.java
+++ b/src/test/java/com/squareup/javapoet/TypeNameTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 
 public class TypeNameTest {
@@ -178,5 +179,6 @@ public class TypeNameTest {
     assertEquals(a.toString(), b.toString());
     assertThat(a.equals(b)).isTrue();
     assertThat(a.hashCode()).isEqualTo(b.hashCode());
+    assertFalse(a.equals(null));
   }
 }


### PR DESCRIPTION
Hello,

I open this pull request to specify the line [197](https://github.com/square/javapoet/blob/master/src/main/java/com/squareup/javapoet/TypeName.java#L197) in the ```equals()``` method of ```com.squareup.javapoet.TypeName```.

```java
if (o == null) return false;
```
