### PR TITLE
Fix search of annotated type parameters in imports

### DIFF
--- a/src/main/java/com/squareup/javapoet/ClassName.java
+++ b/src/main/java/com/squareup/javapoet/ClassName.java
@@ -231,6 +231,6 @@ public final class ClassName extends TypeName implements Comparable<ClassName> {
   }
 
   @Override CodeWriter emit(CodeWriter out) throws IOException {
-    return out.emitAndIndent(out.lookupName(this.withoutAnnotations()));
+    return out.emitAndIndent(out.lookupName(this));
   }
 }

--- a/src/main/java/com/squareup/javapoet/ClassName.java
+++ b/src/main/java/com/squareup/javapoet/ClassName.java
@@ -58,7 +58,7 @@ public final class ClassName extends TypeName implements Comparable<ClassName> {
     return new ClassName(names, concatAnnotations(annotations));
   }
 
-  @Override public TypeName withoutAnnotations() {
+  @Override public ClassName withoutAnnotations() {
     return new ClassName(names);
   }
 
@@ -231,6 +231,6 @@ public final class ClassName extends TypeName implements Comparable<ClassName> {
   }
 
   @Override CodeWriter emit(CodeWriter out) throws IOException {
-    return out.emitAndIndent(out.lookupName(this));
+    return out.emitAndIndent(out.lookupName(this.withoutAnnotations()));
   }
 }

--- a/src/main/java/com/squareup/javapoet/CodeWriter.java
+++ b/src/main/java/com/squareup/javapoet/CodeWriter.java
@@ -360,7 +360,7 @@ final class CodeWriter {
       ClassName resolved = resolve(c.simpleName());
       nameResolved = resolved != null;
 
-      if (Objects.equals(resolved, c)) {
+      if (resolved != null && Objects.equals(resolved.canonicalName, c.canonicalName)) {
         int suffixOffset = c.simpleNames().size() - 1;
         return join(".", className.simpleNames().subList(
             suffixOffset, className.simpleNames().size()));

--- a/src/test/java/com/squareup/javapoet/JavaFileTest.java
+++ b/src/test/java/com/squareup/javapoet/JavaFileTest.java
@@ -17,6 +17,7 @@ package com.squareup.javapoet;
 
 import java.util.Collections;
 import java.util.Date;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import javax.lang.model.element.Modifier;
 import org.junit.Ignore;
@@ -288,6 +289,29 @@ public final class JavaFileTest {
         + "\n"
         + "  java.sql.Date madeFreshDatabaseDate;\n"
         + "}\n");
+  }
+
+  @Test public void annotatedTypeParam() throws Exception {
+    String source = JavaFile.builder("com.squareup.tacos",
+            TypeSpec.classBuilder("Taco")
+                    .addField(ParameterizedTypeName
+                            .get(ClassName.get(List.class),
+                                    ClassName.get("com.squareup.meat", "Chorizo")
+                                            .annotated(AnnotationSpec.builder(
+                                                    ClassName.get("com.squareup.tacos", "Spicy"))
+                                    .build())), "chorizo")
+                    .build())
+            .build()
+            .toString();
+    assertThat(source).isEqualTo(""
+            + "package com.squareup.tacos;\n"
+            + "\n"
+            + "import com.squareup.meat.Chorizo;\n"
+            + "import java.util.List;\n"
+            + "\n"
+            + "class Taco {\n"
+            + "  List<@Spicy Chorizo> chorizo;\n"
+            + "}\n");
   }
 
   @Test public void skipJavaLangImportsWithConflictingClassLast() throws Exception {


### PR DESCRIPTION
Right now generated code is 
`
package com.squareup.tacos;

import com.squareup.meat.Chorizo;
import java.util.List;

class Taco {
  List<@Spicy com.squareup.meat.Chorizo> chorizo;
}
`
and javac can't compile it (see also https://github.com/square/javapoet/issues/431)

Patch does not fix root of problem, but works for common cases.