### PR TITLE
Introduce JDK build matrix on Travis CI

### DIFF
--- a/.buildscript/install-jdk.sh
+++ b/.buildscript/install-jdk.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+#
+# Install JDK from "download.java.net"
+#
+# Adapted from https://github.com/sormuras/bach/blob/master/install-jdk.sh
+#
+
+set -e
+
+JDK_FEATURE='10'
+
+TMP=$(curl -L jdk.java.net/${JDK_FEATURE})
+TMP="${TMP#*Most recent build: jdk-${JDK_FEATURE}-ea+}" # remove everything before the number
+TMP="${TMP%%<*}"                                        # remove everything after the number
+JDK_BUILD="$(echo -e "${TMP}" | tr -d '[:space:]')"     # remove all whitespace
+
+JDK_LICENSE='GPL'
+
+while getopts F:B:L: option
+do
+ case "${option}"
+ in
+ F) JDK_FEATURE=${OPTARG};;
+ B) JDK_BUILD=${OPTARG};;
+ L) JDK_LICENSE=${OPTARG};;
+ esac
+done
+
+JDK_BASENAME='jdk'
+if [ "${JDK_LICENSE}" == 'GPL' ]; then
+  JDK_BASENAME='openjdk'
+fi
+
+JDK_ARCHIVE=${JDK_BASENAME}-${JDK_FEATURE}-ea+${JDK_BUILD}_linux-x64_bin.tar.gz
+
+cd ~
+wget http://download.java.net/java/jdk${JDK_FEATURE}/archive/${JDK_BUILD}/${JDK_LICENSE}/${JDK_ARCHIVE}
+tar -xzf ${JDK_ARCHIVE}
+export JAVA_HOME=~/jdk-${JDK_FEATURE}
+export PATH=${JAVA_HOME}/bin:$PATH
+cd -
+
+java --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,15 @@
 language: java
 
-jdk:
-  - oraclejdk8
-
-addons:
-  apt:
-    packages:
-      - oracle-java8-installer # Updates JDK 8 to the latest available.
+matrix:
+  include:
+    - env: JDK='OracleJDK 8'
+      jdk: oraclejdk8
+    - env: JDK='OracleJDK 9'
+      jdk: oraclejdk9
+    - env: JDK='OracleJDK 10'
+      install: . ./.buildscript/install-jdk.sh -F 10 -L BCL
+    - env: JDK='OpenJDK 10'
+      install: . ./.buildscript/install-jdk.sh -F 10 -L GPL
 
 after_success:
   - .buildscript/deploy_snapshot.sh


### PR DESCRIPTION
Just to make sure JavaPoet builds on various JDKs.

There's a warning printed on all JDK >= 9:

```
[...]
Running com.squareup.javapoet.TypesEclipseTest
Annotation processing got disabled, since it requires a 1.6 compliant JVM
[...]
Tests run: 317, Failures: 0, Errors: 0, Skipped: 4
```
But no test fails?! Same test run numbers a generated by JDK 8.
