### PR TITLE
Set com.squareup.javapoet as automatic module name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,6 +140,19 @@
           </execution>
         </executions>
       </plugin>
+      
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>com.squareup.javapoet</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
Claim `com.squareup.javapoet` as Automatic-Module-Name in the JAR MANIFEST.

The name matches the java package name in which all compilation units reside. It does not match the github "user" name `square`.

See http://branchandbound.net/blog/java/2017/12/automatic-module-name/ for details and background.

Closes #589