### PR TITLE
add sort Method (Issues 683)

### DIFF
--- a/src/main/java/com/squareup/javapoet/TypeSpec.java
+++ b/src/main/java/com/squareup/javapoet/TypeSpec.java
@@ -18,18 +18,7 @@ package com.squareup.javapoet;
 import java.io.IOException;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.Modifier;
@@ -832,6 +821,21 @@ public final class TypeSpec {
           "anonymous type has too many supertypes");
 
       return new TypeSpec(this);
+    }
+    /**
+     * Sort Methods by their names in Dictionary order
+     * @return builder itself
+     * 2020.05.08
+     */
+    public Builder sortMethod() {
+
+      Collections.sort(this.methodSpecs, new Comparator<MethodSpec>() {
+        @Override
+        public int compare(MethodSpec m1, MethodSpec m2) {
+          return m1.name.compareTo(m2.name);
+        }
+      });
+      return this;
     }
   }
 }

--- a/src/test/java/com/squareup/javapoet/TypeSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/TypeSpecTest.java
@@ -2551,4 +2551,80 @@ public final class TypeSpecTest {
         + "class Taco {\n"
         + "}\n");
   }
+  //  When there is no sort method
+//  2020.05.08
+  @Test public void MethodNotsorted() throws IOException {
+    MethodSpec onCreate = MethodSpec.methodBuilder("onCreate")
+            .addStatement("super.onCreate(savedInstanceState)")
+            .build();
+
+    MethodSpec onDelete = MethodSpec.methodBuilder("onDelete")
+            .addStatement("super.onDelete(savedInstanceState)")
+            .build();
+    TypeSpec spec = TypeSpec.classBuilder("sortMethod")
+            .addMethod(onDelete)
+            .addMethod(onCreate)
+            .build();
+    assertThat(toString(spec)).isEqualTo(""+
+            "package com.squareup.tacos;\n"+
+            "\n" +
+            "class sortMethod {\n" +
+            "  void onDelete() {\n" +
+            "    super.onDelete(savedInstanceState);\n" +
+            "  }\n" +
+            "\n" +
+            "  void onCreate() {\n" +
+            "    super.onCreate(savedInstanceState);\n" +
+            "  }\n" +
+
+            "}\n"
+    );
+  }
+  //  To test sort Methods
+//  2020.05.08
+  @Test public void MethodSorted() throws IOException {
+    MethodSpec onCreate = MethodSpec.methodBuilder("onCreate")
+            .addStatement("super.onCreate(savedInstanceState)")
+            .build();
+
+    MethodSpec onDelete = MethodSpec.methodBuilder("onDelete")
+            .addStatement("super.onDelete(savedInstanceState)")
+            .build();
+    MethodSpec toString = MethodSpec.methodBuilder("toString")
+            .build();
+    MethodSpec methodA = MethodSpec.methodBuilder("methodA")
+            .build();
+    MethodSpec methodB = MethodSpec.methodBuilder("methodB")
+            .build();
+    TypeSpec spec = TypeSpec.classBuilder("sortMethod")
+            .addMethod(onDelete)
+            .addMethod(methodB)
+            .addMethod(toString)
+            .addMethod(methodA)
+            .addMethod(onCreate)
+            .sortMethod()
+            .build();
+    assertThat(toString(spec)).isEqualTo(""+
+            "package com.squareup.tacos;\n"+
+            "\n" +
+            "class sortMethod {\n" +
+            "  void methodA() {\n" +
+            "  }\n" +
+            "\n" +
+            "  void methodB() {\n" +
+            "  }\n" +
+            "\n"+
+            "  void onCreate() {\n" +
+            "    super.onCreate(savedInstanceState);\n" +
+            "  }\n" +
+            "\n" +
+            "  void onDelete() {\n" +
+            "    super.onDelete(savedInstanceState);\n" +
+            "  }\n" +
+            "\n" +
+            "  void toString() {\n" +
+            "  }\n"+
+            "}\n"
+    );
+  }
 }


### PR DESCRIPTION
Add a sort method for sort `methodSpec` in dictionary order in `TypeSpec.class`. 
I write some JUnit test to show the result.
By the way, maybe `FieldSpec`, `TypeVariableName`, e.t.c. can also be sortable? 