### PR TITLE
Verify that null is not passed as vararg parameter

### DIFF
--- a/src/main/java/com/squareup/javapoet/TypeSpec.java
+++ b/src/main/java/com/squareup/javapoet/TypeSpec.java
@@ -419,7 +419,10 @@ public final class TypeSpec {
 
     public Builder addModifiers(Modifier... modifiers) {
       checkState(anonymousTypeArguments == null, "forbidden on anonymous types.");
-      Collections.addAll(this.modifiers, modifiers);
+      for (Modifier modifier : modifiers) {
+        checkArgument(modifier != null, "modifiers contain null");
+        this.modifiers.add(modifier);
+      }
       return this;
     }
 

--- a/src/test/java/com/squareup/javapoet/TypeSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/TypeSpecTest.java
@@ -1836,6 +1836,16 @@ public final class TypeSpecTest {
         + "}\n");
   }
 
+  @Test public void nullModifiersAddition() {
+    try {
+      TypeSpec.classBuilder("Taco").addModifiers((Modifier) null);
+      fail();
+    } catch(IllegalArgumentException expected) {
+      assertThat(expected.getMessage())
+          .isEqualTo("modifiers contain null");
+    }
+  }
+
   @Test public void nullTypeVariablesAddition() {
     try {
       TypeSpec.classBuilder("Taco").addTypeVariables(null);


### PR DESCRIPTION
Encountered unexpected behaviour when printing a class as the result of a null being passed from the result of a method call into `TypeSpec` modifiers