### PR TITLE
fix #637: Prevent class loading deadlock between TypeName and ClassName

### DIFF
--- a/src/main/java/com/squareup/javapoet/ClassName.java
+++ b/src/main/java/com/squareup/javapoet/ClassName.java
@@ -32,6 +32,15 @@ import static com.squareup.javapoet.Util.checkNotNull;
 /** A fully-qualified class name for top-level and member classes. */
 public final class ClassName extends TypeName implements Comparable<ClassName> {
   public static final ClassName OBJECT = ClassName.get(Object.class);
+  static final ClassName BOXED_VOID = ClassName.get("java.lang", "Void");
+  static final ClassName BOXED_BOOLEAN = ClassName.get("java.lang", "Boolean");
+  static final ClassName BOXED_BYTE = ClassName.get("java.lang", "Byte");
+  static final ClassName BOXED_SHORT = ClassName.get("java.lang", "Short");
+  static final ClassName BOXED_INT = ClassName.get("java.lang", "Integer");
+  static final ClassName BOXED_LONG = ClassName.get("java.lang", "Long");
+  static final ClassName BOXED_CHAR = ClassName.get("java.lang", "Character");
+  static final ClassName BOXED_FLOAT = ClassName.get("java.lang", "Float");
+  static final ClassName BOXED_DOUBLE = ClassName.get("java.lang", "Double");
 
   /** The name representing the default Java package. */
   private static final String NO_PACKAGE = "";

--- a/src/main/java/com/squareup/javapoet/TypeName.java
+++ b/src/main/java/com/squareup/javapoet/TypeName.java
@@ -75,17 +75,6 @@ public class TypeName {
   public static final TypeName CHAR = new TypeName("char");
   public static final TypeName FLOAT = new TypeName("float");
   public static final TypeName DOUBLE = new TypeName("double");
-  public static final ClassName OBJECT = ClassName.get("java.lang", "Object");
-
-  private static final ClassName BOXED_VOID = ClassName.get("java.lang", "Void");
-  private static final ClassName BOXED_BOOLEAN = ClassName.get("java.lang", "Boolean");
-  private static final ClassName BOXED_BYTE = ClassName.get("java.lang", "Byte");
-  private static final ClassName BOXED_SHORT = ClassName.get("java.lang", "Short");
-  private static final ClassName BOXED_INT = ClassName.get("java.lang", "Integer");
-  private static final ClassName BOXED_LONG = ClassName.get("java.lang", "Long");
-  private static final ClassName BOXED_CHAR = ClassName.get("java.lang", "Character");
-  private static final ClassName BOXED_FLOAT = ClassName.get("java.lang", "Float");
-  private static final ClassName BOXED_DOUBLE = ClassName.get("java.lang", "Double");
 
   /** The name of this type if it is a keyword, or null. */
   private final String keyword;
@@ -144,14 +133,14 @@ public class TypeName {
    * other types types including unboxed primitives and {@code java.lang.Void}.
    */
   public boolean isBoxedPrimitive() {
-    return this.equals(BOXED_BOOLEAN)
-        || this.equals(BOXED_BYTE)
-        || this.equals(BOXED_SHORT)
-        || this.equals(BOXED_INT)
-        || this.equals(BOXED_LONG)
-        || this.equals(BOXED_CHAR)
-        || this.equals(BOXED_FLOAT)
-        || this.equals(BOXED_DOUBLE);
+    return this.equals(ClassName.BOXED_BOOLEAN)
+        || this.equals(ClassName.BOXED_BYTE)
+        || this.equals(ClassName.BOXED_SHORT)
+        || this.equals(ClassName.BOXED_INT)
+        || this.equals(ClassName.BOXED_LONG)
+        || this.equals(ClassName.BOXED_CHAR)
+        || this.equals(ClassName.BOXED_FLOAT)
+        || this.equals(ClassName.BOXED_DOUBLE);
   }
 
   /**
@@ -160,15 +149,15 @@ public class TypeName {
    */
   public TypeName box() {
     if (keyword == null) return this; // Doesn't need boxing.
-    if (this == VOID) return BOXED_VOID;
-    if (this == BOOLEAN) return BOXED_BOOLEAN;
-    if (this == BYTE) return BOXED_BYTE;
-    if (this == SHORT) return BOXED_SHORT;
-    if (this == INT) return BOXED_INT;
-    if (this == LONG) return BOXED_LONG;
-    if (this == CHAR) return BOXED_CHAR;
-    if (this == FLOAT) return BOXED_FLOAT;
-    if (this == DOUBLE) return BOXED_DOUBLE;
+    if (this == VOID) return ClassName.BOXED_VOID;
+    if (this == BOOLEAN) return ClassName.BOXED_BOOLEAN;
+    if (this == BYTE) return ClassName.BOXED_BYTE;
+    if (this == SHORT) return ClassName.BOXED_SHORT;
+    if (this == INT) return ClassName.BOXED_INT;
+    if (this == LONG) return ClassName.BOXED_LONG;
+    if (this == CHAR) return ClassName.BOXED_CHAR;
+    if (this == FLOAT) return ClassName.BOXED_FLOAT;
+    if (this == DOUBLE) return ClassName.BOXED_DOUBLE;
     throw new AssertionError(keyword);
   }
 
@@ -180,15 +169,15 @@ public class TypeName {
    */
   public TypeName unbox() {
     if (keyword != null) return this; // Already unboxed.
-    if (this.equals(BOXED_VOID)) return VOID;
-    if (this.equals(BOXED_BOOLEAN)) return BOOLEAN;
-    if (this.equals(BOXED_BYTE)) return BYTE;
-    if (this.equals(BOXED_SHORT)) return SHORT;
-    if (this.equals(BOXED_INT)) return INT;
-    if (this.equals(BOXED_LONG)) return LONG;
-    if (this.equals(BOXED_CHAR)) return CHAR;
-    if (this.equals(BOXED_FLOAT)) return FLOAT;
-    if (this.equals(BOXED_DOUBLE)) return DOUBLE;
+    if (this.equals(ClassName.BOXED_VOID)) return VOID;
+    if (this.equals(ClassName.BOXED_BOOLEAN)) return BOOLEAN;
+    if (this.equals(ClassName.BOXED_BYTE)) return BYTE;
+    if (this.equals(ClassName.BOXED_SHORT)) return SHORT;
+    if (this.equals(ClassName.BOXED_INT)) return INT;
+    if (this.equals(ClassName.BOXED_LONG)) return LONG;
+    if (this.equals(ClassName.BOXED_CHAR)) return CHAR;
+    if (this.equals(ClassName.BOXED_FLOAT)) return FLOAT;
+    if (this.equals(ClassName.BOXED_DOUBLE)) return DOUBLE;
     throw new UnsupportedOperationException("cannot unbox " + this);
   }
 

--- a/src/main/java/com/squareup/javapoet/TypeVariableName.java
+++ b/src/main/java/com/squareup/javapoet/TypeVariableName.java
@@ -75,7 +75,7 @@ public final class TypeVariableName extends TypeName {
   private static TypeVariableName of(String name, List<TypeName> bounds) {
     // Strip java.lang.Object from bounds if it is present.
     List<TypeName> boundsNoObject = new ArrayList<>(bounds);
-    boundsNoObject.remove(OBJECT);
+    boundsNoObject.remove(ClassName.OBJECT);
     return new TypeVariableName(name, Collections.unmodifiableList(boundsNoObject));
   }
 
@@ -126,7 +126,7 @@ public final class TypeVariableName extends TypeName {
       for (TypeMirror typeMirror : element.getBounds()) {
         bounds.add(TypeName.get(typeMirror, typeVariables));
       }
-      bounds.remove(OBJECT);
+      bounds.remove(ClassName.OBJECT);
     }
     return typeVariableName;
   }
@@ -161,7 +161,7 @@ public final class TypeVariableName extends TypeName {
       for (Type bound : type.getBounds()) {
         bounds.add(TypeName.get(bound, map));
       }
-      bounds.remove(OBJECT);
+      bounds.remove(ClassName.OBJECT);
     }
     return result;
   }

--- a/src/main/java/com/squareup/javapoet/WildcardTypeName.java
+++ b/src/main/java/com/squareup/javapoet/WildcardTypeName.java
@@ -65,7 +65,7 @@ public final class WildcardTypeName extends TypeName {
     if (lowerBounds.size() == 1) {
       return out.emit("? super $T", lowerBounds.get(0));
     }
-    return upperBounds.get(0).equals(TypeName.OBJECT)
+    return upperBounds.get(0).equals(ClassName.OBJECT)
         ? out.emit("?")
         : out.emit("? extends $T", upperBounds.get(0));
   }
@@ -89,7 +89,7 @@ public final class WildcardTypeName extends TypeName {
    * bound} is {@code String.class}, this returns {@code ? super String}.
    */
   public static WildcardTypeName supertypeOf(TypeName lowerBound) {
-    return new WildcardTypeName(Collections.singletonList(OBJECT),
+    return new WildcardTypeName(Collections.singletonList(ClassName.OBJECT),
         Collections.singletonList(lowerBound));
   }
 

--- a/src/test/java/com/squareup/javapoet/AbstractTypesTest.java
+++ b/src/test/java/com/squareup/javapoet/AbstractTypesTest.java
@@ -262,7 +262,7 @@ public abstract class AbstractTypesTest {
     assertThat(TypeName.VOID.box()).isEqualTo(ClassName.get(Void.class));
     assertThat(ClassName.get(Integer.class).box()).isEqualTo(ClassName.get(Integer.class));
     assertThat(ClassName.get(Void.class).box()).isEqualTo(ClassName.get(Void.class));
-    assertThat(TypeName.OBJECT.box()).isEqualTo(TypeName.OBJECT);
+    assertThat(ClassName.OBJECT.box()).isEqualTo(ClassName.OBJECT);
     assertThat(ClassName.get(String.class).box()).isEqualTo(ClassName.get(String.class));
   }
 
@@ -272,7 +272,7 @@ public abstract class AbstractTypesTest {
     assertThat(ClassName.get(Integer.class).unbox()).isEqualTo(TypeName.INT.unbox());
     assertThat(ClassName.get(Void.class).unbox()).isEqualTo(TypeName.VOID.unbox());
     try {
-      TypeName.OBJECT.unbox();
+      ClassName.OBJECT.unbox();
       fail();
     } catch (UnsupportedOperationException expected) {
     }

--- a/src/test/java/com/squareup/javapoet/ClassNameTest.java
+++ b/src/test/java/com/squareup/javapoet/ClassNameTest.java
@@ -186,7 +186,7 @@ public final class ClassNameTest {
 
   @Test
   public void reflectionName() {
-    assertEquals("java.lang.Object", TypeName.OBJECT.reflectionName());
+    assertEquals("java.lang.Object", ClassName.OBJECT.reflectionName());
     assertEquals("java.lang.Thread$State", ClassName.get(Thread.State.class).reflectionName());
     assertEquals("java.util.Map$Entry", ClassName.get(Map.Entry.class).reflectionName());
     assertEquals("Foo", ClassName.get("", "Foo").reflectionName());
@@ -196,7 +196,7 @@ public final class ClassNameTest {
 
   @Test
   public void canonicalName() {
-    assertEquals("java.lang.Object", TypeName.OBJECT.canonicalName());
+    assertEquals("java.lang.Object", ClassName.OBJECT.canonicalName());
     assertEquals("java.lang.Thread.State", ClassName.get(Thread.State.class).canonicalName());
     assertEquals("java.util.Map.Entry", ClassName.get(Map.Entry.class).canonicalName());
     assertEquals("Foo", ClassName.get("", "Foo").canonicalName());


### PR DESCRIPTION
Previously TypeName included static fields initialized with
values of the ClassName subtype, resulting in a deadlock on
class initialization when separate threads attempt to load
ClassName and TypeName in parallel.

The static fields of type ClassName have been migrated from
TypeName to ClassName to prevent this deadlock.

NOTE: This includes a public API break. TypeName.OBJECT has been
removed, consumers should prefer ClassName.OBJECT instead.