### PR TITLE
Add alwaysQualify() API to avoid collisions with known colliding types

### DIFF
--- a/src/main/java/com/squareup/javapoet/JavaFile.java
+++ b/src/main/java/com/squareup/javapoet/JavaFile.java
@@ -34,6 +34,8 @@ import java.util.Set;
 import java.util.TreeSet;
 import javax.annotation.processing.Filer;
 import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.util.ElementFilter;
 import javax.tools.JavaFileObject;
 import javax.tools.JavaFileObject.Kind;
 import javax.tools.SimpleJavaFileObject;
@@ -278,6 +280,70 @@ public final class JavaFile {
       for (String name : simpleNames) {
         checkArgument(name != null, "null entry in simpleNames array: %s", Arrays.toString(simpleNames));
         alwaysQualify.add(name);
+      }
+      return this;
+    }
+
+    /**
+     * Call this to always fully qualify any types that would conflict with possibly nested types of
+     * this {@code typeElement}. For example - if the following type was passed in as the
+     * typeElement:
+     *
+     * <pre><code>
+     *   class Foo {
+     *     class NestedTypeA {
+     *
+     *     }
+     *     class NestedTypeB {
+     *
+     *     }
+     *   }
+     * </code></pre>
+     *
+     * <p>
+     * Then this would add {@code "NestedTypeA"} and {@code "NestedTypeB"} as names that should
+     * always be qualified via {@link #alwaysQualify(String...)}. This way they would avoid
+     * possible import conflicts when this JavaFile is written.
+     *
+     * @param typeElement the {@link TypeElement} with nested types to avoid clashes with.
+     * @return this builder instance.
+     */
+    public Builder avoidClashesWithNestedClasses(TypeElement typeElement) {
+      checkArgument(typeElement != null, "typeElement == null");
+      for (TypeElement nestedType : ElementFilter.typesIn(typeElement.getEnclosedElements())) {
+        alwaysQualify(nestedType.getSimpleName().toString());
+      }
+      return this;
+    }
+
+    /**
+     * Call this to always fully qualify any types that would conflict with possibly nested types of
+     * this {@code typeElement}. For example - if the following type was passed in as the
+     * typeElement:
+     *
+     * <pre><code>
+     *   class Foo {
+     *     class NestedTypeA {
+     *
+     *     }
+     *     class NestedTypeB {
+     *
+     *     }
+     *   }
+     * </code></pre>
+     *
+     * <p>
+     * Then this would add {@code "NestedTypeA"} and {@code "NestedTypeB"} as names that should
+     * always be qualified via {@link #alwaysQualify(String...)}. This way they would avoid
+     * possible import conflicts when this JavaFile is written.
+     *
+     * @param clazz the {@link Class} with nested types to avoid clashes with.
+     * @return this builder instance.
+     */
+    public Builder avoidClashesWithNestedClasses(Class<?> clazz) {
+      checkArgument(clazz != null, "clazz == null");
+      for (Class<?> nestedType : clazz.getDeclaredClasses()) {
+        alwaysQualify(nestedType.getSimpleName());
       }
       return this;
     }

--- a/src/main/java/com/squareup/javapoet/JavaFile.java
+++ b/src/main/java/com/squareup/javapoet/JavaFile.java
@@ -34,8 +34,6 @@ import java.util.Set;
 import java.util.TreeSet;
 import javax.annotation.processing.Filer;
 import javax.lang.model.element.Element;
-import javax.lang.model.element.TypeElement;
-import javax.lang.model.util.ElementFilter;
 import javax.tools.JavaFileObject;
 import javax.tools.JavaFileObject.Kind;
 import javax.tools.SimpleJavaFileObject;

--- a/src/main/java/com/squareup/javapoet/JavaFile.java
+++ b/src/main/java/com/squareup/javapoet/JavaFile.java
@@ -88,7 +88,8 @@ public final class JavaFile {
     Map<String, ClassName> suggestedImports = importsCollector.suggestedImports();
 
     // Second pass: write the code, taking advantage of the imports.
-    CodeWriter codeWriter = new CodeWriter(out, indent, suggestedImports, staticImports, alwaysQualify);
+    CodeWriter codeWriter
+        = new CodeWriter(out, indent, suggestedImports, staticImports, alwaysQualify);
     emit(codeWriter);
   }
 
@@ -278,7 +279,11 @@ public final class JavaFile {
     public Builder alwaysQualify(String... simpleNames) {
       checkArgument(simpleNames != null, "simpleNames == null");
       for (String name : simpleNames) {
-        checkArgument(name != null, "null entry in simpleNames array: %s", Arrays.toString(simpleNames));
+        checkArgument(
+            name != null,
+            "null entry in simpleNames array: %s",
+            Arrays.toString(simpleNames)
+        );
         alwaysQualify.add(name);
       }
       return this;

--- a/src/main/java/com/squareup/javapoet/TypeSpec.java
+++ b/src/main/java/com/squareup/javapoet/TypeSpec.java
@@ -16,6 +16,7 @@
 package com.squareup.javapoet;
 
 import java.io.IOException;
+import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -494,7 +495,32 @@ public final class TypeSpec {
     }
 
     public Builder superclass(Type superclass) {
-      return superclass(TypeName.get(superclass));
+      return superclass(superclass, true);
+    }
+
+    public Builder superclass(Type superclass, boolean avoidNestedTypeNameClashes) {
+      superclass(TypeName.get(superclass));
+      if (avoidNestedTypeNameClashes) {
+        Class<?> clazz = getRawType(superclass);
+        if (clazz != null) {
+          avoidClashesWithNestedClasses(clazz);
+        }
+      }
+      return this;
+    }
+
+    public Builder superclass(TypeMirror superclass) {
+      return superclass(superclass, true);
+    }
+
+    public Builder superclass(TypeMirror superclass, boolean avoidNestedTypeNameClashes) {
+      superclass(TypeName.get(superclass));
+      if (avoidNestedTypeNameClashes && superclass instanceof DeclaredType) {
+        TypeElement superInterfaceElement =
+            (TypeElement) ((DeclaredType) superclass).asElement();
+        avoidClashesWithNestedClasses(superInterfaceElement);
+      }
+      return this;
     }
 
     public Builder addSuperinterfaces(Iterable<? extends TypeName> superinterfaces) {
@@ -512,7 +538,42 @@ public final class TypeSpec {
     }
 
     public Builder addSuperinterface(Type superinterface) {
-      return addSuperinterface(TypeName.get(superinterface));
+      return addSuperinterface(superinterface, true);
+    }
+
+    public Builder addSuperinterface(Type superinterface, boolean avoidNestedTypeNameClashes) {
+      addSuperinterface(TypeName.get(superinterface));
+      if (avoidNestedTypeNameClashes) {
+        Class<?> clazz = getRawType(superinterface);
+        if (clazz != null) {
+          avoidClashesWithNestedClasses(clazz);
+        }
+      }
+      return this;
+    }
+
+    private Class<?> getRawType(Type type) {
+      if (type instanceof Class<?>) {
+        return (Class<?>) type;
+      } else if (type instanceof ParameterizedType) {
+        return getRawType(((ParameterizedType) type).getRawType());
+      } else {
+        return null;
+      }
+    }
+
+    public Builder addSuperinterface(TypeMirror superinterface) {
+      return addSuperinterface(superinterface, true);
+    }
+
+    public Builder addSuperinterface(TypeMirror superinterface, boolean avoidNestedTypeNameClashes) {
+      addSuperinterface(TypeName.get(superinterface));
+      if (avoidNestedTypeNameClashes && superinterface instanceof DeclaredType) {
+        TypeElement superInterfaceElement =
+            (TypeElement) ((DeclaredType) superinterface).asElement();
+        avoidClashesWithNestedClasses(superInterfaceElement);
+      }
+      return this;
     }
 
     public Builder addEnumConstant(String name) {

--- a/src/main/java/com/squareup/javapoet/TypeSpec.java
+++ b/src/main/java/com/squareup/javapoet/TypeSpec.java
@@ -566,7 +566,8 @@ public final class TypeSpec {
       return addSuperinterface(superinterface, true);
     }
 
-    public Builder addSuperinterface(TypeMirror superinterface, boolean avoidNestedTypeNameClashes) {
+    public Builder addSuperinterface(TypeMirror superinterface,
+        boolean avoidNestedTypeNameClashes) {
       addSuperinterface(TypeName.get(superinterface));
       if (avoidNestedTypeNameClashes && superinterface instanceof DeclaredType) {
         TypeElement superInterfaceElement =
@@ -703,7 +704,8 @@ public final class TypeSpec {
       }
       for (TypeMirror superinterface : typeElement.getInterfaces()) {
         if (superinterface instanceof DeclaredType) {
-          TypeElement superinterfaceElement = (TypeElement) ((DeclaredType) superinterface).asElement();
+          TypeElement superinterfaceElement
+              = (TypeElement) ((DeclaredType) superinterface).asElement();
           avoidClashesWithNestedClasses(superinterfaceElement);
         }
       }

--- a/src/main/java/com/squareup/javapoet/TypeSpec.java
+++ b/src/main/java/com/squareup/javapoet/TypeSpec.java
@@ -33,6 +33,9 @@ import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.NoType;
+import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.ElementFilter;
 
 import static com.squareup.javapoet.Util.checkArgument;
@@ -632,6 +635,17 @@ public final class TypeSpec {
       for (TypeElement nestedType : ElementFilter.typesIn(typeElement.getEnclosedElements())) {
         alwaysQualify(nestedType.getSimpleName().toString());
       }
+      TypeMirror superclass = typeElement.getSuperclass();
+      if (!(superclass instanceof NoType) && superclass instanceof DeclaredType) {
+        TypeElement superclassElement = (TypeElement) ((DeclaredType) superclass).asElement();
+        avoidClashesWithNestedClasses(superclassElement);
+      }
+      for (TypeMirror superinterface : typeElement.getInterfaces()) {
+        if (superinterface instanceof DeclaredType) {
+          TypeElement superinterfaceElement = (TypeElement) ((DeclaredType) superinterface).asElement();
+          avoidClashesWithNestedClasses(superinterfaceElement);
+        }
+      }
       return this;
     }
 
@@ -663,6 +677,13 @@ public final class TypeSpec {
       checkArgument(clazz != null, "clazz == null");
       for (Class<?> nestedType : clazz.getDeclaredClasses()) {
         alwaysQualify(nestedType.getSimpleName());
+      }
+      Class<?> superclass = clazz.getSuperclass();
+      if (superclass != null && !Object.class.equals(superclass)) {
+        avoidClashesWithNestedClasses(superclass);
+      }
+      for (Class<?> superinterface : clazz.getInterfaces()) {
+        avoidClashesWithNestedClasses(superinterface);
       }
       return this;
     }

--- a/src/test/java/com/squareup/javapoet/JavaFileTest.java
+++ b/src/test/java/com/squareup/javapoet/JavaFileTest.java
@@ -725,8 +725,8 @@ public final class JavaFileTest {
     String source = JavaFile.builder("com.squareup.tacos",
         TypeSpec.classBuilder("Taco")
             .addField(Thread.class, "thread")
+            .alwaysQualify("Thread")
             .build())
-        .alwaysQualify("Thread")
         .build()
         .toString();
     assertThat(source).isEqualTo(""
@@ -741,8 +741,8 @@ public final class JavaFileTest {
     String source = JavaFile.builder("com.squareup.tacos",
         TypeSpec.classBuilder("Taco")
             .addField(Thread.class, "thread")
+            .alwaysQualify("Thread")
             .build())
-        .alwaysQualify("Thread")
         .skipJavaLangImports(true)
         .build()
         .toString();
@@ -764,8 +764,8 @@ public final class JavaFileTest {
             .addField(ClassName.get("other", "NestedTypeC"), "nestedC")
             // This one shouldn't since we only look at nested types
             .addField(ClassName.get("other", "Foo"), "foo")
+            .avoidClashesWithNestedClasses(Foo.class)
             .build())
-        .avoidClashesWithNestedClasses(Foo.class)
         .build()
         .toString();
     assertThat(source).isEqualTo(""
@@ -795,8 +795,8 @@ public final class JavaFileTest {
             .addField(ClassName.get("other", "NestedTypeC"), "nestedC")
             // This one shouldn't since we only look at nested types
             .addField(ClassName.get("other", "Foo"), "foo")
+            .avoidClashesWithNestedClasses(getElement(Foo.class))
             .build())
-        .avoidClashesWithNestedClasses(getElement(Foo.class))
         .build()
         .toString();
     assertThat(source).isEqualTo(""

--- a/src/test/java/com/squareup/javapoet/JavaFileTest.java
+++ b/src/test/java/com/squareup/javapoet/JavaFileTest.java
@@ -20,6 +20,7 @@ import com.google.testing.compile.CompilationRule;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
@@ -973,6 +974,7 @@ public final class JavaFileTest {
         + "}\n");
   }
 
+  // Regression test for https://github.com/square/javapoet/issues/77
   // This covers class and inheritance
   static class Parent implements ParentInterface {
     static class Pattern {
@@ -984,5 +986,29 @@ public final class JavaFileTest {
     class Optional {
 
     }
+  }
+
+  // Regression test for case raised here: https://github.com/square/javapoet/issues/77#issuecomment-519972404
+  @Test
+  public void avoidClashes_mapEntry() {
+    String source = JavaFile.builder("com.squareup.javapoet",
+        TypeSpec.classBuilder("MapType")
+            .addMethod(MethodSpec.methodBuilder("optionalString")
+                .returns(ClassName.get("com.foo", "Entry"))
+                .addStatement("return null")
+                .build())
+            .addSuperinterface(Map.class)
+            .build())
+        .build()
+        .toString();
+    assertThat(source).isEqualTo("package com.squareup.javapoet;\n"
+        + "\n"
+        + "import java.util.Map;\n"
+        + "\n"
+        + "class MapType implements Map {\n"
+        + "  com.foo.Entry optionalString() {\n"
+        + "    return null;\n"
+        + "  }\n"
+        + "}\n");
   }
 }

--- a/src/test/java/com/squareup/javapoet/JavaFileTest.java
+++ b/src/test/java/com/squareup/javapoet/JavaFileTest.java
@@ -710,4 +710,37 @@ public final class JavaFileTest {
         + "class Taco {\n"
         + "}\n");
   }
+
+  @Test public void alwaysQualifySimple() {
+    String source = JavaFile.builder("com.squareup.tacos",
+        TypeSpec.classBuilder("Taco")
+            .addField(Thread.class, "thread")
+            .build())
+        .alwaysQualify("Thread")
+        .build()
+        .toString();
+    assertThat(source).isEqualTo(""
+        + "package com.squareup.tacos;\n"
+        + "\n"
+        + "class Taco {\n"
+        + "  java.lang.Thread thread;\n"
+        + "}\n");
+  }
+
+  @Test public void alwaysQualifySupersedesJavaLangImports() {
+    String source = JavaFile.builder("com.squareup.tacos",
+        TypeSpec.classBuilder("Taco")
+            .addField(Thread.class, "thread")
+            .build())
+        .alwaysQualify("Thread")
+        .skipJavaLangImports(true)
+        .build()
+        .toString();
+    assertThat(source).isEqualTo(""
+        + "package com.squareup.tacos;\n"
+        + "\n"
+        + "class Taco {\n"
+        + "  java.lang.Thread thread;\n"
+        + "}\n");
+  }
 }

--- a/src/test/java/com/squareup/javapoet/TypeSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/TypeSpecTest.java
@@ -2284,12 +2284,15 @@ public final class TypeSpecTest {
             .addStatement("foo = $S", "FOO")
             .build())
         .addOriginatingElement(originatingElement)
+        .alwaysQualify("com.example.AlwaysQualified")
         .build();
 
     TypeSpec recreatedTaco = taco.toBuilder().build();
     assertThat(toString(taco)).isEqualTo(toString(recreatedTaco));
     assertThat(taco.originatingElements)
         .containsExactlyElementsIn(recreatedTaco.originatingElements);
+    assertThat(taco.alwaysQualifiedNames)
+        .containsExactlyElementsIn(recreatedTaco.alwaysQualifiedNames);
 
     TypeSpec initializersAdded = taco.toBuilder()
         .addInitializerBlock(CodeBlock.builder()


### PR DESCRIPTION
Implementation based on https://github.com/square/javapoet/issues/77#issuecomment-507387399

Resolves #77

Note that I'm not sure what to do about nested types like `java.util.Map.Entry`, open to suggestions!

CC @eamonnmcmanus