### PR TITLE
Allow multiple TypeSpecs to be added to a JavaFile

### DIFF
--- a/src/test/java/com/squareup/javapoet/JavaFileTest.java
+++ b/src/test/java/com/squareup/javapoet/JavaFileTest.java
@@ -20,6 +20,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import javax.lang.model.element.Modifier;
+
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -689,4 +690,52 @@ public final class JavaFileTest {
         + "  A a;\n"
         + "}\n");
   }
+
+  @Test
+  public void multipleTypeSpecs() {
+    TypeSpec fooInterface = TypeSpec.interfaceBuilder("Foo")
+        .addModifiers(Modifier.PUBLIC)
+        .addMethod(
+            MethodSpec.methodBuilder("getBar")
+                .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+                .returns(ClassName.get(String.class))
+                .build())
+        .build();
+
+    TypeSpec fooImpl = TypeSpec.classBuilder("FooImpl")
+        .addSuperinterface(ClassName.get("", fooInterface.name))
+        .addMethod(
+            MethodSpec.methodBuilder("getBar")
+                .addModifiers(Modifier.PUBLIC)
+                .addStatement("$T sb = new $T()",
+                    ClassName.get(StringBuilder.class),
+                    ClassName.get(StringBuilder.class))
+                .addStatement("sb.append(\"bar\")")
+                .addStatement("return sb.toString()")
+                .returns(String.class)
+                .build())
+        .build();
+
+    String source = JavaFile.builder("com.squareup.tacos", fooInterface, fooImpl).build().toString();
+
+    assertThat(source).isEqualTo("" +
+        "package com.squareup.tacos;\n" +
+        "\n" +
+        "import java.lang.String;\n" +
+        "import java.lang.StringBuilder;\n" +
+        "\n" +
+        "public interface Foo {\n" +
+        "  String getBar();\n" +
+        "}\n" +
+        "class FooImpl implements Foo {\n" +
+        "  public String getBar() {\n" +
+        "    StringBuilder sb = new StringBuilder();\n" +
+        "    sb.append(\"bar\");\n" +
+        "    return sb.toString();\n" +
+        "  }\n" +
+        "}\n" +
+        ""
+    );
+  }
+
 }


### PR DESCRIPTION
This change allows multiple `TypeSpec`s to be added to a single `JavaFile`.

This allows files like this to be generated:

```java
package com.squareup.tacos;

import java.lang.String;
import java.lang.StringBuilder;

public interface Foo {
  String getBar();
}
class FooImpl implements Foo {
  public String getBar() {
    StringBuilder sb = new StringBuilder();
    sb.append("bar");
    return sb.toString();
  }
}
```

A more compelling/complete example would have a static factory method on the interface that built and returned the package-private implementation but this should illustrate the point well enough.

There's room for improvement by validating that the first `TypeSpec` has as either public or package visibility and that any additional specs have at most package visibility.