### PR TITLE
Don't copy parameter annotations when creating a ParameterSpec.

### DIFF
--- a/src/main/java/com/squareup/javapoet/MethodSpec.java
+++ b/src/main/java/com/squareup/javapoet/MethodSpec.java
@@ -24,7 +24,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
@@ -233,16 +232,7 @@ public final class MethodSpec {
     }
 
     methodBuilder.returns(TypeName.get(method.getReturnType()));
-    // Copying parameter annotations from the overridden method can be incorrect so we're
-    // deliberately dropping them. See https://github.com/square/javapoet/issues/482.
-    methodBuilder.addParameters(ParameterSpec.parametersOf(method)
-        .stream()
-        .map(parameterSpec -> {
-          ParameterSpec.Builder builder = parameterSpec.toBuilder();
-          builder.annotations.clear();
-          return builder.build();
-        })
-        .collect(Collectors.toList()));
+    methodBuilder.addParameters(ParameterSpec.parametersOf(method));
     methodBuilder.varargs(method.isVarArgs());
 
     for (TypeMirror thrownType : method.getThrownTypes()) {

--- a/src/main/java/com/squareup/javapoet/ParameterSpec.java
+++ b/src/main/java/com/squareup/javapoet/ParameterSpec.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
@@ -87,17 +86,12 @@ public final class ParameterSpec {
   public static ParameterSpec get(VariableElement element) {
     checkArgument(element.getKind().equals(ElementKind.PARAMETER), "element is not a parameter");
 
-    // Copy over any annotations from element.
-    List<AnnotationSpec> annotations = element.getAnnotationMirrors()
-        .stream()
-        .map((mirror) -> AnnotationSpec.get(mirror))
-        .collect(Collectors.toList());
-
     TypeName type = TypeName.get(element.asType());
     String name = element.getSimpleName().toString();
+    // Copying parameter annotations can be incorrect so we're deliberately not including them.
+    // See https://github.com/square/javapoet/issues/482.
     return ParameterSpec.builder(type, name)
         .addModifiers(element.getModifiers())
-        .addAnnotations(annotations)
         .build();
   }
 

--- a/src/test/java/com/squareup/javapoet/MethodSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/MethodSpecTest.java
@@ -37,7 +37,6 @@ import javax.lang.model.util.Types;
 import javax.tools.JavaFileObject;
 
 import com.google.testing.compile.CompilationSubject;
-import com.google.testing.compile.JavaFileObjects;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -261,7 +260,7 @@ public final class MethodSpecTest {
     abstract void foo(@PrivateAnnotation final String bar);
   }
 
-  @Test public void overrideNotCopyParameterAnnotations() {
+  @Test public void overrideDoesNotCopyParameterAnnotations() {
     TypeElement abstractTypeElement = getElement(AbstractClassWithPrivateAnnotation.class);
     ExecutableElement fooElement = ElementFilter.methodsIn(abstractTypeElement.getEnclosedElements()).get(0);
     ClassName implClassName = ClassName.get("com.squareup.javapoet", "Impl");

--- a/src/test/java/com/squareup/javapoet/ParameterSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/ParameterSpecTest.java
@@ -99,7 +99,7 @@ public class ParameterSpecTest {
     VariableElement parameterElement = element.getParameters().get(0);
 
     assertThat(ParameterSpec.get(parameterElement).toString())
-        .isEqualTo("@javax.annotation.Nullable java.lang.String arg0");
+        .isEqualTo("java.lang.String arg0");
   }
 
   @Test public void addNonFinalModifier() {


### PR DESCRIPTION
This further preserves the behaviour discussed in https://github.com/square/javapoet/issues/482.
Unifying it for both MethodSpec.overriding and ParameterSpec.get.