### PR TITLE
Fix for #795 - MethodSpec.beginControlFlow inserts unneccessary space when argument is empty

### DIFF
--- a/src/main/java/com/squareup/javapoet/CodeBlock.java
+++ b/src/main/java/com/squareup/javapoet/CodeBlock.java
@@ -365,7 +365,7 @@ public final class CodeBlock {
      * Shouldn't contain braces or newline characters.
      */
     public Builder beginControlFlow(String controlFlow, Object... args) {
-      add(controlFlow + " {\n", args);
+      add(controlFlow + (!controlFlow.isEmpty() ? " ": "" ) + "{\n", args);
       indent();
       return this;
     }

--- a/src/test/java/com/squareup/javapoet/MethodSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/MethodSpecTest.java
@@ -462,6 +462,26 @@ public final class MethodSpecTest {
         + "}\n");
   }
 
+  @Test public void controlBlockTestWithEmptyBeginBlock(){
+    MethodSpec methodSpec = MethodSpec.methodBuilder("method")
+            .beginControlFlow("")
+            .addStatement("int value = 42")
+            .endControlFlow()
+            .beginControlFlow("")
+            .addStatement("int value = 42")
+            .endControlFlow()
+            .build();
+    assertThat(methodSpec.toString()).isEqualTo("" +
+            "void method() {\n" +
+            "  {\n" +
+            "    int value = 42;\n" +
+            "  }\n" +
+            "  {\n" +
+            "    int value = 42;\n" +
+            "  }\n" +
+            "}\n");
+  }
+
   @Test public void doWhileWithNamedCodeBlocks() {
     Map<String, Object> m = new HashMap<>();
     m.put("field", "valueField");


### PR DESCRIPTION
Code changes made to handle spaces for both empty and non-empty "beginControlFlow"