### PR TITLE
Unify behavior of writeTo() on file encoding.

### DIFF
--- a/src/main/java/com/squareup/javapoet/JavaFile.java
+++ b/src/main/java/com/squareup/javapoet/JavaFile.java
@@ -105,7 +105,7 @@ public final class JavaFile {
     writeTo(directory.toPath());
   }
 
-  /** Writes this to {@code filer}. */
+  /** Writes this to {@code filer} as UTF-8. */
   public void writeTo(Filer filer) throws IOException {
     String fileName = packageName.isEmpty()
         ? typeSpec.name
@@ -113,7 +113,7 @@ public final class JavaFile {
     List<Element> originatingElements = typeSpec.originatingElements;
     JavaFileObject filerSourceFile = filer.createSourceFile(fileName,
         originatingElements.toArray(new Element[originatingElements.size()]));
-    try (Writer writer = filerSourceFile.openWriter()) {
+    try (Writer writer = new OutputStreamWriter(filerSourceFile.openOutputStream(), UTF_8)) {
       writeTo(writer);
     } catch (Exception e) {
       try {


### PR DESCRIPTION
Let **com.squareup.javapoet.JavaFile#writeTo(javax.annotation.processing.Filer)** behave like other writeTo() methods which save files in UTF-8 encoding by default instead of system default encoding.  

That is more intuitive and more useful for common use.