### PR TITLE
Change AnnotationSpec.type to be a ClassName

### DIFF
--- a/src/main/java/com/squareup/javapoet/AnnotationSpec.java
+++ b/src/main/java/com/squareup/javapoet/AnnotationSpec.java
@@ -42,7 +42,7 @@ import static com.squareup.javapoet.Util.checkNotNull;
 
 /** A generated annotation on a declaration. */
 public final class AnnotationSpec {
-  public final TypeName type;
+  public final ClassName type;
   public final Map<String, List<CodeBlock>> members;
 
   private AnnotationSpec(Builder builder) {
@@ -191,10 +191,10 @@ public final class AnnotationSpec {
   }
 
   public static final class Builder {
-    private final TypeName type;
+    private final ClassName type;
     private final Map<String, List<CodeBlock>> members = new LinkedHashMap<>();
 
-    private Builder(TypeName type) {
+    private Builder(ClassName type) {
       this.type = type;
     }
 


### PR DESCRIPTION
Annotation types _must_ be Classes, right? I think that's reflected in the API for the builder that it only accepts `Class<?>` or `ClassName`

Note that this would technically be a binary-incompatible change.

I'd be happy to also make this change on the KotlinPoet side of things too.