### PR TITLE
Add convenience method for adding multiple CodeBlock statements.

### DIFF
--- a/src/main/java/com/squareup/javapoet/CodeBlock.java
+++ b/src/main/java/com/squareup/javapoet/CodeBlock.java
@@ -408,6 +408,11 @@ public final class CodeBlock {
       return addStatement("$L", codeBlock);
     }
 
+    public Builder addStatements(Iterable<CodeBlock> codeBlocks) {
+      codeBlocks.forEach(this::addStatement);
+      return this;
+    }
+
     public Builder add(CodeBlock codeBlock) {
       formatParts.addAll(codeBlock.formatParts);
       args.addAll(codeBlock.args);

--- a/src/main/java/com/squareup/javapoet/MethodSpec.java
+++ b/src/main/java/com/squareup/javapoet/MethodSpec.java
@@ -541,6 +541,11 @@ public final class MethodSpec {
       return this;
     }
 
+    public Builder addStatements(Iterable<CodeBlock> codeBlocks) {
+      code.addStatements(codeBlocks);
+      return this;
+    }
+
     public MethodSpec build() {
       return new MethodSpec(this);
     }


### PR DESCRIPTION
This adds the `MethodSpec.addStatements(Iterable<CodeBlock>)` and `CodeBlock.addStatements(Iterable<CodeBlock>)`, which allows you to add multiple statements all in one line. This allows you to take code like this (imagine myCode is generated):

```
List<CodeBlock> myCode = new ArrayList<>();
MethodSpec.Builder fooMethodSpecBuilder = MethodSpec.methodBuilder("foo")
    .addModifiers(Modifier.PUBLIC);
myCode.forEach(fooMethodSpecBuilder::addStatement);
MethodSpec fooMethodSpec = fooMethodSpecBuilder.build();
```

And make it more fluent:

```
List<CodeBlock> myCode = new ArrayList<>();
MethodSpec fooMethodSpec = MethodSpec.methodBuilder("foo")
    .addModifiers(Modifier.PUBLIC)
    .addStatements(myCode)
    .build();
```

I found myself needing to use this pattern in an annotation processor I was working on, where I was building static methods on the fly and needing to call them to an overarching static method. I at first tried using MethodSpec.addCode() with CodeBlock.join(), but then realized that by doing that I lost the importing of types. So, I ended up with the top pattern, which proved rather awkward since there were other statements I needed to make before and after the static method calls were added. So, I made this slight change to make this usage flow better.