### PR TITLE
Remove argument whose value isn't needed

### DIFF
--- a/src/main/java/com/squareup/javapoet/CodeBlock.java
+++ b/src/main/java/com/squareup/javapoet/CodeBlock.java
@@ -189,7 +189,7 @@ public final class CodeBlock {
       while (p < format.length()) {
         int nextP = format.indexOf("$", p);
         if (nextP == -1) {
-          formatParts.add(format.substring(p, format.length()));
+          formatParts.add(format.substring(p));
           break;
         }
 


### PR DESCRIPTION
The single-argument overload will use the end of the String as the end index automatically.