### PR TITLE
JUnit 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,8 +22,8 @@
 
     <java.version>1.7</java.version>
     <junit.version>4.12</junit.version>
-    <truth.version>0.28</truth.version>
-    <compile-testing.version>0.9</compile-testing.version>
+    <truth.version>0.39</truth.version>
+    <compile-testing.version>0.15</compile-testing.version>
   </properties>
 
   <scm>
@@ -72,19 +72,19 @@
     <dependency>
       <groupId>com.google.jimfs</groupId>
       <artifactId>jimfs</artifactId>
-      <version>1.0</version>
+      <version>1.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>1.10.16</version>
+      <version>2.13.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jdt.core.compiler</groupId>
       <artifactId>ecj</artifactId>
-      <version>4.4.2</version>
+      <version>4.6.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -94,7 +94,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.6.1</version>
+        <version>3.7.0</version>
         <configuration>
           <compilerId>javac-with-errorprone</compilerId>
           <forceJavacCompilerUse>true</forceJavacCompilerUse>
@@ -105,12 +105,12 @@
           <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-compiler-javac-errorprone</artifactId>
-            <version>2.8.1</version>
+            <version>2.8.2</version>
           </dependency>
           <dependency>
             <groupId>com.google.errorprone</groupId>
             <artifactId>error_prone_core</artifactId>
-            <version>2.0.16</version>
+            <version>2.2.0</version>
           </dependency>
         </dependencies>
       </plugin>
@@ -123,7 +123,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>7.7</version>
+            <version>8.7</version>
           </dependency>
         </dependencies>
         <configuration>
@@ -144,6 +144,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
+        <version>3.0.2</version>
         <configuration>
           <archive>
             <manifestEntries>

--- a/pom.xml
+++ b/pom.xml
@@ -20,8 +20,11 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <java.version>1.7</java.version>
+    <java.version>1.8</java.version>
     <junit.version>4.12</junit.version>
+    <junit.platform.version>1.0.3</junit.platform.version>
+    <junit.jupiter.version>5.0.3</junit.jupiter.version>
+    <junit.vintage.version>${junit.version}.3</junit.vintage.version>
     <truth.version>0.39</truth.version>
     <compile-testing.version>0.15</compile-testing.version>
   </properties>
@@ -64,9 +67,15 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>${junit.jupiter.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <version>${junit.vintage.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -116,6 +125,18 @@
       </plugin>
 
       <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.19.1</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-surefire-provider</artifactId>
+            <version>${junit.platform.version}</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
         <version>2.17</version>
@@ -130,6 +151,8 @@
           <failsOnError>true</failsOnError>
           <configLocation>checkstyle.xml</configLocation>
           <consoleOutput>true</consoleOutput>
+          <includeTestSourceDirectory>false</includeTestSourceDirectory>
+          <linkXRef>false</linkXRef>
         </configuration>
         <executions>
           <execution>

--- a/src/test/java/com/squareup/javapoet/CodeBlockTest.java
+++ b/src/test/java/com/squareup/javapoet/CodeBlockTest.java
@@ -44,7 +44,7 @@ public final class CodeBlockTest {
       CodeBlock.builder().add("$1>", "taco").build();
       fail();
     } catch (IllegalArgumentException exp) {
-      assertThat(exp).hasMessage("$$, $>, $<, $[, $], and $W may not have an index");
+      assertThat(exp).hasMessageThat().isEqualTo("$$, $>, $<, $[, $], and $W may not have an index");
     }
   }
 
@@ -53,7 +53,7 @@ public final class CodeBlockTest {
       CodeBlock.builder().add("$1<", "taco").build();
       fail();
     } catch (IllegalArgumentException exp) {
-      assertThat(exp).hasMessage("$$, $>, $<, $[, $], and $W may not have an index");
+      assertThat(exp).hasMessageThat().isEqualTo("$$, $>, $<, $[, $], and $W may not have an index");
     }
   }
 
@@ -62,7 +62,7 @@ public final class CodeBlockTest {
       CodeBlock.builder().add("$1$", "taco").build();
       fail();
     } catch (IllegalArgumentException exp) {
-      assertThat(exp).hasMessage("$$, $>, $<, $[, $], and $W may not have an index");
+      assertThat(exp).hasMessageThat().isEqualTo("$$, $>, $<, $[, $], and $W may not have an index");
     }
   }
 
@@ -71,7 +71,7 @@ public final class CodeBlockTest {
       CodeBlock.builder().add("$1[", "taco").build();
       fail();
     } catch (IllegalArgumentException exp) {
-      assertThat(exp).hasMessage("$$, $>, $<, $[, $], and $W may not have an index");
+      assertThat(exp).hasMessageThat().isEqualTo("$$, $>, $<, $[, $], and $W may not have an index");
     }
   }
 
@@ -80,7 +80,7 @@ public final class CodeBlockTest {
       CodeBlock.builder().add("$1]", "taco").build();
       fail();
     } catch (IllegalArgumentException exp) {
-      assertThat(exp).hasMessage("$$, $>, $<, $[, $], and $W may not have an index");
+      assertThat(exp).hasMessageThat().isEqualTo("$$, $>, $<, $[, $], and $W may not have an index");
     }
   }
 
@@ -135,7 +135,7 @@ public final class CodeBlockTest {
       CodeBlock.builder().addNamed("$text:S", map).build();
       fail();
     } catch(IllegalArgumentException expected) {
-      assertThat(expected).hasMessage("Missing named argument for $text");
+      assertThat(expected).hasMessageThat().isEqualTo("Missing named argument for $text");
     }
   }
 
@@ -146,7 +146,7 @@ public final class CodeBlockTest {
       CodeBlock block = CodeBlock.builder().addNamed("$Text:S", map).build();
       fail();
     } catch(IllegalArgumentException expected) {
-      assertThat(expected).hasMessage("argument 'Text' must start with a lowercase character");
+      assertThat(expected).hasMessageThat().isEqualTo("argument 'Text' must start with a lowercase character");
     }
   }
 
@@ -177,7 +177,7 @@ public final class CodeBlockTest {
       CodeBlock.builder().addNamed("$clazz:T$", map).build();
       fail();
     } catch(IllegalArgumentException expected) {
-      assertThat(expected).hasMessage("dangling $ at end");
+      assertThat(expected).hasMessageThat().isEqualTo("dangling $ at end");
     }
   }
 
@@ -186,7 +186,7 @@ public final class CodeBlockTest {
       CodeBlock.builder().add("$2T", String.class).build();
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessage("index 2 for '$2T' not in range (received 1 arguments)");
+      assertThat(expected).hasMessageThat().isEqualTo("index 2 for '$2T' not in range (received 1 arguments)");
     }
   }
 
@@ -195,7 +195,7 @@ public final class CodeBlockTest {
       CodeBlock.builder().add("$0T", String.class).build();
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessage("index 0 for '$0T' not in range (received 1 arguments)");
+      assertThat(expected).hasMessageThat().isEqualTo("index 0 for '$0T' not in range (received 1 arguments)");
     }
   }
 
@@ -204,7 +204,7 @@ public final class CodeBlockTest {
       CodeBlock.builder().add("$-1T", String.class).build();
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessage("invalid format string: '$-1T'");
+      assertThat(expected).hasMessageThat().isEqualTo("invalid format string: '$-1T'");
     }
   }
 
@@ -213,7 +213,7 @@ public final class CodeBlockTest {
       CodeBlock.builder().add("$1", String.class).build();
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessage("dangling format characters in '$1'");
+      assertThat(expected).hasMessageThat().isEqualTo("dangling format characters in '$1'");
     }
   }
 
@@ -222,7 +222,7 @@ public final class CodeBlockTest {
       CodeBlock.builder().add("$1 taco", String.class).build();
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessage("invalid format string: '$1 taco'");
+      assertThat(expected).hasMessageThat().isEqualTo("invalid format string: '$1 taco'");
     }
   }
 
@@ -231,7 +231,7 @@ public final class CodeBlockTest {
       CodeBlock.builder().add("$1T").build();
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessage("index 1 for '$1T' not in range (received 0 arguments)");
+      assertThat(expected).hasMessageThat().isEqualTo("index 1 for '$1T' not in range (received 0 arguments)");
     }
   }
 
@@ -240,7 +240,7 @@ public final class CodeBlockTest {
       CodeBlock.builder().add("$", String.class).build();
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessage("dangling format characters in '$'");
+      assertThat(expected).hasMessageThat().isEqualTo("dangling format characters in '$'");
     }
   }
 
@@ -249,7 +249,7 @@ public final class CodeBlockTest {
       CodeBlock.builder().add("$ tacoString", String.class).build();
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessage("invalid format string: '$ tacoString'");
+      assertThat(expected).hasMessageThat().isEqualTo("invalid format string: '$ tacoString'");
     }
   }
 
@@ -267,7 +267,7 @@ public final class CodeBlockTest {
       codeBlock.toString();
       fail();
     } catch (IllegalStateException expected) {
-      assertThat(expected).hasMessage("statement enter $[ followed by statement enter $[");
+      assertThat(expected).hasMessageThat().isEqualTo("statement enter $[ followed by statement enter $[");
     }
   }
 
@@ -278,7 +278,7 @@ public final class CodeBlockTest {
       codeBlock.toString();
       fail();
     } catch (IllegalStateException expected) {
-      assertThat(expected).hasMessage("statement exit $] has no matching statement enter $[");
+      assertThat(expected).hasMessageThat().isEqualTo("statement exit $] has no matching statement enter $[");
     }
   }
 }

--- a/src/test/java/com/squareup/javapoet/FileReadingTest.java
+++ b/src/test/java/com/squareup/javapoet/FileReadingTest.java
@@ -113,7 +113,8 @@ public class FileReadingTest {
     assertThat(diagnosticCollector.getDiagnostics()).isEmpty();
 
     ClassLoader loader = fileManager.getClassLoader(StandardLocation.CLASS_OUTPUT);
-    Callable<?> test = Class.forName("foo.Test", true, loader).asSubclass(Callable.class).newInstance();
+    Callable<?> test = Class.forName("foo.Test", true, loader).asSubclass(Callable.class).
+            getDeclaredConstructor().newInstance();
     assertThat(Callable.class.getMethod("call").invoke(test)).isEqualTo(value);
   }
 }

--- a/src/test/java/com/squareup/javapoet/MethodSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/MethodSpecTest.java
@@ -74,7 +74,7 @@ public final class MethodSpecTest {
       MethodSpec.methodBuilder("doSomething").addAnnotations(null);
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessage("annotationSpecs == null");
+      assertThat(expected).hasMessageThat().isEqualTo("annotationSpecs == null");
     }
   }
 
@@ -83,7 +83,7 @@ public final class MethodSpecTest {
       MethodSpec.methodBuilder("doSomething").addTypeVariables(null);
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessage("typeVariables == null");
+      assertThat(expected).hasMessageThat().isEqualTo("typeVariables == null");
     }
   }
 
@@ -92,7 +92,7 @@ public final class MethodSpecTest {
       MethodSpec.methodBuilder("doSomething").addParameters(null);
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessage("parameterSpecs == null");
+      assertThat(expected).hasMessageThat().isEqualTo("parameterSpecs == null");
     }
   }
 
@@ -101,7 +101,7 @@ public final class MethodSpecTest {
       MethodSpec.methodBuilder("doSomething").addExceptions(null);
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessage("exceptions == null");
+      assertThat(expected).hasMessageThat().isEqualTo("exceptions == null");
     }
   }
 
@@ -118,7 +118,7 @@ public final class MethodSpecTest {
     @Override public abstract String toString();
   }
 
-  interface ExtendsOthers extends Callable<Integer>, Comparable<Long> {
+  interface ExtendsOthers extends Callable<Integer>, Comparable<ExtendsOthers> {
   }
   
   interface ExtendsIterableWithDefaultMethods extends Iterable<Object> {
@@ -175,7 +175,7 @@ public final class MethodSpecTest {
     method = MethodSpec.overriding(exec, classType, types).build();
     assertThat(method.toString()).isEqualTo(""
         + "@java.lang.Override\n"
-        + "public int compareTo(java.lang.Long arg0) {\n"
+        + "public int compareTo(" + ExtendsOthers.class.getCanonicalName() + " arg0) {\n"
         + "}\n");
   }
 
@@ -189,21 +189,21 @@ public final class MethodSpecTest {
       MethodSpec.overriding(method);
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessage("cannot override method with modifiers: [final]");
+      assertThat(expected).hasMessageThat().isEqualTo("cannot override method with modifiers: [final]");
     }
     when(method.getModifiers()).thenReturn(ImmutableSet.of(Modifier.PRIVATE));
     try {
       MethodSpec.overriding(method);
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessage("cannot override method with modifiers: [private]");
+      assertThat(expected).hasMessageThat().isEqualTo("cannot override method with modifiers: [private]");
     }
     when(method.getModifiers()).thenReturn(ImmutableSet.of(Modifier.STATIC));
     try {
       MethodSpec.overriding(method);
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessage("cannot override method with modifiers: [static]");
+      assertThat(expected).hasMessageThat().isEqualTo("cannot override method with modifiers: [static]");
     }
   }
 

--- a/src/test/java/com/squareup/javapoet/NameAllocatorTest.java
+++ b/src/test/java/com/squareup/javapoet/NameAllocatorTest.java
@@ -79,7 +79,7 @@ public final class NameAllocatorTest {
       nameAllocator.newName("bar", 1);
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessage("tag 1 cannot be used for both 'foo' and 'bar'");
+      assertThat(expected).hasMessageThat().isEqualTo("tag 1 cannot be used for both 'foo' and 'bar'");
     }
   }
 
@@ -89,7 +89,7 @@ public final class NameAllocatorTest {
       nameAllocator.get(1);
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessage("unknown tag: 1");
+      assertThat(expected).hasMessageThat().isEqualTo("unknown tag: 1");
     }
   }
 

--- a/src/test/java/com/squareup/javapoet/TypeSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/TypeSpecTest.java
@@ -1979,7 +1979,7 @@ public final class TypeSpecTest {
       CodeBlock.builder().add("$N", String.class);
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessage("expected name but was " + String.class);
+      assertThat(expected).hasMessageThat().isEqualTo("expected name but was " + String.class);
     }
   }
 
@@ -2020,7 +2020,7 @@ public final class TypeSpecTest {
       CodeBlock.builder().add("$T", "java.lang.String");
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessage("expected type but was java.lang.String");
+      assertThat(expected).hasMessageThat().isEqualTo("expected type but was java.lang.String");
     }
   }
 
@@ -2029,7 +2029,7 @@ public final class TypeSpecTest {
       CodeBlock.builder().add("$S");
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessage("index 1 for '$S' not in range (received 0 arguments)");
+      assertThat(expected).hasMessageThat().isEqualTo("index 1 for '$S' not in range (received 0 arguments)");
     }
   }
 
@@ -2038,7 +2038,7 @@ public final class TypeSpecTest {
       CodeBlock.builder().add("$L $L", "a", "b", "c");
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessage("unused arguments: expected 2, received 3");
+      assertThat(expected).hasMessageThat().isEqualTo("unused arguments: expected 2, received 3");
     }
   }
 
@@ -2047,19 +2047,19 @@ public final class TypeSpecTest {
       CodeBlock.builder().add("$1L $2L", "a", "b", "c");
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessage("unused argument: $3");
+      assertThat(expected).hasMessageThat().isEqualTo("unused argument: $3");
     }
     try {
       CodeBlock.builder().add("$1L $1L $1L", "a", "b", "c");
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessage("unused arguments: $2, $3");
+      assertThat(expected).hasMessageThat().isEqualTo("unused arguments: $2, $3");
     }
     try {
       CodeBlock.builder().add("$3L $1L $3L $1L $3L", "a", "b", "c", "d");
       fail();
     } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessage("unused arguments: $2, $4");
+      assertThat(expected).hasMessageThat().isEqualTo("unused arguments: $2, $4");
     }
   }
 

--- a/src/test/java/com/squareup/javapoet/UtilTest.java
+++ b/src/test/java/com/squareup/javapoet/UtilTest.java
@@ -15,61 +15,87 @@
  */
 package com.squareup.javapoet;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.DynamicContainer.dynamicContainer;
+import static org.junit.jupiter.api.DynamicTest.dynamicTest;
 
-import org.junit.Test;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DynamicNode;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
 
-public class UtilTest {
-  @Test public void characterLiteral() {
-    assertEquals("a", Util.characterLiteralWithoutSingleQuotes('a'));
-    assertEquals("b", Util.characterLiteralWithoutSingleQuotes('b'));
-    assertEquals("c", Util.characterLiteralWithoutSingleQuotes('c'));
-    assertEquals("%", Util.characterLiteralWithoutSingleQuotes('%'));
-    // common escapes
-    assertEquals("\\b", Util.characterLiteralWithoutSingleQuotes('\b'));
-    assertEquals("\\t", Util.characterLiteralWithoutSingleQuotes('\t'));
-    assertEquals("\\n", Util.characterLiteralWithoutSingleQuotes('\n'));
-    assertEquals("\\f", Util.characterLiteralWithoutSingleQuotes('\f'));
-    assertEquals("\\r", Util.characterLiteralWithoutSingleQuotes('\r'));
-    assertEquals("\"", Util.characterLiteralWithoutSingleQuotes('"'));
-    assertEquals("\\'", Util.characterLiteralWithoutSingleQuotes('\''));
-    assertEquals("\\\\", Util.characterLiteralWithoutSingleQuotes('\\'));
-    // octal escapes
-    assertEquals("\\u0000", Util.characterLiteralWithoutSingleQuotes('\0'));
-    assertEquals("\\u0007", Util.characterLiteralWithoutSingleQuotes('\7'));
-    assertEquals("?", Util.characterLiteralWithoutSingleQuotes('\77'));
-    assertEquals("\\u007f", Util.characterLiteralWithoutSingleQuotes('\177'));
-    assertEquals("¿", Util.characterLiteralWithoutSingleQuotes('\277'));
-    assertEquals("ÿ", Util.characterLiteralWithoutSingleQuotes('\377'));
-    // unicode escapes
-    assertEquals("\\u0000", Util.characterLiteralWithoutSingleQuotes('\u0000'));
-    assertEquals("\\u0001", Util.characterLiteralWithoutSingleQuotes('\u0001'));
-    assertEquals("\\u0002", Util.characterLiteralWithoutSingleQuotes('\u0002'));
-    assertEquals("€", Util.characterLiteralWithoutSingleQuotes('\u20AC'));
-    assertEquals("☃", Util.characterLiteralWithoutSingleQuotes('\u2603'));
-    assertEquals("♠", Util.characterLiteralWithoutSingleQuotes('\u2660'));
-    assertEquals("♣", Util.characterLiteralWithoutSingleQuotes('\u2663'));
-    assertEquals("♥", Util.characterLiteralWithoutSingleQuotes('\u2665'));
-    assertEquals("♦", Util.characterLiteralWithoutSingleQuotes('\u2666'));
-    assertEquals("✵", Util.characterLiteralWithoutSingleQuotes('\u2735'));
-    assertEquals("✺", Util.characterLiteralWithoutSingleQuotes('\u273A'));
-    assertEquals("／", Util.characterLiteralWithoutSingleQuotes('\uFF0F'));
+class UtilTest {
+
+  @TestFactory Stream<DynamicNode> characterLiteralWithoutSingleQuotes() {
+    return Stream.of(
+        dynamicContainer(
+            "basic (not escaped)",
+            Stream.of(
+                assertCharacterLiteralWithoutSingleQuotes("a", 'a'),
+                assertCharacterLiteralWithoutSingleQuotes("b", 'b'),
+                assertCharacterLiteralWithoutSingleQuotes("c", 'c'),
+                assertCharacterLiteralWithoutSingleQuotes("%", '%'))),
+        dynamicContainer(
+            "common escapes",
+            Stream.of(
+                assertCharacterLiteralWithoutSingleQuotes("\\b", '\b'),
+                assertCharacterLiteralWithoutSingleQuotes("\\t", '\t'),
+                assertCharacterLiteralWithoutSingleQuotes("\\n", '\n'),
+                assertCharacterLiteralWithoutSingleQuotes("\\f", '\f'),
+                assertCharacterLiteralWithoutSingleQuotes("\\r", '\r'),
+                assertCharacterLiteralWithoutSingleQuotes("\"", '"'),
+                assertCharacterLiteralWithoutSingleQuotes("\\'", '\''),
+                assertCharacterLiteralWithoutSingleQuotes("\\\\", '\\'))),
+        dynamicContainer(
+            "octal escapes",
+            Stream.of(
+                assertCharacterLiteralWithoutSingleQuotes("\\u0000", '\0'),
+                assertCharacterLiteralWithoutSingleQuotes("\\u0007", '\7'),
+                assertCharacterLiteralWithoutSingleQuotes("?", '\77'),
+                assertCharacterLiteralWithoutSingleQuotes("\\u007f", '\177'),
+                assertCharacterLiteralWithoutSingleQuotes("¿", '\277'),
+                assertCharacterLiteralWithoutSingleQuotes("ÿ", '\377'))),
+        dynamicContainer(
+            "unicode escapes",
+            Stream.of(
+                assertCharacterLiteralWithoutSingleQuotes("\\u0000", '\u0000'),
+                assertCharacterLiteralWithoutSingleQuotes("\\u0001", '\u0001'),
+                assertCharacterLiteralWithoutSingleQuotes("\\u0002", '\u0002'),
+                assertCharacterLiteralWithoutSingleQuotes("€", '\u20AC'),
+                assertCharacterLiteralWithoutSingleQuotes("☃", '\u2603'),
+                assertCharacterLiteralWithoutSingleQuotes("♠", '\u2660'),
+                assertCharacterLiteralWithoutSingleQuotes("♣", '\u2663'),
+                assertCharacterLiteralWithoutSingleQuotes("♥", '\u2665'),
+                assertCharacterLiteralWithoutSingleQuotes("♦", '\u2666'),
+                assertCharacterLiteralWithoutSingleQuotes("✵", '\u2735'),
+                assertCharacterLiteralWithoutSingleQuotes("✺", '\u273A'),
+                assertCharacterLiteralWithoutSingleQuotes("／", '\uFF0F'))));
   }
 
-  @Test public void stringLiteral() {
-    stringLiteral("abc");
-    stringLiteral("♦♥♠♣");
-    stringLiteral("€\\t@\\t$", "€\t@\t$", " ");
-    stringLiteral("abc();\\n\"\n  + \"def();", "abc();\ndef();", " ");
-    stringLiteral("This is \\\"quoted\\\"!", "This is \"quoted\"!", " ");
-    stringLiteral("e^{i\\\\pi}+1=0", "e^{i\\pi}+1=0", " ");
+  private DynamicTest assertCharacterLiteralWithoutSingleQuotes(String expected, char c) {
+    String displayName = "char(" + c + ") -> " + expected;
+    String actual = Util.characterLiteralWithoutSingleQuotes(c);
+    return dynamicTest(displayName, () -> assertEquals(expected, actual));
+  }
+
+  @Test void stringLiteralWithDoubleQuotes() {
+    assertAll(
+        "stringLiteralWithDoubleQuotes assertions",
+        () -> stringLiteral("abc"),
+        () -> stringLiteral("♦♥♠♣"),
+        () -> stringLiteral("€\\t@\\t$", "€\t@\t$"),
+        () -> stringLiteral("abc();\\n\"\n  + \"def();", "abc();\ndef();"),
+        () -> stringLiteral("This is \\\"quoted\\\"!", "This is \"quoted\"!"),
+        () -> stringLiteral("e^{i\\\\pi}+1=0", "e^{i\\pi}+1=0"));
   }
 
   void stringLiteral(String string) {
-    stringLiteral(string, string, " ");
+    stringLiteral(string, string);
   }
 
-  void stringLiteral(String expected, String value, String indent) {
-    assertEquals("\"" + expected + "\"", Util.stringLiteralWithDoubleQuotes(value, indent));
+  void stringLiteral(String expected, String value) {
+    assertEquals("\"" + expected + "\"", Util.stringLiteralWithDoubleQuotes(value, " "));
   }
 }


### PR DESCRIPTION
Proof-of-concept PR showing how-to upgrade to [JUnit 5](http://junit.org/junit5/). Due to the modular architecture of JUnit 5, JUnit Platform executes "legacy" JUnit 4 tests with the Vintage Engine. No code was changed here.

A single test, namely `UtilTest`, was migrated and now uses the new JUnit Jupiter API:

- [assertAll](http://junit.org/junit5/docs/current/api/org/junit/jupiter/api/Assertions.html#assertAll-java.lang.String-java.util.stream.Stream-)
- [Dynamic Tests](http://junit.org/junit5/docs/current/user-guide/#writing-tests-dynamic-tests)