### PR TITLE
Fix an issue where ClassName could not handle classes in the default (empty) package

### DIFF
--- a/src/main/java/com/squareup/javapoet/ClassName.java
+++ b/src/main/java/com/squareup/javapoet/ClassName.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
@@ -32,7 +33,7 @@ import static com.squareup.javapoet.Util.checkNotNull;
 public final class ClassName extends TypeName implements Comparable<ClassName> {
   public static final ClassName OBJECT = ClassName.get(Object.class);
 
-  /** The name representing the default Java package */
+  /** The name representing the default Java package. */
   private static final String NO_PACKAGE = "";
 
   /** The package name of this class, or "" if this is in the default package. */
@@ -56,7 +57,7 @@ public final class ClassName extends TypeName implements Comparable<ClassName> {
   private ClassName(String packageName, ClassName enclosingClassName, String simpleName,
       List<AnnotationSpec> annotations) {
     super(annotations);
-    this.packageName = (packageName != null) ? packageName : NO_PACKAGE;
+    this.packageName = Objects.requireNonNull(packageName, "packageName == null");
     this.enclosingClassName = enclosingClassName;
     this.simpleName = simpleName;
     this.canonicalName = enclosingClassName != null

--- a/src/main/java/com/squareup/javapoet/ClassName.java
+++ b/src/main/java/com/squareup/javapoet/ClassName.java
@@ -32,6 +32,9 @@ import static com.squareup.javapoet.Util.checkNotNull;
 public final class ClassName extends TypeName implements Comparable<ClassName> {
   public static final ClassName OBJECT = ClassName.get(Object.class);
 
+  /** The name representing the default Java package */
+  private static final String NO_PACKAGE = "";
+
   /** The package name of this class, or "" if this is in the default package. */
   final String packageName;
 
@@ -53,14 +56,12 @@ public final class ClassName extends TypeName implements Comparable<ClassName> {
   private ClassName(String packageName, ClassName enclosingClassName, String simpleName,
       List<AnnotationSpec> annotations) {
     super(annotations);
-    this.packageName = packageName;
+    this.packageName = (packageName != null) ? packageName : NO_PACKAGE;
     this.enclosingClassName = enclosingClassName;
     this.simpleName = simpleName;
     this.canonicalName = enclosingClassName != null
         ? (enclosingClassName.canonicalName + '.' + simpleName)
-        : (packageName == null || packageName.isEmpty()
-            ? simpleName
-            : packageName + '.' + simpleName);
+        : (this.packageName.isEmpty() ? simpleName : packageName + '.' + simpleName);
   }
 
   @Override public ClassName annotated(List<AnnotationSpec> annotations) {
@@ -174,7 +175,7 @@ public final class ClassName extends TypeName implements Comparable<ClassName> {
     if (clazz.getEnclosingClass() == null) {
       // Avoid unreliable Class.getPackage(). https://github.com/square/javapoet/issues/295
       int lastDot = clazz.getName().lastIndexOf('.');
-      String packageName = (lastDot != -1) ? clazz.getName().substring(0, lastDot) : null;
+      String packageName = (lastDot != -1) ? clazz.getName().substring(0, lastDot) : NO_PACKAGE;
       return new ClassName(packageName, null, name);
     }
 
@@ -196,7 +197,7 @@ public final class ClassName extends TypeName implements Comparable<ClassName> {
       p = classNameString.indexOf('.', p) + 1;
       checkArgument(p != 0, "couldn't make a guess for %s", classNameString);
     }
-    String packageName = p == 0 ? "" : classNameString.substring(0, p - 1);
+    String packageName = p == 0 ? NO_PACKAGE : classNameString.substring(0, p - 1);
 
     // Add class names like "Map" and "Entry".
     ClassName className = null;

--- a/src/main/java/com/squareup/javapoet/ClassName.java
+++ b/src/main/java/com/squareup/javapoet/ClassName.java
@@ -58,7 +58,9 @@ public final class ClassName extends TypeName implements Comparable<ClassName> {
     this.simpleName = simpleName;
     this.canonicalName = enclosingClassName != null
         ? (enclosingClassName.canonicalName + '.' + simpleName)
-        : (packageName.isEmpty() ? simpleName : packageName + '.' + simpleName);
+        : (packageName == null || packageName.isEmpty()
+            ? simpleName
+            : packageName + '.' + simpleName);
   }
 
   @Override public ClassName annotated(List<AnnotationSpec> annotations) {

--- a/src/main/java/com/squareup/javapoet/CodeWriter.java
+++ b/src/main/java/com/squareup/javapoet/CodeWriter.java
@@ -400,7 +400,7 @@ final class CodeWriter {
   }
 
   private void importableType(ClassName className) {
-    if (className.packageName() == null || className.packageName().isEmpty()) {
+    if (className.packageName().isEmpty()) {
       return;
     }
     ClassName topLevelClassName = className.topLevelClassName();

--- a/src/main/java/com/squareup/javapoet/CodeWriter.java
+++ b/src/main/java/com/squareup/javapoet/CodeWriter.java
@@ -400,7 +400,7 @@ final class CodeWriter {
   }
 
   private void importableType(ClassName className) {
-    if (className.packageName().isEmpty()) {
+    if (className.packageName() == null || className.packageName().isEmpty()) {
       return;
     }
     ClassName topLevelClassName = className.topLevelClassName();

--- a/src/test/java/NoPackageTest.java
+++ b/src/test/java/NoPackageTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2019 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.squareup.javapoet.ClassName;
+import org.junit.Test;
+
+/**
+ * Since it is impossible to import classes from the default package into other
+ * modules, this test must live in this package.
+ */
+public class NoPackageTest {
+
+  @Test public void shouldSupportClassInDefaultPackage() {
+    final ClassName className = ClassName.get(getClass());
+    assertThat(className.simpleName()).isEqualTo(getClass().getSimpleName());
+  }
+
+}


### PR DESCRIPTION
A product that I'm working on utilizes javapoet to generate code from user-defined-functions. As an example, we have built a simple jar file that contains a class that is in the default java package (i.e. empty package). If we use this class and try to format it using 
```java
CodeBlock.builder()
  .addStatement("$T", ThatClass.class)
  .build()
  .toString()
```
It fails with an NPE in the most recent version of javapoet.

This PR attempts to fix it by adding null checks on any access to the package name.

__NOTE:__ I added the test in the default package instead of in `ClassNameTest` so that I could reference the class without mocking it. If anyone has a better idea I'm all ears!

P.S. Thanks for this library :) it's helped me clean up legacy code in multiple different companies!