### PR TITLE
Nit: Simplify a CodeBlock

### DIFF
--- a/src/main/java/com/squareup/javapoet/TypeSpec.java
+++ b/src/main/java/com/squareup/javapoet/TypeSpec.java
@@ -139,9 +139,7 @@ public final class TypeSpec {
   }
 
   public static Builder anonymousClassBuilder(String typeArgumentsFormat, Object... args) {
-    return anonymousClassBuilder(CodeBlock.builder()
-        .add(typeArgumentsFormat, args)
-        .build());
+    return anonymousClassBuilder(CodeBlock.of(typeArgumentsFormat, args));
   }
 
   public static Builder anonymousClassBuilder(CodeBlock typeArguments) {


### PR DESCRIPTION
I created an ErrorProne refactoring to detect superfluous `CodeBlock.Builder` usages. Conveniently, I found one in JavaPoet itself :)