### PR TITLE
Refactor configurable indent(#622)

### DIFF
--- a/src/main/java/com/squareup/javapoet/JavaFile.java
+++ b/src/main/java/com/squareup/javapoet/JavaFile.java
@@ -268,6 +268,13 @@ public final class JavaFile {
       return this;
     }
 
+    public Builder indent(int indentCount) {
+      char[] indentChars = new char[indentCount];
+      Arrays.fill(indentChars, ' ');
+      this.indent = new String(indentChars);
+      return this;
+    }
+
     public JavaFile build() {
       return new JavaFile(this);
     }

--- a/src/main/java/com/squareup/javapoet/JavaFile.java
+++ b/src/main/java/com/squareup/javapoet/JavaFile.java
@@ -264,6 +264,12 @@ public final class JavaFile {
       return this;
     }
 
+    /**
+     * Sets the indentation of the Java file to the given String, filtering out any invalid characters, such as letters or
+     * symbols. Uses the {@link IndentChar} enum to define which characters are allowed.
+     *
+     * @param indent Value of the indent
+    */
     public Builder indent(String indent) {
       String allowedChars = Arrays.stream(IndentChar.values())
                                   .map(IndentChar::toString).reduce((a, b) -> a+b).orElse(" ");
@@ -271,6 +277,12 @@ public final class JavaFile {
       return this;
     }
 
+    /**
+     * Sets the length of the indentation in the Java file. The character used in the indent is
+     * stored in {@link #indentChar}. See {@link #indentChar(IndentChar)} for setting this value.
+     *
+     * @param indentCount Number of characters to indent with
+     */
     public Builder indent(int indentCount) {
       char[] indentChars = new char[indentCount];
       Arrays.fill(indentChars, indentChar.value());
@@ -278,12 +290,25 @@ public final class JavaFile {
       return this;
     }
 
+    /**
+     * Sets the indentation in the Java file to a given number of given characters. Combines the functionality of
+     * {@link #indent(int)} and {@link #indentChar(IndentChar)}.
+     *
+     * @param indentCount Number of characters to indent with
+     * @param indentChar The character used to indent the file
+     */
     public Builder indent(int indentCount, IndentChar indentChar) {
       this.indentChar = indentChar;
       this.indent(indentCount);
       return this;
     }
 
+    /**
+     * Sets the characters of the indentation in the Java file to the given characters. See {@link #indent(int)} for
+     * setting the number of characters to use.
+     *
+     * @param indentChar The character used to indent the file
+     */
     public Builder indentChar(IndentChar indentChar) {
       this.indentChar = indentChar;
       this.indent = this.indent.replaceAll(".", indentChar.value().toString());
@@ -295,6 +320,9 @@ public final class JavaFile {
     }
   }
 
+  /**
+   * An enum defining characters allowed for use in indentations.
+   */
   public enum IndentChar {
     TAB('\t'), SPACE(' ');
     private final Character indentChar;

--- a/src/main/java/com/squareup/javapoet/JavaFile.java
+++ b/src/main/java/com/squareup/javapoet/JavaFile.java
@@ -275,8 +275,26 @@ public final class JavaFile {
       return this;
     }
 
+    public Builder indentChar(IndentChar indentChar) {
+      this.indent = this.indent.replaceAll(".", indentChar.value().toString());
+      return this;
+    }
+
     public JavaFile build() {
       return new JavaFile(this);
+    }
+  }
+
+  public enum IndentChar {
+    TAB('\t'), SPACE(' ');
+    private final Character indentChar;
+
+    IndentChar(Character indentChar) {
+      this.indentChar = indentChar;
+    }
+
+    public Character value() {
+      return indentChar;
     }
   }
 }

--- a/src/main/java/com/squareup/javapoet/JavaFile.java
+++ b/src/main/java/com/squareup/javapoet/JavaFile.java
@@ -264,7 +264,9 @@ public final class JavaFile {
     }
 
     public Builder indent(String indent) {
-      this.indent = indent.replaceAll("[^\\s\t]", "");;
+      String allowedChars = Arrays.stream(IndentChar.values())
+                                  .map(IndentChar::toString).reduce((a, b) -> a+b).orElse(" ");
+      this.indent = indent.replaceAll("[^"+allowedChars+"]", "");
       return this;
     }
 
@@ -295,6 +297,11 @@ public final class JavaFile {
 
     public Character value() {
       return indentChar;
+    }
+
+    @Override
+    public String toString() {
+      return indentChar.toString();
     }
   }
 }

--- a/src/main/java/com/squareup/javapoet/JavaFile.java
+++ b/src/main/java/com/squareup/javapoet/JavaFile.java
@@ -278,6 +278,12 @@ public final class JavaFile {
       return this;
     }
 
+    public Builder indent(int indentCount, IndentChar indentChar) {
+      this.indentChar = indentChar;
+      this.indent(indentCount);
+      return this;
+    }
+
     public Builder indentChar(IndentChar indentChar) {
       this.indentChar = indentChar;
       this.indent = this.indent.replaceAll(".", indentChar.value().toString());

--- a/src/main/java/com/squareup/javapoet/JavaFile.java
+++ b/src/main/java/com/squareup/javapoet/JavaFile.java
@@ -219,6 +219,7 @@ public final class JavaFile {
     private final CodeBlock.Builder fileComment = CodeBlock.builder();
     private final Set<String> staticImports = new TreeSet<>();
     private boolean skipJavaLangImports;
+    private IndentChar indentChar = IndentChar.SPACE;
     private String indent = "  ";
 
     private Builder(String packageName, TypeSpec typeSpec) {
@@ -272,12 +273,13 @@ public final class JavaFile {
 
     public Builder indent(int indentCount) {
       char[] indentChars = new char[indentCount];
-      Arrays.fill(indentChars, ' ');
+      Arrays.fill(indentChars, indentChar.value());
       this.indent = new String(indentChars);
       return this;
     }
 
     public Builder indentChar(IndentChar indentChar) {
+      this.indentChar = indentChar;
       this.indent = this.indent.replaceAll(".", indentChar.value().toString());
       return this;
     }

--- a/src/main/java/com/squareup/javapoet/JavaFile.java
+++ b/src/main/java/com/squareup/javapoet/JavaFile.java
@@ -264,7 +264,7 @@ public final class JavaFile {
     }
 
     public Builder indent(String indent) {
-      this.indent = indent;
+      this.indent = indent.replaceAll("[^\\s\t]", "");;
       return this;
     }
 

--- a/src/test/java/com/squareup/javapoet/JavaFileTest.java
+++ b/src/test/java/com/squareup/javapoet/JavaFileTest.java
@@ -435,6 +435,33 @@ public final class JavaFileTest {
             + "}\n");
   }
 
+  @Test public void indentCharReplacesAllCharactersInIndentWithGivenIndentChar() {
+    String source = JavaFile.builder("com.squareup.Strings",
+            TypeSpec.classBuilder("MyStringClass")
+                    .addField(String.class, "myString")
+                    .addMethod(
+                            MethodSpec.methodBuilder("returnMyString")
+                                      .returns(String.class)
+                                      .addStatement("return $N", "myString")
+                                      .build())
+                    .build())
+                            .indentChar(JavaFile.IndentChar.TAB)
+                            .build()
+                            .toString();
+    assertThat(source).isEqualTo(""
+            + "package com.squareup.Strings;\n"
+            + "\n"
+            + "import java.lang.String;\n"
+            + "\n"
+            + "class MyStringClass {\n"
+            + "\t\tString myString;\n"
+            + "\n"
+            + "\t\tString returnMyString() {\n"
+            + "\t\t\t\treturn myString;\n"
+            + "\t\t}\n"
+            + "}\n");
+  }
+
   @Test public void conflictingParentName() throws Exception {
     String source = JavaFile.builder("com.squareup.tacos",
         TypeSpec.classBuilder("A")

--- a/src/test/java/com/squareup/javapoet/JavaFileTest.java
+++ b/src/test/java/com/squareup/javapoet/JavaFileTest.java
@@ -381,6 +381,33 @@ public final class JavaFileTest {
             + "}\n");
   }
 
+  @Test public void indentRemovesInvalidCharactersFromGivenStringForAValidIndent() throws Exception {
+    String source = JavaFile.builder("com.squareup.Strings",
+            TypeSpec.classBuilder("MyStringClass")
+                    .addField(String.class, "myString")
+                    .addMethod(
+                            MethodSpec.methodBuilder("returnMyString")
+                                      .returns(String.class)
+                                      .addStatement("return $N", "myString")
+                                      .build())
+                    .build())
+                            .indent("IAmNotAValidIndentButThisSpaceIs: AndSoIsThisTab:\t")
+                            .build()
+                            .toString();
+    assertThat(source).isEqualTo(""
+            + "package com.squareup.Strings;\n"
+            + "\n"
+            + "import java.lang.String;\n"
+            + "\n"
+            + "class MyStringClass {\n"
+            + " \tString myString;\n"
+            + "\n"
+            + " \tString returnMyString() {\n"
+            + " \t \treturn myString;\n"
+            + " \t}\n"
+            + "}\n");
+  }
+
   @Test public void conflictingParentName() throws Exception {
     String source = JavaFile.builder("com.squareup.tacos",
         TypeSpec.classBuilder("A")

--- a/src/test/java/com/squareup/javapoet/JavaFileTest.java
+++ b/src/test/java/com/squareup/javapoet/JavaFileTest.java
@@ -408,6 +408,33 @@ public final class JavaFileTest {
             + "}\n");
   }
 
+  @Test public void indentSetsIndentToNumberOfSpacesMAtchingGivenInt() {
+    String source = JavaFile.builder("com.squareup.Strings",
+            TypeSpec.classBuilder("MyStringClass")
+                    .addField(String.class, "myString")
+                    .addMethod(
+                            MethodSpec.methodBuilder("returnMyString")
+                                      .returns(String.class)
+                                      .addStatement("return $N", "myString")
+                                      .build())
+                    .build())
+                            .indent(4)
+                            .build()
+                            .toString();
+    assertThat(source).isEqualTo(""
+            + "package com.squareup.Strings;\n"
+            + "\n"
+            + "import java.lang.String;\n"
+            + "\n"
+            + "class MyStringClass {\n"
+            + "    String myString;\n"
+            + "\n"
+            + "    String returnMyString() {\n"
+            + "        return myString;\n"
+            + "    }\n"
+            + "}\n");
+  }
+
   @Test public void conflictingParentName() throws Exception {
     String source = JavaFile.builder("com.squareup.tacos",
         TypeSpec.classBuilder("A")

--- a/src/test/java/com/squareup/javapoet/JavaFileTest.java
+++ b/src/test/java/com/squareup/javapoet/JavaFileTest.java
@@ -518,6 +518,33 @@ public final class JavaFileTest {
             + "}\n");
   }
 
+  @Test public void indentWithIntAndIndentCharCorrectlySetsTheCharacterAndLengthOfTheIndent() {
+    String source = JavaFile.builder("com.squareup.Strings",
+            TypeSpec.classBuilder("MyStringClass")
+                    .addField(String.class, "myString")
+                    .addMethod(
+                            MethodSpec.methodBuilder("returnMyString")
+                                      .returns(String.class)
+                                      .addStatement("return $N", "myString")
+                                      .build())
+                    .build())
+                            .indent(4, JavaFile.IndentChar.TAB)
+                            .build()
+                            .toString();
+    assertThat(source).isEqualTo(""
+            + "package com.squareup.Strings;\n"
+            + "\n"
+            + "import java.lang.String;\n"
+            + "\n"
+            + "class MyStringClass {\n"
+            + "\t\t\t\tString myString;\n"
+            + "\n"
+            + "\t\t\t\tString returnMyString() {\n"
+            + "\t\t\t\t\t\t\t\treturn myString;\n"
+            + "\t\t\t\t}\n"
+            + "}\n");
+  }
+
   @Test public void conflictingParentName() throws Exception {
     String source = JavaFile.builder("com.squareup.tacos",
         TypeSpec.classBuilder("A")

--- a/src/test/java/com/squareup/javapoet/JavaFileTest.java
+++ b/src/test/java/com/squareup/javapoet/JavaFileTest.java
@@ -354,6 +354,33 @@ public final class JavaFileTest {
         + "}\n");
   }
 
+  @Test public void indentReplacesDefaultIndentWithGivenString() throws Exception {
+    String source = JavaFile.builder("com.squareup.Strings",
+            TypeSpec.classBuilder("MyStringClass")
+                    .addField(String.class, "myString")
+                    .addMethod(
+                            MethodSpec.methodBuilder("returnMyString")
+                                      .returns(String.class)
+                                      .addStatement("return $N", "myString")
+                                      .build())
+                    .build())
+                            .indent("    ")
+                            .build()
+                            .toString();
+    assertThat(source).isEqualTo(""
+            + "package com.squareup.Strings;\n"
+            + "\n"
+            + "import java.lang.String;\n"
+            + "\n"
+            + "class MyStringClass {\n"
+            + "    String myString;\n"
+            + "\n"
+            + "    String returnMyString() {\n"
+            + "        return myString;\n"
+            + "    }\n"
+            + "}\n");
+  }
+
   @Test public void conflictingParentName() throws Exception {
     String source = JavaFile.builder("com.squareup.tacos",
         TypeSpec.classBuilder("A")

--- a/src/test/java/com/squareup/javapoet/JavaFileTest.java
+++ b/src/test/java/com/squareup/javapoet/JavaFileTest.java
@@ -490,6 +490,34 @@ public final class JavaFileTest {
             + "}\n");
   }
 
+  @Test public void indentCharDoesNothingWhenIndentStringIsLengthZero() {
+    String source = JavaFile.builder("com.squareup.Strings",
+            TypeSpec.classBuilder("MyStringClass")
+                    .addField(String.class, "myString")
+                    .addMethod(
+                            MethodSpec.methodBuilder("returnMyString")
+                                      .returns(String.class)
+                                      .addStatement("return $N", "myString")
+                                      .build())
+                    .build())
+                            .indent(0)
+                            .indentChar(JavaFile.IndentChar.TAB)
+                            .build()
+                            .toString();
+    assertThat(source).isEqualTo(""
+            + "package com.squareup.Strings;\n"
+            + "\n"
+            + "import java.lang.String;\n"
+            + "\n"
+            + "class MyStringClass {\n"
+            + "String myString;\n"
+            + "\n"
+            + "String returnMyString() {\n"
+            + "return myString;\n"
+            + "}\n"
+            + "}\n");
+  }
+
   @Test public void conflictingParentName() throws Exception {
     String source = JavaFile.builder("com.squareup.tacos",
         TypeSpec.classBuilder("A")

--- a/src/test/java/com/squareup/javapoet/JavaFileTest.java
+++ b/src/test/java/com/squareup/javapoet/JavaFileTest.java
@@ -462,6 +462,34 @@ public final class JavaFileTest {
             + "}\n");
   }
 
+  @Test public void indentCharSetsTheCharacterUsedByIndentMethodWithInteger() {
+    String source = JavaFile.builder("com.squareup.Strings",
+            TypeSpec.classBuilder("MyStringClass")
+                    .addField(String.class, "myString")
+                    .addMethod(
+                            MethodSpec.methodBuilder("returnMyString")
+                                      .returns(String.class)
+                                      .addStatement("return $N", "myString")
+                                      .build())
+                    .build())
+                            .indentChar(JavaFile.IndentChar.TAB)
+                            .indent(4)
+                            .build()
+                            .toString();
+    assertThat(source).isEqualTo(""
+            + "package com.squareup.Strings;\n"
+            + "\n"
+            + "import java.lang.String;\n"
+            + "\n"
+            + "class MyStringClass {\n"
+            + "\t\t\t\tString myString;\n"
+            + "\n"
+            + "\t\t\t\tString returnMyString() {\n"
+            + "\t\t\t\t\t\t\t\treturn myString;\n"
+            + "\t\t\t\t}\n"
+            + "}\n");
+  }
+
   @Test public void conflictingParentName() throws Exception {
     String source = JavaFile.builder("com.squareup.tacos",
         TypeSpec.classBuilder("A")


### PR DESCRIPTION
Enhanced indent feature with new methods for setting the indent. Have worked around the original indent method, which setting the String directly, for the sake of backwards compatibility, but I recommend adding the @deprecated annotation to that method.

All development work has followed TDD and comes with JavaDocs.