### PR TITLE
Adds messaging to NPEs thrown in MethodSpec.methodBuilder(),addModifiers()

### DIFF
--- a/src/main/java/com/squareup/javapoet/MethodSpec.java
+++ b/src/main/java/com/squareup/javapoet/MethodSpec.java
@@ -281,6 +281,7 @@ public final class MethodSpec {
     private CodeBlock defaultValue;
 
     private Builder(String name) {
+      checkNotNull(name, "name == null");
       checkArgument(name.equals(CONSTRUCTOR) || SourceVersion.isName(name),
           "not a valid name: %s", name);
       this.name = name;
@@ -320,6 +321,7 @@ public final class MethodSpec {
     }
 
     public Builder addModifiers(Modifier... modifiers) {
+      checkNotNull(modifiers, "modifiers == null");
       Collections.addAll(this.modifiers, modifiers);
       return this;
     }

--- a/src/test/java/com/squareup/javapoet/MethodSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/MethodSpecTest.java
@@ -238,4 +238,22 @@ public final class MethodSpecTest {
       .isEqualTo(Arrays.asList(ioException, timeoutException));
   }
 
+  @Test public void nullIsNotAValidMethodName() {
+    try {
+      MethodSpec.methodBuilder(null);
+      fail("NullPointerException expected");
+    } catch (NullPointerException e) {
+      assertThat(e.getMessage()).isEqualTo("name == null");
+    }
+  }
+
+  @Test public void addModifiersVarargsShouldNotBeNull() {
+    try {
+      MethodSpec.methodBuilder("taco")
+              .addModifiers((Modifier[]) null);
+      fail("NullPointerException expected");
+    } catch (NullPointerException e) {
+      assertThat(e.getMessage()).isEqualTo("modifiers == null");
+    }
+  }
 }


### PR DESCRIPTION
I encountered the NPEs because of variations in the API response which I use to generate my code. I figured it would be better to add some messaging to the NPEs, rather that getting the vanilla NPEs.