### PR TITLE
Memoize ClassName.simpleNames()

### DIFF
--- a/src/main/java/com/squareup/javapoet/ClassName.java
+++ b/src/main/java/com/squareup/javapoet/ClassName.java
@@ -41,6 +41,8 @@ public final class ClassName extends TypeName implements Comparable<ClassName> {
   /** This class name, like "Entry" for java.util.Map.Entry. */
   final String simpleName;
 
+  private List<String> simpleNames;
+
   /** The full class name like "java.util.Map.Entry". */
   final String canonicalName;
 
@@ -108,11 +110,18 @@ public final class ClassName extends TypeName implements Comparable<ClassName> {
   }
 
   public List<String> simpleNames() {
-    List<String> simpleNames = new ArrayList<>();
-    if (enclosingClassName != null) {
-      simpleNames.addAll(enclosingClassName().simpleNames());
+    if (simpleNames != null) {
+      return simpleNames;
     }
-    simpleNames.add(simpleName);
+
+    if (enclosingClassName == null) {
+      simpleNames = Collections.singletonList(simpleName);
+    } else {
+      List<String> mutableNames = new ArrayList<>();
+      mutableNames.addAll(enclosingClassName().simpleNames());
+      mutableNames.add(simpleName);
+      simpleNames = Collections.unmodifiableList(mutableNames);
+    }
     return simpleNames;
   }
 


### PR DESCRIPTION
In addition to being used repeatedly in CodeWriter.lookupName(), the current implementation is N^2 (albeit for a usually low N) since it recursively calls itself on the enclosing class name. This should get rid of some of the garbage created in code writing.