### PR TITLE
Add Javadoc to ParameterSpec

### DIFF
--- a/src/main/java/com/squareup/javapoet/MethodSpec.java
+++ b/src/main/java/com/squareup/javapoet/MethodSpec.java
@@ -142,7 +142,7 @@ public final class MethodSpec {
 
   private CodeBlock javadocWithParameters() {
     CodeBlock.Builder builder = javadoc.toBuilder();
-    for (ParameterSpec parameterSpec: parameters) {
+    for (ParameterSpec parameterSpec : parameters) {
       if (!parameterSpec.javadoc.isEmpty()) {
         builder.add("@param $L $L", parameterSpec.name, parameterSpec.javadoc);
       }

--- a/src/main/java/com/squareup/javapoet/MethodSpec.java
+++ b/src/main/java/com/squareup/javapoet/MethodSpec.java
@@ -145,7 +145,8 @@ public final class MethodSpec {
     boolean emitTagNewline = true;
     for (ParameterSpec parameterSpec : parameters) {
       if (!parameterSpec.javadoc.isEmpty()) {
-        if (emitTagNewline) builder.add("\n");
+        // Emit a new line before @param section only if the method javadoc is present.
+        if (emitTagNewline && !javadoc.isEmpty()) builder.add("\n");
         emitTagNewline = false;
         builder.add("@param $L $L", parameterSpec.name, parameterSpec.javadoc);
       }

--- a/src/main/java/com/squareup/javapoet/MethodSpec.java
+++ b/src/main/java/com/squareup/javapoet/MethodSpec.java
@@ -63,6 +63,8 @@ public final class MethodSpec {
         "last parameter of varargs method %s must be an array", builder.name);
 
     this.name = checkNotNull(builder.name, "name == null");
+    // Add parameter Javadoc to the method Javadoc
+    builder.javadoc.add(builder.parameterJavadoc.build());
     this.javadoc = builder.javadoc.build();
     this.annotations = Util.immutableList(builder.annotations);
     this.modifiers = Util.immutableSet(builder.modifiers);
@@ -281,6 +283,7 @@ public final class MethodSpec {
     private final String name;
 
     private final CodeBlock.Builder javadoc = CodeBlock.builder();
+    private final CodeBlock.Builder parameterJavadoc = CodeBlock.builder();
     private final List<AnnotationSpec> annotations = new ArrayList<>();
     private final List<Modifier> modifiers = new ArrayList<>();
     private List<TypeVariableName> typeVariables = new ArrayList<>();
@@ -371,14 +374,23 @@ public final class MethodSpec {
     public Builder addParameters(Iterable<ParameterSpec> parameterSpecs) {
       checkArgument(parameterSpecs != null, "parameterSpecs == null");
       for (ParameterSpec parameterSpec : parameterSpecs) {
+        addParameterJavadoc(parameterSpec);
         this.parameters.add(parameterSpec);
       }
       return this;
     }
 
     public Builder addParameter(ParameterSpec parameterSpec) {
+      addParameterJavadoc(parameterSpec);
       this.parameters.add(parameterSpec);
       return this;
+    }
+
+    private void addParameterJavadoc(ParameterSpec parameterSpec) {
+      if (!parameterSpec.javadoc.isEmpty()) {
+        this.parameterJavadoc.add("@param $L ", parameterSpec.name)
+            .add(parameterSpec.javadoc);
+      }
     }
 
     public Builder addParameter(TypeName type, String name, Modifier... modifiers) {

--- a/src/main/java/com/squareup/javapoet/MethodSpec.java
+++ b/src/main/java/com/squareup/javapoet/MethodSpec.java
@@ -142,8 +142,11 @@ public final class MethodSpec {
 
   private CodeBlock javadocWithParameters() {
     CodeBlock.Builder builder = javadoc.toBuilder();
+    boolean emitTagNewline = true;
     for (ParameterSpec parameterSpec : parameters) {
       if (!parameterSpec.javadoc.isEmpty()) {
+        if (emitTagNewline) builder.add("\n");
+        emitTagNewline = false;
         builder.add("@param $L $L", parameterSpec.name, parameterSpec.javadoc);
       }
     }

--- a/src/main/java/com/squareup/javapoet/MethodSpec.java
+++ b/src/main/java/com/squareup/javapoet/MethodSpec.java
@@ -388,8 +388,7 @@ public final class MethodSpec {
 
     private void addParameterJavadoc(ParameterSpec parameterSpec) {
       if (!parameterSpec.javadoc.isEmpty()) {
-        this.parameterJavadoc.add("@param $L ", parameterSpec.name)
-            .add(parameterSpec.javadoc);
+        this.parameterJavadoc.add("@param $L $L", parameterSpec.name, parameterSpec.javadoc);
       }
     }
 

--- a/src/main/java/com/squareup/javapoet/ParameterSpec.java
+++ b/src/main/java/com/squareup/javapoet/ParameterSpec.java
@@ -35,12 +35,14 @@ public final class ParameterSpec {
   public final List<AnnotationSpec> annotations;
   public final Set<Modifier> modifiers;
   public final TypeName type;
+  public final CodeBlock javadoc;
 
   private ParameterSpec(Builder builder) {
     this.name = checkNotNull(builder.name, "name == null");
     this.annotations = Util.immutableList(builder.annotations);
     this.modifiers = Util.immutableSet(builder.modifiers);
     this.type = checkNotNull(builder.type, "type == null");
+    this.javadoc = builder.javadoc.build();
   }
 
   public boolean hasModifier(Modifier modifier) {
@@ -121,6 +123,7 @@ public final class ParameterSpec {
   public static final class Builder {
     private final TypeName type;
     private final String name;
+    private final CodeBlock.Builder javadoc = CodeBlock.builder();
 
     private final List<AnnotationSpec> annotations = new ArrayList<>();
     private final List<Modifier> modifiers = new ArrayList<>();
@@ -128,6 +131,16 @@ public final class ParameterSpec {
     private Builder(TypeName type, String name) {
       this.type = type;
       this.name = name;
+    }
+
+    public Builder addJavadoc(String format, Object... args) {
+      javadoc.add(format, args);
+      return this;
+    }
+
+    public Builder addJavadoc(CodeBlock block) {
+      javadoc.add(block);
+      return this;
     }
 
     public Builder addAnnotations(Iterable<AnnotationSpec> annotationSpecs) {

--- a/src/test/java/com/squareup/javapoet/MethodSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/MethodSpecTest.java
@@ -270,6 +270,40 @@ public final class MethodSpecTest {
     assertThat(a.hashCode()).isEqualTo(b.hashCode());
   }
 
+  @Test public void withoutParameterJavaDoc() {
+    MethodSpec methodSpec = MethodSpec.methodBuilder("getTaco")
+        .addModifiers(Modifier.PRIVATE)
+        .addParameter(TypeName.DOUBLE, "money")
+        .addJavadoc("Gets the best Taco\n")
+        .build();
+    assertThat(methodSpec.toString()).isEqualTo(""
+        + "/**\n"
+        + " * Gets the best Taco\n"
+        + " */\n"
+        + "private void getTaco(double money) {\n"
+        + "}\n");
+  }
+
+  @Test public void withParameterJavaDoc() {
+    MethodSpec methodSpec = MethodSpec.methodBuilder("getTaco")
+        .addParameter(ParameterSpec.builder(TypeName.DOUBLE, "money")
+            .addJavadoc("the amount required to buy the taco.\n")
+            .build())
+        .addParameter(ParameterSpec.builder(TypeName.INT, "count")
+            .addJavadoc("the number of Tacos to buy.\n")
+            .build())
+        .addJavadoc("Gets the best Taco money can buy.\n")
+        .build();
+    assertThat(methodSpec.toString()).isEqualTo(""
+        + "/**\n"
+        + " * Gets the best Taco money can buy.\n"
+        + " * @param money the amount required to buy the taco.\n"
+        + " * @param count the number of Tacos to buy.\n"
+        + " */\n"
+        + "void getTaco(double money, int count) {\n"
+        + "}\n");
+  }
+
   @Test public void duplicateExceptionsIgnored() {
     ClassName ioException = ClassName.get(IOException.class);
     ClassName timeoutException = ClassName.get(TimeoutException.class);

--- a/src/test/java/com/squareup/javapoet/MethodSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/MethodSpecTest.java
@@ -305,6 +305,24 @@ public final class MethodSpecTest {
         + "}\n");
   }
 
+  @Test public void withParameterJavaDocAndWithoutMethodJavadoc() {
+    MethodSpec methodSpec = MethodSpec.methodBuilder("getTaco")
+        .addParameter(ParameterSpec.builder(TypeName.DOUBLE, "money")
+            .addJavadoc("the amount required to buy the taco.\n")
+            .build())
+        .addParameter(ParameterSpec.builder(TypeName.INT, "count")
+            .addJavadoc("the number of Tacos to buy.\n")
+            .build())
+        .build();
+    assertThat(methodSpec.toString()).isEqualTo(""
+        + "/**\n"
+        + " * @param money the amount required to buy the taco.\n"
+        + " * @param count the number of Tacos to buy.\n"
+        + " */\n"
+        + "void getTaco(double money, int count) {\n"
+        + "}\n");
+  }
+
   @Test public void duplicateExceptionsIgnored() {
     ClassName ioException = ClassName.get(IOException.class);
     ClassName timeoutException = ClassName.get(TimeoutException.class);

--- a/src/test/java/com/squareup/javapoet/MethodSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/MethodSpecTest.java
@@ -297,6 +297,7 @@ public final class MethodSpecTest {
     assertThat(methodSpec.toString()).isEqualTo(""
         + "/**\n"
         + " * Gets the best Taco money can buy.\n"
+        + " *\n"
         + " * @param money the amount required to buy the taco.\n"
         + " * @param count the number of Tacos to buy.\n"
         + " */\n"


### PR DESCRIPTION
Resolves #495 

Wanted to get some feedback. Right now, to ensure that the `@param name description of name` comes to the end of the Javadoc, I've kept a separate field called `parameterJavadoc`. I'm unsure whether that is the best practice since if we think about adding Javadoc to return types and exception, it might be a bit much. 

The alternative is to put the onus on the consumer to then do:
```java
methodSpec
  .addJavadoc("Method description")
  .addParameter(ParameterSpec.builder(String.class, "name")
      .addJavadoc("The name of the user\n")
      .build())
```
and make sure that the method javadoc comes before the parameter javadoc. 