### PR TITLE
Mutable builder list fields

### DIFF
--- a/src/main/java/com/squareup/javapoet/AnnotationSpec.java
+++ b/src/main/java/com/squareup/javapoet/AnnotationSpec.java
@@ -192,7 +192,8 @@ public final class AnnotationSpec {
 
   public static final class Builder {
     private final TypeName type;
-    private final Map<String, List<CodeBlock>> members = new LinkedHashMap<>();
+
+    public final Map<String, List<CodeBlock>> members = new LinkedHashMap<>();
 
     private Builder(TypeName type) {
       this.type = type;

--- a/src/main/java/com/squareup/javapoet/AnnotationSpec.java
+++ b/src/main/java/com/squareup/javapoet/AnnotationSpec.java
@@ -204,8 +204,6 @@ public final class AnnotationSpec {
     }
 
     public Builder addMember(String name, CodeBlock codeBlock) {
-      checkNotNull(name, "name == null");
-      checkArgument(SourceVersion.isName(name), "not a valid name: %s", name);
       List<CodeBlock> values = members.computeIfAbsent(name, k -> new ArrayList<>());
       values.add(codeBlock);
       return this;
@@ -239,6 +237,10 @@ public final class AnnotationSpec {
     }
 
     public AnnotationSpec build() {
+      for (String name : members.keySet()) {
+        checkNotNull(name, "name == null");
+        checkArgument(SourceVersion.isName(name), "not a valid name: %s", name);
+      }
       return new AnnotationSpec(this);
     }
   }

--- a/src/main/java/com/squareup/javapoet/FieldSpec.java
+++ b/src/main/java/com/squareup/javapoet/FieldSpec.java
@@ -111,9 +111,10 @@ public final class FieldSpec {
     private final String name;
 
     private final CodeBlock.Builder javadoc = CodeBlock.builder();
-    private final List<AnnotationSpec> annotations = new ArrayList<>();
-    private final List<Modifier> modifiers = new ArrayList<>();
     private CodeBlock initializer = null;
+
+    public final List<AnnotationSpec> annotations = new ArrayList<>();
+    public final List<Modifier> modifiers = new ArrayList<>();
 
     private Builder(TypeName type, String name) {
       this.type = type;

--- a/src/main/java/com/squareup/javapoet/JavaFile.java
+++ b/src/main/java/com/squareup/javapoet/JavaFile.java
@@ -225,9 +225,10 @@ public final class JavaFile {
     private final String packageName;
     private final TypeSpec typeSpec;
     private final CodeBlock.Builder fileComment = CodeBlock.builder();
-    private final Set<String> staticImports = new TreeSet<>();
     private boolean skipJavaLangImports;
     private String indent = "  ";
+
+    public final Set<String> staticImports = new TreeSet<>();
 
     private Builder(String packageName, TypeSpec typeSpec) {
       this.packageName = packageName;

--- a/src/main/java/com/squareup/javapoet/MethodSpec.java
+++ b/src/main/java/com/squareup/javapoet/MethodSpec.java
@@ -295,15 +295,16 @@ public final class MethodSpec {
     private String name;
 
     private final CodeBlock.Builder javadoc = CodeBlock.builder();
-    private final List<AnnotationSpec> annotations = new ArrayList<>();
-    private final List<Modifier> modifiers = new ArrayList<>();
-    private List<TypeVariableName> typeVariables = new ArrayList<>();
     private TypeName returnType;
-    private final List<ParameterSpec> parameters = new ArrayList<>();
     private final Set<TypeName> exceptions = new LinkedHashSet<>();
     private final CodeBlock.Builder code = CodeBlock.builder();
     private boolean varargs;
     private CodeBlock defaultValue;
+
+    public final List<TypeVariableName> typeVariables = new ArrayList<>();
+    public final List<AnnotationSpec> annotations = new ArrayList<>();
+    public final List<Modifier> modifiers = new ArrayList<>();
+    public final List<ParameterSpec> parameters = new ArrayList<>();
 
     private Builder(String name) {
       setName(name);

--- a/src/main/java/com/squareup/javapoet/ParameterSpec.java
+++ b/src/main/java/com/squareup/javapoet/ParameterSpec.java
@@ -136,8 +136,8 @@ public final class ParameterSpec {
     private final String name;
     private final CodeBlock.Builder javadoc = CodeBlock.builder();
 
-    private final List<AnnotationSpec> annotations = new ArrayList<>();
-    private final List<Modifier> modifiers = new ArrayList<>();
+    public final List<AnnotationSpec> annotations = new ArrayList<>();
+    public final List<Modifier> modifiers = new ArrayList<>();
 
     private Builder(TypeName type, String name) {
       this.type = type;

--- a/src/main/java/com/squareup/javapoet/TypeSpec.java
+++ b/src/main/java/com/squareup/javapoet/TypeSpec.java
@@ -601,7 +601,8 @@ public final class TypeSpec {
       }
 
       if (!typeVariables.isEmpty()) {
-        checkState(anonymousTypeArguments == null, "typevariables are forbidden on anonymous types.");
+        checkState(anonymousTypeArguments == null,
+            "typevariables are forbidden on anonymous types.");
         for (TypeVariableName typeVariableName : typeVariables) {
           checkArgument(typeVariableName != null, "typeVariables contain null");
         }

--- a/src/main/java/com/squareup/javapoet/TypeSpec.java
+++ b/src/main/java/com/squareup/javapoet/TypeSpec.java
@@ -455,16 +455,11 @@ public final class TypeSpec {
     }
 
     public Builder addModifiers(Modifier... modifiers) {
-      checkState(anonymousTypeArguments == null, "forbidden on anonymous types.");
-      for (Modifier modifier : modifiers) {
-        checkArgument(modifier != null, "modifiers contain null");
-        this.modifiers.add(modifier);
-      }
+      Collections.addAll(this.modifiers, modifiers);
       return this;
     }
 
     public Builder addTypeVariables(Iterable<TypeVariableName> typeVariables) {
-      checkState(anonymousTypeArguments == null, "forbidden on anonymous types.");
       checkArgument(typeVariables != null, "typeVariables == null");
       for (TypeVariableName typeVariable : typeVariables) {
         this.typeVariables.add(typeVariable);
@@ -473,7 +468,6 @@ public final class TypeSpec {
     }
 
     public Builder addTypeVariable(TypeVariableName typeVariable) {
-      checkState(anonymousTypeArguments == null, "forbidden on anonymous types.");
       typeVariables.add(typeVariable);
       return this;
     }
@@ -514,10 +508,6 @@ public final class TypeSpec {
     }
 
     public Builder addEnumConstant(String name, TypeSpec typeSpec) {
-      checkState(kind == Kind.ENUM, "%s is not enum", this.name);
-      checkArgument(typeSpec.anonymousTypeArguments != null,
-          "enum constants must have anonymous type arguments");
-      checkArgument(SourceVersion.isName(name), "not a valid enum constant: %s", name);
       enumConstants.put(name, typeSpec);
       return this;
     }
@@ -531,12 +521,6 @@ public final class TypeSpec {
     }
 
     public Builder addField(FieldSpec fieldSpec) {
-      if (kind == Kind.INTERFACE || kind == Kind.ANNOTATION) {
-        requireExactlyOneOf(fieldSpec.modifiers, Modifier.PUBLIC, Modifier.PRIVATE);
-        Set<Modifier> check = EnumSet.of(Modifier.STATIC, Modifier.FINAL);
-        checkState(fieldSpec.modifiers.containsAll(check), "%s %s.%s requires modifiers %s",
-            kind, name, fieldSpec.name, check);
-      }
       fieldSpecs.add(fieldSpec);
       return this;
     }
@@ -575,23 +559,6 @@ public final class TypeSpec {
     }
 
     public Builder addMethod(MethodSpec methodSpec) {
-      if (kind == Kind.INTERFACE) {
-        requireExactlyOneOf(methodSpec.modifiers, Modifier.ABSTRACT, Modifier.STATIC,
-            Modifier.DEFAULT);
-        requireExactlyOneOf(methodSpec.modifiers, Modifier.PUBLIC, Modifier.PRIVATE);
-      } else if (kind == Kind.ANNOTATION) {
-        checkState(methodSpec.modifiers.equals(kind.implicitMethodModifiers),
-            "%s %s.%s requires modifiers %s",
-            kind, name, methodSpec.name, kind.implicitMethodModifiers);
-      }
-      if (kind != Kind.ANNOTATION) {
-        checkState(methodSpec.defaultValue == null, "%s %s.%s cannot have a default value",
-            kind, name, methodSpec.name);
-      }
-      if (kind != Kind.INTERFACE) {
-        checkState(!methodSpec.hasModifier(Modifier.DEFAULT), "%s %s.%s cannot be default",
-            kind, name, methodSpec.name);
-      }
       methodSpecs.add(methodSpec);
       return this;
     }
@@ -605,9 +572,6 @@ public final class TypeSpec {
     }
 
     public Builder addType(TypeSpec typeSpec) {
-      checkArgument(typeSpec.modifiers.containsAll(kind.implicitTypeModifiers),
-          "%s %s.%s requires modifiers %s", kind, name, typeSpec.name,
-          kind.implicitTypeModifiers);
       typeSpecs.add(typeSpec);
       return this;
     }
@@ -618,8 +582,72 @@ public final class TypeSpec {
     }
 
     public TypeSpec build() {
+      for (AnnotationSpec annotationSpec : annotations) {
+        checkNotNull(annotationSpec, "annotationSpec == null");
+      }
+
+      if (!modifiers.isEmpty()) {
+        checkState(anonymousTypeArguments == null, "forbidden on anonymous types.");
+        for (Modifier modifier : modifiers) {
+          checkArgument(modifier != null, "modifiers contain null");
+        }
+      }
+
       checkArgument(kind != Kind.ENUM || !enumConstants.isEmpty(),
           "at least one enum constant is required for %s", name);
+
+      for (TypeName superinterface : superinterfaces) {
+        checkArgument(superinterface != null, "superinterfaces contains null");
+      }
+
+      if (!typeVariables.isEmpty()) {
+        checkState(anonymousTypeArguments == null, "typevariables are forbidden on anonymous types.");
+        for (TypeVariableName typeVariableName : typeVariables) {
+          checkArgument(typeVariableName != null, "typeVariables contain null");
+        }
+      }
+
+      for (Map.Entry<String, TypeSpec> enumConstant : enumConstants.entrySet()) {
+        checkState(kind == Kind.ENUM, "%s is not enum", this.name);
+        checkArgument(enumConstant.getValue().anonymousTypeArguments != null,
+            "enum constants must have anonymous type arguments");
+        checkArgument(SourceVersion.isName(name), "not a valid enum constant: %s", name);
+      }
+
+      for (FieldSpec fieldSpec : fieldSpecs) {
+        if (kind == Kind.INTERFACE || kind == Kind.ANNOTATION) {
+          requireExactlyOneOf(fieldSpec.modifiers, Modifier.PUBLIC, Modifier.PRIVATE);
+          Set<Modifier> check = EnumSet.of(Modifier.STATIC, Modifier.FINAL);
+          checkState(fieldSpec.modifiers.containsAll(check), "%s %s.%s requires modifiers %s",
+              kind, name, fieldSpec.name, check);
+        }
+      }
+
+      for (MethodSpec methodSpec : methodSpecs) {
+        if (kind == Kind.INTERFACE) {
+          requireExactlyOneOf(methodSpec.modifiers, Modifier.ABSTRACT, Modifier.STATIC,
+              Modifier.DEFAULT);
+          requireExactlyOneOf(methodSpec.modifiers, Modifier.PUBLIC, Modifier.PRIVATE);
+        } else if (kind == Kind.ANNOTATION) {
+          checkState(methodSpec.modifiers.equals(kind.implicitMethodModifiers),
+              "%s %s.%s requires modifiers %s",
+              kind, name, methodSpec.name, kind.implicitMethodModifiers);
+        }
+        if (kind != Kind.ANNOTATION) {
+          checkState(methodSpec.defaultValue == null, "%s %s.%s cannot have a default value",
+              kind, name, methodSpec.name);
+        }
+        if (kind != Kind.INTERFACE) {
+          checkState(!methodSpec.hasModifier(Modifier.DEFAULT), "%s %s.%s cannot be default",
+              kind, name, methodSpec.name);
+        }
+      }
+
+      for (TypeSpec typeSpec : typeSpecs) {
+        checkArgument(typeSpec.modifiers.containsAll(kind.implicitTypeModifiers),
+            "%s %s.%s requires modifiers %s", kind, name, typeSpec.name,
+            kind.implicitTypeModifiers);
+      }
 
       boolean isAbstract = modifiers.contains(Modifier.ABSTRACT) || kind != Kind.CLASS;
       for (MethodSpec methodSpec : methodSpecs) {

--- a/src/main/java/com/squareup/javapoet/TypeSpec.java
+++ b/src/main/java/com/squareup/javapoet/TypeSpec.java
@@ -400,18 +400,19 @@ public final class TypeSpec {
     private final CodeBlock anonymousTypeArguments;
 
     private final CodeBlock.Builder javadoc = CodeBlock.builder();
-    private final List<AnnotationSpec> annotations = new ArrayList<>();
-    private final List<Modifier> modifiers = new ArrayList<>();
-    private final List<TypeVariableName> typeVariables = new ArrayList<>();
     private TypeName superclass = ClassName.OBJECT;
-    private final List<TypeName> superinterfaces = new ArrayList<>();
-    private final Map<String, TypeSpec> enumConstants = new LinkedHashMap<>();
-    private final List<FieldSpec> fieldSpecs = new ArrayList<>();
     private final CodeBlock.Builder staticBlock = CodeBlock.builder();
     private final CodeBlock.Builder initializerBlock = CodeBlock.builder();
-    private final List<MethodSpec> methodSpecs = new ArrayList<>();
-    private final List<TypeSpec> typeSpecs = new ArrayList<>();
-    private final List<Element> originatingElements = new ArrayList<>();
+
+    public final Map<String, TypeSpec> enumConstants = new LinkedHashMap<>();
+    public final List<AnnotationSpec> annotations = new ArrayList<>();
+    public final List<Modifier> modifiers = new ArrayList<>();
+    public final List<TypeVariableName> typeVariables = new ArrayList<>();
+    public final List<TypeName> superinterfaces = new ArrayList<>();
+    public final List<FieldSpec> fieldSpecs = new ArrayList<>();
+    public final List<MethodSpec> methodSpecs = new ArrayList<>();
+    public final List<TypeSpec> typeSpecs = new ArrayList<>();
+    public final List<Element> originatingElements = new ArrayList<>();
 
     private Builder(Kind kind, String name,
         CodeBlock anonymousTypeArguments) {

--- a/src/test/java/com/squareup/javapoet/AnnotationSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/AnnotationSpecTest.java
@@ -20,6 +20,8 @@ import java.lang.annotation.Annotation;
 import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.util.Arrays;
+
 import javax.lang.model.element.TypeElement;
 import org.junit.Rule;
 import org.junit.Test;
@@ -369,6 +371,16 @@ public final class AnnotationSpecTest {
     } catch (IllegalArgumentException e) {
       assertThat(e).hasMessageThat().isEqualTo("not a valid name: @");
     }
+  }
+
+  @Test public void modifyMembers() {
+    AnnotationSpec.Builder builder = AnnotationSpec.builder(SuppressWarnings.class)
+            .addMember("value", "$S", "Foo");
+    
+    builder.members.clear();
+    builder.members.put("value", Arrays.asList(CodeBlock.of("$S", "Bar")));
+
+    assertThat(builder.build().toString()).isEqualTo("@java.lang.SuppressWarnings(\"Bar\")");
   }
 
   private String toString(TypeSpec typeSpec) {

--- a/src/test/java/com/squareup/javapoet/FieldSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/FieldSpecTest.java
@@ -46,4 +46,21 @@ public class FieldSpecTest {
           .isEqualTo("annotationSpecs == null");
     }
   }
+
+  @Test public void modifyAnnotations() {
+    FieldSpec.Builder builder = FieldSpec.builder(int.class, "foo")
+          .addAnnotation(Override.class)
+          .addAnnotation(SuppressWarnings.class);
+
+    builder.annotations.remove(1);
+    assertThat(builder.build().annotations).hasSize(1);
+  }
+
+  @Test public void modifyModifiers() {
+    FieldSpec.Builder builder = FieldSpec.builder(int.class, "foo")
+          .addModifiers(Modifier.PUBLIC, Modifier.STATIC);
+
+    builder.modifiers.remove(1);
+    assertThat(builder.build().modifiers).containsExactly(Modifier.PUBLIC);
+  }
 }

--- a/src/test/java/com/squareup/javapoet/JavaFileTest.java
+++ b/src/test/java/com/squareup/javapoet/JavaFileTest.java
@@ -15,6 +15,7 @@
  */
 package com.squareup.javapoet;
 
+import java.io.File;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -687,6 +688,26 @@ public final class JavaFileTest {
         + "\n"
         + "class Taco extends com.taco.bell.A {\n"
         + "  A a;\n"
+        + "}\n");
+  }
+
+  @Test public void modifyStaticImports() throws Exception {
+    JavaFile.Builder builder = JavaFile.builder("com.squareup.tacos",
+        TypeSpec.classBuilder("Taco")
+            .build())
+            .addStaticImport(File.class, "separator");
+
+    builder.staticImports.clear();
+    builder.staticImports.add(File.class.getCanonicalName() + ".separatorChar");
+
+    String source = builder.build().toString();
+
+    assertThat(source).isEqualTo(""
+        + "package com.squareup.tacos;\n"
+        + "\n"
+        + "import static java.io.File.separatorChar;\n"
+        + "\n"
+        + "class Taco {\n"
         + "}\n");
   }
 }

--- a/src/test/java/com/squareup/javapoet/MethodSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/MethodSpecTest.java
@@ -356,8 +356,41 @@ public final class MethodSpecTest {
         .setName("revisedMethod")
         .build();
 
-    assertThat(methodSpec.toString()).isEqualTo(""
-        + "void revisedMethod() {\n"
-        + "}\n");
+    assertThat(methodSpec.toString()).isEqualTo("" + "void revisedMethod() {\n" + "}\n");
+  }
+
+  @Test public void modifyAnnotations() {
+    MethodSpec.Builder builder = MethodSpec.methodBuilder("foo")
+            .addAnnotation(Override.class)
+            .addAnnotation(SuppressWarnings.class);
+
+    builder.annotations.remove(1);
+    assertThat(builder.build().annotations).hasSize(1);
+  }
+
+  @Test public void modifyModifiers() {
+    MethodSpec.Builder builder = MethodSpec.methodBuilder("foo")
+            .addModifiers(Modifier.PUBLIC, Modifier.STATIC);
+
+    builder.modifiers.remove(1);
+    assertThat(builder.build().modifiers).containsExactly(Modifier.PUBLIC);
+  }
+
+  @Test public void modifyParameters() {
+    MethodSpec.Builder builder = MethodSpec.methodBuilder("foo")
+            .addParameter(int.class, "source");
+
+    builder.parameters.remove(0);
+    assertThat(builder.build().parameters).isEmpty();
+  }
+
+  @Test public void modifyTypeVariables() {
+    TypeVariableName t = TypeVariableName.get("T");
+    MethodSpec.Builder builder = MethodSpec.methodBuilder("foo")
+            .addTypeVariable(t)
+            .addTypeVariable(TypeVariableName.get("V"));
+
+    builder.typeVariables.remove(1);
+    assertThat(builder.build().typeVariables).containsExactly(t);
   }
 }

--- a/src/test/java/com/squareup/javapoet/ParameterSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/ParameterSpecTest.java
@@ -109,11 +109,28 @@ public class ParameterSpecTest {
     modifiers.add(Modifier.PUBLIC);
 
     try {
-      ParameterSpec.builder(int.class, "foo").addModifiers(modifiers);
+      ParameterSpec.builder(int.class, "foo")
+          .addModifiers(modifiers);
       fail();
     } catch (Exception e) {
-      assertThat(e.getMessage())
-          .isEqualTo("unexpected parameter modifier: public");
+      assertThat(e.getMessage()).isEqualTo("unexpected parameter modifier: public");
     }
+  }
+
+  @Test public void modifyAnnotations() {
+    ParameterSpec.Builder builder = ParameterSpec.builder(int.class, "foo")
+            .addAnnotation(Override.class)
+            .addAnnotation(SuppressWarnings.class);
+
+    builder.annotations.remove(1);
+    assertThat(builder.build().annotations).hasSize(1);
+  }
+
+  @Test public void modifyModifiers() {
+    ParameterSpec.Builder builder = ParameterSpec.builder(int.class, "foo")
+            .addModifiers(Modifier.PUBLIC, Modifier.STATIC);
+
+    builder.modifiers.remove(1);
+    assertThat(builder.build().modifiers).containsExactly(Modifier.PUBLIC);
   }
 }

--- a/src/test/java/com/squareup/javapoet/ParameterSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/ParameterSpecTest.java
@@ -25,6 +25,7 @@ import javax.lang.model.element.VariableElement;
 import javax.lang.model.util.Elements;
 import org.junit.Before;
 import org.junit.Rule;
+import javax.lang.model.element.Modifier;
 import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertThat;
@@ -32,8 +33,6 @@ import static com.squareup.javapoet.TestUtil.findFirst;
 import static javax.lang.model.util.ElementFilter.fieldsIn;
 import static javax.lang.model.util.ElementFilter.methodsIn;
 import static org.junit.Assert.fail;
-
-import javax.lang.model.element.Modifier;
 
 public class ParameterSpecTest {
   @Rule public final CompilationRule compilation = new CompilationRule();

--- a/src/test/java/com/squareup/javapoet/TypeSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/TypeSpecTest.java
@@ -1911,7 +1911,7 @@ public final class TypeSpecTest {
 
   @Test public void nullModifiersAddition() {
     try {
-      TypeSpec.classBuilder("Taco").addModifiers((Modifier) null);
+      TypeSpec.classBuilder("Taco").addModifiers((Modifier) null).build();
       fail();
     } catch(IllegalArgumentException expected) {
       assertThat(expected.getMessage())

--- a/src/test/java/com/squareup/javapoet/TypeSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/TypeSpecTest.java
@@ -17,6 +17,14 @@ package com.squareup.javapoet;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.testing.compile.CompilationRule;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mockito;
+
+import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
 import java.math.BigDecimal;
@@ -31,15 +39,11 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.Callable;
+
 import javax.lang.model.element.Element;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeMirror;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
-import org.mockito.Mockito;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
@@ -2423,5 +2427,93 @@ public final class TypeSpecTest {
     assertThat(TypeSpec.interfaceBuilder(className).build().name).isEqualTo("Example");
     assertThat(TypeSpec.enumBuilder(className).addEnumConstant("A").build().name).isEqualTo("Example");
     assertThat(TypeSpec.annotationBuilder(className).build().name).isEqualTo("Example");
+  }
+
+  @Test
+  public void modifyAnnotations() {
+    TypeSpec.Builder builder =
+        TypeSpec.classBuilder("Taco")
+            .addAnnotation(Override.class)
+            .addAnnotation(SuppressWarnings.class);
+
+    builder.annotations.remove(1);
+    assertThat(builder.build().annotations).hasSize(1);
+  }
+
+  @Test
+  public void modifyModifiers() {
+    TypeSpec.Builder builder =
+        TypeSpec.classBuilder("Taco").addModifiers(Modifier.PUBLIC, Modifier.FINAL);
+
+    builder.modifiers.remove(1);
+    assertThat(builder.build().modifiers).containsExactly(Modifier.PUBLIC);
+  }
+
+  @Test
+  public void modifyFields() {
+    TypeSpec.Builder builder = TypeSpec.classBuilder("Taco")
+        .addField(int.class, "source");
+
+    builder.fieldSpecs.remove(0);
+    assertThat(builder.build().fieldSpecs).isEmpty();
+  }
+
+  @Test
+  public void modifyTypeVariables() {
+    TypeVariableName t = TypeVariableName.get("T");
+    TypeSpec.Builder builder =
+        TypeSpec.classBuilder("Taco")
+            .addTypeVariable(t)
+            .addTypeVariable(TypeVariableName.get("V"));
+
+    builder.typeVariables.remove(1);
+    assertThat(builder.build().typeVariables).containsExactly(t);
+  }
+
+  @Test
+  public void modifySuperinterfaces() {
+    TypeSpec.Builder builder = TypeSpec.classBuilder("Taco")
+        .addSuperinterface(File.class);
+
+    builder.superinterfaces.clear();
+    assertThat(builder.build().superinterfaces).isEmpty();
+  }
+
+  @Test
+  public void modifyMethods() {
+    TypeSpec.Builder builder = TypeSpec.classBuilder("Taco")
+        .addMethod(MethodSpec.methodBuilder("bell").build());
+
+    builder.methodSpecs.clear();
+    assertThat(builder.build().methodSpecs).isEmpty();
+  }
+
+  @Test
+  public void modifyTypes() {
+    TypeSpec.Builder builder = TypeSpec.classBuilder("Taco")
+        .addType(TypeSpec.classBuilder("Bell").build());
+
+    builder.typeSpecs.clear();
+    assertThat(builder.build().typeSpecs).isEmpty();
+  }
+
+  @Test
+  public void modifyEnumConstants() {
+    TypeSpec constantType = TypeSpec.anonymousClassBuilder("").build();
+    TypeSpec.Builder builder = TypeSpec.enumBuilder("Taco")
+        .addEnumConstant("BELL", constantType)
+        .addEnumConstant("WUT", TypeSpec.anonymousClassBuilder("").build());
+
+    builder.enumConstants.remove("WUT");
+    assertThat(builder.build().enumConstants).containsExactly("BELL", constantType);
+  }
+
+  @Test
+  public void modifyOriginatingElements() {
+    TypeSpec.Builder builder = TypeSpec.classBuilder("Taco")
+        .addOriginatingElement(Mockito.mock(Element.class));
+
+    builder.originatingElements.clear();
+    assertThat(builder.build().originatingElements).isEmpty();
   }
 }


### PR DESCRIPTION
A case that often comes up for us is that if you expose a post processing API in code gen, builders become a pain because any list property in a builder is append-only. 

What this means is that in order to modify one of them, you have to manually make a new copy of the type that builder is constructing and copy over every property but the one you're trying to change. Then for the one you're changing, you have to copy all the other ones and then your modified version.

A classic example is a typespec with a methodspec in it that you want to add an annotation to.

After talking with @swankjesse about it, we decided to take the approach of making builders' collection fields public and mutable with the idea that if you're manipulating those directly, we just assume you know what you're doing and defer to checks in `build()` to enforce things.