### PR TITLE
Remove parameter annotations in MethodSpec.overriding

### DIFF
--- a/src/main/java/com/squareup/javapoet/MethodSpec.java
+++ b/src/main/java/com/squareup/javapoet/MethodSpec.java
@@ -24,6 +24,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
@@ -232,7 +233,14 @@ public final class MethodSpec {
     }
 
     methodBuilder.returns(TypeName.get(method.getReturnType()));
-    methodBuilder.addParameters(ParameterSpec.parametersOf(method));
+    methodBuilder.addParameters(ParameterSpec.parametersOf(method)
+        .stream()
+        .map(parameterSpec -> {
+          ParameterSpec.Builder builder = parameterSpec.toBuilder();
+          builder.annotations.clear();
+          return builder.build();
+        })
+        .collect(Collectors.toList()));
     methodBuilder.varargs(method.isVarArgs());
 
     for (TypeMirror thrownType : method.getThrownTypes()) {

--- a/src/test/java/com/squareup/javapoet/MethodSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/MethodSpecTest.java
@@ -148,8 +148,8 @@ public final class MethodSpecTest {
         + "@java.lang.Override\n"
         + "protected <T extends java.lang.Runnable & java.io.Closeable> java.lang.Runnable "
         + "everything(\n"
-        + "    @com.squareup.javapoet.MethodSpecTest.Nullable java.lang.String arg0,\n"
-        + "    java.util.List<? extends T> arg1) throws java.io.IOException, java.lang.SecurityException {\n"
+        + "    java.lang.String arg0, java.util.List<? extends T> arg1) throws java.io.IOException,\n"
+        + "    java.lang.SecurityException {\n"
         + "}\n");
   }
 


### PR DESCRIPTION
- Change to not copy parameter annotations was first introduced in
9505ad0e027a1f125b5352ac722ea141831fbf1c.
- Change to properly copy mirror annotations in ParameterSpec.get
was introduced in a0eadbbf0e7b70f0fbbc66043536e4328c3808fd,
breaking the behavior of MethodSpec.overriding.
- This change preserves the correct behavior of ParameterSpec.get
while also removing annotations in MethodSpec.overriding.