### PR TITLE
Hardcoded line separator bug

### DIFF
--- a/src/main/java/com/squareup/javapoet/CodeWriter.java
+++ b/src/main/java/com/squareup/javapoet/CodeWriter.java
@@ -456,7 +456,7 @@ final class CodeWriter {
    */
   CodeWriter emitAndIndent(String s) throws IOException {
     boolean first = true;
-    for (String line : s.split("\n", -1)) {
+    for (String line : s.split("\r?\n", -1)) {
       // Emit a newline character. Make sure blank lines in Javadoc & comments look good.
       if (!first) {
         if ((javadoc || comment) && trailingNewline) {

--- a/src/main/java/com/squareup/javapoet/CodeWriter.java
+++ b/src/main/java/com/squareup/javapoet/CodeWriter.java
@@ -456,7 +456,7 @@ final class CodeWriter {
    */
   CodeWriter emitAndIndent(String s) throws IOException {
     boolean first = true;
-    for (String line : s.split("\r?\n", -1)) {
+    for (String line : s.split("\\R", -1)) {
       // Emit a newline character. Make sure blank lines in Javadoc & comments look good.
       if (!first) {
         if ((javadoc || comment) && trailingNewline) {

--- a/src/test/java/com/squareup/javapoet/CodeWriterTest.java
+++ b/src/test/java/com/squareup/javapoet/CodeWriterTest.java
@@ -1,0 +1,23 @@
+package com.squareup.javapoet;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static com.google.common.truth.Truth.assertThat;
+
+public class CodeWriterTest {
+
+    @Test
+    public void emptyLineInJavaDocDosEndings() throws IOException {
+        CodeBlock javadocCodeBlock = CodeBlock.of("A\r\n\r\nB\r\n");
+        StringBuilder out = new StringBuilder();
+        new CodeWriter(out).emitJavadoc(javadocCodeBlock);
+        assertThat(out.toString()).isEqualTo(
+                "/**\n" +
+                        " * A\n" +
+                        " *\n" +
+                        " * B\n" +
+                        " */\n");
+    }
+}


### PR DESCRIPTION
Use regex for new line character to cover both dos and unix endings when calling emitAndIndent - fixes #552