### PR TITLE
Remove n^2 algorithm in CodeWriter.resolve() by precomputing all of the nested simple names of a TypeSpec

### DIFF
--- a/src/main/java/com/squareup/javapoet/CodeWriter.java
+++ b/src/main/java/com/squareup/javapoet/CodeWriter.java
@@ -420,10 +420,8 @@ final class CodeWriter {
     // Match a child of the current (potentially nested) class.
     for (int i = typeSpecStack.size() - 1; i >= 0; i--) {
       TypeSpec typeSpec = typeSpecStack.get(i);
-      for (TypeSpec visibleChild : typeSpec.typeSpecs) {
-        if (Objects.equals(visibleChild.name, simpleName)) {
-          return stackClassName(i, simpleName);
-        }
+      if (typeSpec.nestedTypesSimpleNames.contains(simpleName)) {
+        return stackClassName(i, simpleName);
       }
     }
 

--- a/src/main/java/com/squareup/javapoet/TypeSpec.java
+++ b/src/main/java/com/squareup/javapoet/TypeSpec.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -53,6 +54,7 @@ public final class TypeSpec {
   public final CodeBlock initializerBlock;
   public final List<MethodSpec> methodSpecs;
   public final List<TypeSpec> typeSpecs;
+  final Set<String> nestedTypesSimpleNames;
   public final List<Element> originatingElements;
 
   private TypeSpec(Builder builder) {
@@ -72,11 +74,14 @@ public final class TypeSpec {
     this.methodSpecs = Util.immutableList(builder.methodSpecs);
     this.typeSpecs = Util.immutableList(builder.typeSpecs);
 
+    nestedTypesSimpleNames = new HashSet<>(builder.typeSpecs.size());
     List<Element> originatingElementsMutable = new ArrayList<>();
     originatingElementsMutable.addAll(builder.originatingElements);
     for (TypeSpec typeSpec : builder.typeSpecs) {
+      nestedTypesSimpleNames.add(typeSpec.name);
       originatingElementsMutable.addAll(typeSpec.originatingElements);
     }
+
     this.originatingElements = Util.immutableList(originatingElementsMutable);
   }
 
@@ -102,6 +107,7 @@ public final class TypeSpec {
     this.methodSpecs = Collections.emptyList();
     this.typeSpecs = Collections.emptyList();
     this.originatingElements = Collections.emptyList();
+    this.nestedTypesSimpleNames = Collections.emptySet();
   }
 
   public boolean hasModifier(Modifier modifier) {


### PR DESCRIPTION
For one large (100K lines) Dagger component implementation, this saved 3.5s/build. The type has ~360 subcomponents, and each of those have a sibling builder type, so ~720 nested types at the worst point. 

I wasn't sure what your style preferences are for whether `nestedTypesSimpleNames` should be immutable or not given that it's internal, so I implemented it as mutable and figured I'd ask your thoughts. I can also call `Util.immutableSet()` or create a single mutable set that never escaped and wrap that in an `unmodifiableSet`.