### PR TITLE
Upgrade errorprone to 2.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
           <dependency>
             <groupId>com.google.errorprone</groupId>
             <artifactId>error_prone_core</artifactId>
-            <version>2.2.0</version>
+            <version>2.3.1</version>
           </dependency>
         </dependencies>
       </plugin>


### PR DESCRIPTION
Use latest `errorprone` version, which seems to be Java 11-ready.