### PR TITLE
Public getter for canonical name of ClassName

### DIFF
--- a/src/main/java/com/squareup/javapoet/ClassName.java
+++ b/src/main/java/com/squareup/javapoet/ClassName.java
@@ -138,6 +138,14 @@ public final class ClassName extends TypeName implements Comparable<ClassName> {
     return simpleName;
   }
 
+  /**
+   * Returns the full class name of this class, like {@code "java.util.Map.Entry"}
+   * for {@link Map.Entry}.
+   * */
+  public String canonicalName() {
+    return canonicalName;
+  }
+
   public static ClassName get(Class<?> clazz) {
     checkNotNull(clazz, "clazz == null");
     checkArgument(!clazz.isPrimitive(), "primitive types cannot be represented as a ClassName");

--- a/src/main/java/com/squareup/javapoet/ClassName.java
+++ b/src/main/java/com/squareup/javapoet/ClassName.java
@@ -139,8 +139,8 @@ public final class ClassName extends TypeName implements Comparable<ClassName> {
   }
 
   /**
-   * Returns the full class name of this class, like {@code "java.util.Map.Entry"}
-   * for {@link Map.Entry}.
+   * Returns the full class name of this class.
+   * Like {@code "java.util.Map.Entry"} for {@link Map.Entry}.
    * */
   public String canonicalName() {
     return canonicalName;

--- a/src/test/java/com/squareup/javapoet/ClassNameTest.java
+++ b/src/test/java/com/squareup/javapoet/ClassNameTest.java
@@ -193,4 +193,14 @@ public final class ClassNameTest {
     assertEquals("Foo$Bar$Baz", ClassName.get("", "Foo", "Bar", "Baz").reflectionName());
     assertEquals("a.b.c.Foo$Bar$Baz", ClassName.get("a.b.c", "Foo", "Bar", "Baz").reflectionName());
   }
+
+  @Test
+  public void canonicalName() {
+    assertEquals("java.lang.Object", TypeName.OBJECT.canonicalName());
+    assertEquals("java.lang.Thread.State", ClassName.get(Thread.State.class).canonicalName());
+    assertEquals("java.util.Map.Entry", ClassName.get(Map.Entry.class).canonicalName());
+    assertEquals("Foo", ClassName.get("", "Foo").canonicalName());
+    assertEquals("Foo.Bar.Baz", ClassName.get("", "Foo", "Bar", "Baz").canonicalName());
+    assertEquals("a.b.c.Foo.Bar.Baz", ClassName.get("a.b.c", "Foo", "Bar", "Baz").canonicalName());
+  }
 }


### PR DESCRIPTION
Canonical name may be useful when creating `JavaFileObject` for code generation in APT Processor instead of manually concatenating `packageName()` and `simpleName()`