### PR TITLE
Fix checkState message in CodeWriter

### DIFF
--- a/src/main/java/com/squareup/javapoet/CodeWriter.java
+++ b/src/main/java/com/squareup/javapoet/CodeWriter.java
@@ -116,7 +116,7 @@ final class CodeWriter {
   }
 
   public CodeWriter popPackage() {
-    checkState(this.packageName != NO_PACKAGE, "package already set: %s", this.packageName);
+    checkState(this.packageName != NO_PACKAGE, "package not set");
     this.packageName = NO_PACKAGE;
     return this;
   }


### PR DESCRIPTION
I was scanning through this file and this error message seemed wrong to me. If the checkState fails, the packageName _not_ be set, right?