### PR TITLE
Ensure trailing newlines in javadocs and method bodies

### DIFF
--- a/src/main/java/com/squareup/javapoet/CodeWriter.java
+++ b/src/main/java/com/squareup/javapoet/CodeWriter.java
@@ -153,6 +153,9 @@ final class CodeWriter {
     } finally {
       javadoc = false;
     }
+    if (out.lastChar() != '\n') {
+      emit("\n");
+    }
     emit(" */\n");
   }
 

--- a/src/main/java/com/squareup/javapoet/CodeWriter.java
+++ b/src/main/java/com/squareup/javapoet/CodeWriter.java
@@ -149,12 +149,9 @@ final class CodeWriter {
     emit("/**\n");
     javadoc = true;
     try {
-      emit(javadocCodeBlock);
+      emit(javadocCodeBlock, true);
     } finally {
       javadoc = false;
-    }
-    if (out.lastChar() != '\n') {
-      emit("\n");
     }
     emit(" */\n");
   }
@@ -222,6 +219,10 @@ final class CodeWriter {
   }
 
   public CodeWriter emit(CodeBlock codeBlock) throws IOException {
+    return emit(codeBlock, false);
+  }
+
+  public CodeWriter emit(CodeBlock codeBlock, boolean ensureTrailingNewline) throws IOException {
     int a = 0;
     ClassName deferredTypeName = null; // used by "import static" logic
     ListIterator<String> partIterator = codeBlock.formatParts.listIterator();
@@ -309,6 +310,9 @@ final class CodeWriter {
           emitAndIndent(part);
           break;
       }
+    }
+    if (ensureTrailingNewline && out.lastChar() != '\n') {
+      emit("\n");
     }
     return this;
   }

--- a/src/main/java/com/squareup/javapoet/LineWrapper.java
+++ b/src/main/java/com/squareup/javapoet/LineWrapper.java
@@ -141,7 +141,7 @@ final class LineWrapper {
   }
 
   /** A delegating {@link Appendable} that records info about the chars passing through it. */
-  final static class RecordingAppendable implements Appendable {
+  static final class RecordingAppendable implements Appendable {
     private final Appendable delegate;
 
     char lastChar = Character.MIN_VALUE;

--- a/src/main/java/com/squareup/javapoet/MethodSpec.java
+++ b/src/main/java/com/squareup/javapoet/MethodSpec.java
@@ -132,7 +132,7 @@ public final class MethodSpec {
       codeWriter.emit(" {\n");
 
       codeWriter.indent();
-      codeWriter.emit(code);
+      codeWriter.emit(code, true);
       codeWriter.unindent();
 
       codeWriter.emit("}\n");

--- a/src/test/java/com/squareup/javapoet/MethodSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/MethodSpecTest.java
@@ -179,9 +179,7 @@ public final class MethodSpecTest {
     TypeElement classElement = getElement(ExtendsIterableWithDefaultMethods.class);
     DeclaredType classType = (DeclaredType) classElement.asType();
     List<ExecutableElement> methods = methodsIn(elements.getAllMembers(classElement));
-    ExecutableElement exec = 
-      
-      (methods, "spliterator");
+    ExecutableElement exec = findFirst(methods, "spliterator");
     MethodSpec method = MethodSpec.overriding(exec, classType, types).build();
     assertThat(method.toString()).isEqualTo(""
         + "@java.lang.Override\n"

--- a/src/test/java/com/squareup/javapoet/MethodSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/MethodSpecTest.java
@@ -37,7 +37,6 @@ import org.junit.Test;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.common.truth.Truth.assertThat;
-import static com.squareup.javapoet.MethodSpec.CONSTRUCTOR;
 import static javax.lang.model.util.ElementFilter.methodsIn;
 import static org.junit.Assert.fail;
 
@@ -366,6 +365,29 @@ public final class MethodSpecTest {
 
     assertThat(methodSpec.toString()).isEqualTo(""
         + "void revisedMethod() {\n"
+        + "}\n");
+  }
+
+  @Test public void ensureTrailingNewline() {
+    MethodSpec methodSpec = MethodSpec.methodBuilder("method")
+        .addCode("codeWithNoNewline();")
+        .build();
+
+    assertThat(methodSpec.toString()).isEqualTo(""
+        + "void method() {\n"
+        + "  codeWithNoNewline();\n"
+        + "}\n");
+  }
+
+  /** Ensures that we don't add a duplicate newline if one is already present. */
+  @Test public void ensureTrailingNewlineWithExistingNewline() {
+    MethodSpec methodSpec = MethodSpec.methodBuilder("method")
+        .addCode("codeWithNoNewline();\n") // Have a newline already, so ensure we're not adding one
+        .build();
+
+    assertThat(methodSpec.toString()).isEqualTo(""
+        + "void method() {\n"
+        + "  codeWithNoNewline();\n"
         + "}\n");
   }
 }

--- a/src/test/java/com/squareup/javapoet/TypeSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/TypeSpecTest.java
@@ -2440,4 +2440,19 @@ public final class TypeSpecTest {
         + "class Taco {\n"
         + "}\n");
   }
+
+  @Test public void javadocEnsuresTrailingLine() {
+    TypeSpec spec = TypeSpec.classBuilder("Taco")
+        .addJavadoc("Some doc with a newline")
+        .build();
+
+    assertThat(toString(spec)).isEqualTo(""
+        + "package com.squareup.tacos;\n"
+        + "\n"
+        + "/**\n"
+        + " * Some doc with a newline\n"
+        + " */\n"
+        + "class Taco {\n"
+        + "}\n");
+  }
 }

--- a/src/test/java/com/squareup/javapoet/TypeSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/TypeSpecTest.java
@@ -1848,7 +1848,8 @@ public final class TypeSpecTest {
         + "  }\n"
         + "\n"
         + "  /**\n"
-        + "   * chosen by fair dice roll ;) */\n"
+        + "   * chosen by fair dice roll ;)\n"
+        + "   */\n"
         + "  public int getRandomQuantity() {\n"
         + "    return 4;\n"
         + "  }\n"
@@ -2423,5 +2424,20 @@ public final class TypeSpecTest {
     assertThat(TypeSpec.interfaceBuilder(className).build().name).isEqualTo("Example");
     assertThat(TypeSpec.enumBuilder(className).addEnumConstant("A").build().name).isEqualTo("Example");
     assertThat(TypeSpec.annotationBuilder(className).build().name).isEqualTo("Example");
+  }
+
+  @Test public void javadocWithTrailingLineDoesNotAddAnother() {
+    TypeSpec spec = TypeSpec.classBuilder("Taco")
+        .addJavadoc("Some doc with a newline\n")
+        .build();
+
+    assertThat(toString(spec)).isEqualTo(""
+        + "package com.squareup.tacos;\n"
+        + "\n"
+        + "/**\n"
+        + " * Some doc with a newline\n"
+        + " */\n"
+        + "class Taco {\n"
+        + "}\n");
   }
 }


### PR DESCRIPTION
This introduces functionality that tracks the last char emitted, and uses it to check if a trailing newline needs to be added after emitting a codeblock for javadocs and method bodies.

Resolves #731
Resolves #722

I tried to keep this as performant and lightweight as possible. If this implementation looks good, I'll do the same for KotlinPoet.