### PR TITLE
Fail fast with null AnnotationSpec on type.

### DIFF
--- a/src/main/java/com/squareup/javapoet/TypeSpec.java
+++ b/src/main/java/com/squareup/javapoet/TypeSpec.java
@@ -435,6 +435,7 @@ public final class TypeSpec {
     }
 
     public Builder addAnnotation(AnnotationSpec annotationSpec) {
+      checkNotNull(annotationSpec, "annotationSpec == null");
       this.annotations.add(annotationSpec);
       return this;
     }

--- a/src/test/java/com/squareup/javapoet/TypeSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/TypeSpecTest.java
@@ -325,6 +325,27 @@ public final class TypeSpecTest {
         + "}\n");
   }
 
+  @Test public void addAnnotationDisallowsNull() {
+    try {
+      TypeSpec.classBuilder("Foo").addAnnotation((AnnotationSpec) null);
+      fail();
+    } catch (NullPointerException expected) {
+      assertThat(expected).hasMessageThat().isEqualTo("annotationSpec == null");
+    }
+    try {
+      TypeSpec.classBuilder("Foo").addAnnotation((ClassName) null);
+      fail();
+    } catch (NullPointerException expected) {
+      assertThat(expected).hasMessageThat().isEqualTo("type == null");
+    }
+    try {
+      TypeSpec.classBuilder("Foo").addAnnotation((Class<?>) null);
+      fail();
+    } catch (NullPointerException expected) {
+      assertThat(expected).hasMessageThat().isEqualTo("clazz == null");
+    }
+  }
+
   @Test public void enumWithSubclassing() throws Exception {
     TypeSpec roshambo = TypeSpec.enumBuilder("Roshambo")
         .addModifiers(Modifier.PUBLIC)


### PR DESCRIPTION
`fun getGeneratedAnnotation() : AnnotationSpec?`
`addAnnotation(getGeneratedAnnotation())` wouldn't fail until the type was emitted.

(If these low-effort PRs aren't worth anything, feel free to let me know and close, of course.)