### PR TITLE
Add checks to ParameterSpec with VariableElement + copy over annotations

### DIFF
--- a/src/main/java/com/squareup/javapoet/ParameterSpec.java
+++ b/src/main/java/com/squareup/javapoet/ParameterSpec.java
@@ -21,7 +21,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.lang.model.SourceVersion;
+import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.VariableElement;
@@ -83,10 +85,19 @@ public final class ParameterSpec {
   }
 
   public static ParameterSpec get(VariableElement element) {
+    checkArgument(element.getKind().equals(ElementKind.PARAMETER), "element is not a parameter");
+
+    // Copy over any annotations from element.
+    List<AnnotationSpec> annotations = element.getAnnotationMirrors()
+        .stream()
+        .map((mirror) -> AnnotationSpec.get(mirror))
+        .collect(Collectors.toList());
+
     TypeName type = TypeName.get(element.asType());
     String name = element.getSimpleName().toString();
     return ParameterSpec.builder(type, name)
         .addModifiers(element.getModifiers())
+        .addAnnotations(annotations)
         .build();
   }
 

--- a/src/test/java/com/squareup/javapoet/MethodSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/MethodSpecTest.java
@@ -37,6 +37,7 @@ import org.junit.Test;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.common.truth.Truth.assertThat;
+import static com.squareup.javapoet.TestUtil.findFirstExecutableElement;
 import static javax.lang.model.util.ElementFilter.methodsIn;
 import static org.junit.Assert.fail;
 
@@ -53,15 +54,6 @@ public final class MethodSpecTest {
 
   private TypeElement getElement(Class<?> clazz) {
     return elements.getTypeElement(clazz.getCanonicalName());
-  }
-
-  private ExecutableElement findFirst(Collection<ExecutableElement> elements, String name) {
-    for (ExecutableElement executableElement : elements) {
-      if (executableElement.getSimpleName().toString().equals(name)) {
-        return executableElement;
-      }
-    }
-    throw new IllegalArgumentException(name + " not found in " + elements);
   }
 
   @Test public void nullAnnotationsAddition() {
@@ -186,7 +178,7 @@ public final class MethodSpecTest {
     TypeElement classElement = getElement(ExtendsIterableWithDefaultMethods.class);
     DeclaredType classType = (DeclaredType) classElement.asType();
     List<ExecutableElement> methods = methodsIn(elements.getAllMembers(classElement));
-    ExecutableElement exec = findFirst(methods, "spliterator");
+    ExecutableElement exec = findFirstExecutableElement(methods, "spliterator");
     MethodSpec method = MethodSpec.overriding(exec, classType, types).build();
     assertThat(method.toString()).isEqualTo(""
         + "@java.lang.Override\n"
@@ -198,19 +190,19 @@ public final class MethodSpecTest {
     TypeElement classElement = getElement(ExtendsOthers.class);
     DeclaredType classType = (DeclaredType) classElement.asType();
     List<ExecutableElement> methods = methodsIn(elements.getAllMembers(classElement));
-    ExecutableElement exec = findFirst(methods, "call");
+    ExecutableElement exec = findFirstExecutableElement(methods, "call");
     MethodSpec method = MethodSpec.overriding(exec, classType, types).build();
     assertThat(method.toString()).isEqualTo(""
         + "@java.lang.Override\n"
         + "public java.lang.Integer call() throws java.lang.Exception {\n"
         + "}\n");
-    exec = findFirst(methods, "compareTo");
+    exec = findFirstExecutableElement(methods, "compareTo");
     method = MethodSpec.overriding(exec, classType, types).build();
     assertThat(method.toString()).isEqualTo(""
         + "@java.lang.Override\n"
         + "public int compareTo(" + ExtendsOthers.class.getCanonicalName() + " arg0) {\n"
         + "}\n");
-    exec = findFirst(methods, "fail");
+    exec = findFirstExecutableElement(methods, "fail");
     method = MethodSpec.overriding(exec, classType, types).build();
     assertThat(method.toString()).isEqualTo(""
         + "@java.lang.Override\n"
@@ -222,7 +214,7 @@ public final class MethodSpecTest {
     TypeElement classElement = getElement(FinalClass.class);
     List<ExecutableElement> methods = methodsIn(elements.getAllMembers(classElement));
     try {
-      MethodSpec.overriding(findFirst(methods, "method"));
+      MethodSpec.overriding(findFirstExecutableElement(methods, "method"));
       fail();
     } catch (IllegalArgumentException expected) {
       assertThat(expected).hasMessageThat().isEqualTo(
@@ -234,19 +226,19 @@ public final class MethodSpecTest {
     TypeElement classElement = getElement(InvalidOverrideMethods.class);
     List<ExecutableElement> methods = methodsIn(elements.getAllMembers(classElement));
     try {
-      MethodSpec.overriding(findFirst(methods, "finalMethod"));
+      MethodSpec.overriding(findFirstExecutableElement(methods, "finalMethod"));
       fail();
     } catch (IllegalArgumentException expected) {
       assertThat(expected).hasMessageThat().isEqualTo("cannot override method with modifiers: [final]");
     }
     try {
-      MethodSpec.overriding(findFirst(methods, "privateMethod"));
+      MethodSpec.overriding(findFirstExecutableElement(methods, "privateMethod"));
       fail();
     } catch (IllegalArgumentException expected) {
       assertThat(expected).hasMessageThat().isEqualTo("cannot override method with modifiers: [private]");
     }
     try {
-      MethodSpec.overriding(findFirst(methods, "staticMethod"));
+      MethodSpec.overriding(findFirstExecutableElement(methods, "staticMethod"));
       fail();
     } catch (IllegalArgumentException expected) {
       assertThat(expected).hasMessageThat().isEqualTo("cannot override method with modifiers: [static]");

--- a/src/test/java/com/squareup/javapoet/MethodSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/MethodSpecTest.java
@@ -154,8 +154,8 @@ public final class MethodSpecTest {
         + "@java.lang.Override\n"
         + "protected <T extends java.lang.Runnable & java.io.Closeable> java.lang.Runnable "
         + "everything(\n"
-        + "    java.lang.String arg0, java.util.List<? extends T> arg1) throws java.io.IOException,\n"
-        + "    java.lang.SecurityException {\n"
+        + "    @com.squareup.javapoet.MethodSpecTest.Nullable java.lang.String arg0,\n"
+        + "    java.util.List<? extends T> arg1) throws java.io.IOException, java.lang.SecurityException {\n"
         + "}\n");
   }
 

--- a/src/test/java/com/squareup/javapoet/MethodSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/MethodSpecTest.java
@@ -37,7 +37,7 @@ import org.junit.Test;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.common.truth.Truth.assertThat;
-import static com.squareup.javapoet.TestUtil.findFirstExecutableElement;
+import static com.squareup.javapoet.TestUtil.findFirst;
 import static javax.lang.model.util.ElementFilter.methodsIn;
 import static org.junit.Assert.fail;
 
@@ -178,7 +178,7 @@ public final class MethodSpecTest {
     TypeElement classElement = getElement(ExtendsIterableWithDefaultMethods.class);
     DeclaredType classType = (DeclaredType) classElement.asType();
     List<ExecutableElement> methods = methodsIn(elements.getAllMembers(classElement));
-    ExecutableElement exec = findFirstExecutableElement(methods, "spliterator");
+    ExecutableElement exec = findFirst(methods, "spliterator");
     MethodSpec method = MethodSpec.overriding(exec, classType, types).build();
     assertThat(method.toString()).isEqualTo(""
         + "@java.lang.Override\n"
@@ -190,19 +190,19 @@ public final class MethodSpecTest {
     TypeElement classElement = getElement(ExtendsOthers.class);
     DeclaredType classType = (DeclaredType) classElement.asType();
     List<ExecutableElement> methods = methodsIn(elements.getAllMembers(classElement));
-    ExecutableElement exec = findFirstExecutableElement(methods, "call");
+    ExecutableElement exec = findFirst(methods, "call");
     MethodSpec method = MethodSpec.overriding(exec, classType, types).build();
     assertThat(method.toString()).isEqualTo(""
         + "@java.lang.Override\n"
         + "public java.lang.Integer call() throws java.lang.Exception {\n"
         + "}\n");
-    exec = findFirstExecutableElement(methods, "compareTo");
+    exec = findFirst(methods, "compareTo");
     method = MethodSpec.overriding(exec, classType, types).build();
     assertThat(method.toString()).isEqualTo(""
         + "@java.lang.Override\n"
         + "public int compareTo(" + ExtendsOthers.class.getCanonicalName() + " arg0) {\n"
         + "}\n");
-    exec = findFirstExecutableElement(methods, "fail");
+    exec = findFirst(methods, "fail");
     method = MethodSpec.overriding(exec, classType, types).build();
     assertThat(method.toString()).isEqualTo(""
         + "@java.lang.Override\n"
@@ -214,7 +214,7 @@ public final class MethodSpecTest {
     TypeElement classElement = getElement(FinalClass.class);
     List<ExecutableElement> methods = methodsIn(elements.getAllMembers(classElement));
     try {
-      MethodSpec.overriding(findFirstExecutableElement(methods, "method"));
+      MethodSpec.overriding(findFirst(methods, "method"));
       fail();
     } catch (IllegalArgumentException expected) {
       assertThat(expected).hasMessageThat().isEqualTo(
@@ -226,19 +226,19 @@ public final class MethodSpecTest {
     TypeElement classElement = getElement(InvalidOverrideMethods.class);
     List<ExecutableElement> methods = methodsIn(elements.getAllMembers(classElement));
     try {
-      MethodSpec.overriding(findFirstExecutableElement(methods, "finalMethod"));
+      MethodSpec.overriding(findFirst(methods, "finalMethod"));
       fail();
     } catch (IllegalArgumentException expected) {
       assertThat(expected).hasMessageThat().isEqualTo("cannot override method with modifiers: [final]");
     }
     try {
-      MethodSpec.overriding(findFirstExecutableElement(methods, "privateMethod"));
+      MethodSpec.overriding(findFirst(methods, "privateMethod"));
       fail();
     } catch (IllegalArgumentException expected) {
       assertThat(expected).hasMessageThat().isEqualTo("cannot override method with modifiers: [private]");
     }
     try {
-      MethodSpec.overriding(findFirstExecutableElement(methods, "staticMethod"));
+      MethodSpec.overriding(findFirst(methods, "staticMethod"));
       fail();
     } catch (IllegalArgumentException expected) {
       assertThat(expected).hasMessageThat().isEqualTo("cannot override method with modifiers: [static]");

--- a/src/test/java/com/squareup/javapoet/ParameterSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/ParameterSpecTest.java
@@ -28,8 +28,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertThat;
-import static com.squareup.javapoet.TestUtil.findFirstExecutableElement;
-import static com.squareup.javapoet.TestUtil.findFirstVariableElement;
+import static com.squareup.javapoet.TestUtil.findFirst;
 import static javax.lang.model.util.ElementFilter.fieldsIn;
 import static javax.lang.model.util.ElementFilter.methodsIn;
 import static org.junit.Assert.fail;
@@ -79,7 +78,7 @@ public class ParameterSpecTest {
   @Test public void fieldVariableElement() {
     TypeElement classElement = getElement(VariableElementFieldClass.class);
     List<VariableElement> methods = fieldsIn(elements.getAllMembers(classElement));
-    VariableElement element = findFirstVariableElement(methods, "name");
+    VariableElement element = findFirst(methods, "name");
 
     try {
       ParameterSpec.get(element);
@@ -97,7 +96,7 @@ public class ParameterSpecTest {
   @Test public void parameterVariableElement() {
     TypeElement classElement = getElement(VariableElementParameterClass.class);
     List<ExecutableElement> methods = methodsIn(elements.getAllMembers(classElement));
-    ExecutableElement element = findFirstExecutableElement(methods, "foo");
+    ExecutableElement element = findFirst(methods, "foo");
     VariableElement parameterElement = element.getParameters().get(0);
 
     assertThat(ParameterSpec.get(parameterElement).toString())

--- a/src/test/java/com/squareup/javapoet/ParameterSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/ParameterSpecTest.java
@@ -17,20 +17,19 @@ package com.squareup.javapoet;
 
 import com.google.testing.compile.CompilationRule;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import javax.annotation.Nullable;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
-import javax.lang.model.type.DeclaredType;
 import javax.lang.model.util.Elements;
-import javax.lang.model.util.Types;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.squareup.javapoet.TestUtil.findFirstExecutableElement;
+import static com.squareup.javapoet.TestUtil.findFirstVariableElement;
 import static javax.lang.model.util.ElementFilter.fieldsIn;
 import static javax.lang.model.util.ElementFilter.methodsIn;
 import static org.junit.Assert.fail;
@@ -49,34 +48,6 @@ public class ParameterSpecTest {
   private TypeElement getElement(Class<?> clazz) {
     return elements.getTypeElement(clazz.getCanonicalName());
   }
-
-  private VariableElement findFirst(Collection<VariableElement> elements, String name) {
-    for (VariableElement variableElement : elements) {
-      if (variableElement.getSimpleName().toString().equals(name)) {
-        return variableElement;
-      }
-    }
-    throw new IllegalArgumentException(name + " not found in " + elements);
-  }
-
-  private ExecutableElement findFirstExecutable(Collection<ExecutableElement> elements, String name) {
-    for (ExecutableElement executableElement : elements) {
-      if (executableElement.getSimpleName().toString().equals(name)) {
-        return executableElement;
-      }
-    }
-    throw new IllegalArgumentException(name + " not found in " + elements);
-  }
-
-  final class VariableElementFieldClass {
-    String name;
-  }
-
-  final class VariableElementParameterClass {
-    public void foo(@Nullable String bar) {
-    }
-  }
-
 
   @Test public void equalsAndHashCode() {
     ParameterSpec a = ParameterSpec.builder(int.class, "foo").build();
@@ -101,22 +72,32 @@ public class ParameterSpecTest {
     }
   }
 
+  final class VariableElementFieldClass {
+    String name;
+  }
+
   @Test public void fieldVariableElement() {
     TypeElement classElement = getElement(VariableElementFieldClass.class);
     List<VariableElement> methods = fieldsIn(elements.getAllMembers(classElement));
-    VariableElement element = findFirst(methods, "name");
+    VariableElement element = findFirstVariableElement(methods, "name");
 
     try {
       ParameterSpec.get(element);
+      fail();
     } catch (IllegalArgumentException exception) {
       assertThat(exception).hasMessageThat().isEqualTo("element is not a parameter");
+    }
+  }
+
+  final class VariableElementParameterClass {
+    public void foo(@Nullable final String bar) {
     }
   }
 
   @Test public void parameterVariableElement() {
     TypeElement classElement = getElement(VariableElementParameterClass.class);
     List<ExecutableElement> methods = methodsIn(elements.getAllMembers(classElement));
-    ExecutableElement element = findFirstExecutable(methods, "foo");
+    ExecutableElement element = findFirstExecutableElement(methods, "foo");
     VariableElement parameterElement = element.getParameters().get(0);
 
     assertThat(ParameterSpec.get(parameterElement).toString())

--- a/src/test/java/com/squareup/javapoet/TestUtil.java
+++ b/src/test/java/com/squareup/javapoet/TestUtil.java
@@ -1,0 +1,26 @@
+package com.squareup.javapoet;
+
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.VariableElement;
+import java.util.Collection;
+
+final class TestUtil {
+
+  static VariableElement findFirstVariableElement(Collection<VariableElement> elements, String name) {
+    for (VariableElement variableElement : elements) {
+      if (variableElement.getSimpleName().toString().equals(name)) {
+        return variableElement;
+      }
+    }
+    throw new IllegalArgumentException(name + " not found in " + elements);
+  }
+
+  static ExecutableElement findFirstExecutableElement(Collection<ExecutableElement> elements, String name) {
+    for (ExecutableElement executableElement : elements) {
+      if (executableElement.getSimpleName().toString().equals(name)) {
+        return executableElement;
+      }
+    }
+    throw new IllegalArgumentException(name + " not found in " + elements);
+  }
+}

--- a/src/test/java/com/squareup/javapoet/TestUtil.java
+++ b/src/test/java/com/squareup/javapoet/TestUtil.java
@@ -5,7 +5,6 @@ import javax.lang.model.element.VariableElement;
 import java.util.Collection;
 
 final class TestUtil {
-
   static VariableElement findFirstVariableElement(Collection<VariableElement> elements, String name) {
     for (VariableElement variableElement : elements) {
       if (variableElement.getSimpleName().toString().equals(name)) {

--- a/src/test/java/com/squareup/javapoet/TestUtil.java
+++ b/src/test/java/com/squareup/javapoet/TestUtil.java
@@ -1,23 +1,15 @@
 package com.squareup.javapoet;
 
+import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.VariableElement;
 import java.util.Collection;
 
 final class TestUtil {
-  static VariableElement findFirstVariableElement(Collection<VariableElement> elements, String name) {
-    for (VariableElement variableElement : elements) {
-      if (variableElement.getSimpleName().toString().equals(name)) {
-        return variableElement;
-      }
-    }
-    throw new IllegalArgumentException(name + " not found in " + elements);
-  }
-
-  static ExecutableElement findFirstExecutableElement(Collection<ExecutableElement> elements, String name) {
-    for (ExecutableElement executableElement : elements) {
-      if (executableElement.getSimpleName().toString().equals(name)) {
-        return executableElement;
+  static <E extends Element> E findFirst(Collection<E> elements, String name) {
+    for (E element : elements) {
+      if (element.getSimpleName().toString().equals(name)) {
+        return element;
       }
     }
     throw new IllegalArgumentException(name + " not found in " + elements);


### PR DESCRIPTION
Resolves #665 

I'd love to add some tests around the `get(variableElement)` method but I'm not sure how to do that with creating a `VariableElement`. If you have any suggestions, let me know! 