### PR TITLE
Include annotations when emitting type variables.

### DIFF
--- a/src/main/java/com/squareup/javapoet/CodeWriter.java
+++ b/src/main/java/com/squareup/javapoet/CodeWriter.java
@@ -191,6 +191,7 @@ final class CodeWriter {
     boolean firstTypeVariable = true;
     for (TypeVariableName typeVariable : typeVariables) {
       if (!firstTypeVariable) emit(", ");
+      emitAnnotations(typeVariable.annotations, true);
       emit("$L", typeVariable.name);
       boolean firstBound = true;
       for (TypeName bound : typeVariable.bounds) {

--- a/src/test/java/com/squareup/javapoet/TypeSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/TypeSpecTest.java
@@ -597,7 +597,7 @@ public final class TypeSpecTest {
         + "import java.lang.Comparable;\n"
         + "import java.lang.Number;\n"
         + "\n"
-        + "class Location<P extends Number & Comparable, Q extends Number & Comparable> {\n"
+        + "class Location<P extends Number & Comparable, @A Q extends Number & Comparable> {\n"
         + "  P x;\n"
         + "\n"
         + "  @A Q y;\n"


### PR DESCRIPTION
Turns out this was already covered in a test but we had the wrong expected output declared.

Closes #573.