### PR TITLE
Solving the problem of NameAllocator replacing ignorable chars in the suggested Java identifier

### DIFF
--- a/src/main/java/com/squareup/javapoet/NameAllocator.java
+++ b/src/main/java/com/squareup/javapoet/NameAllocator.java
@@ -134,9 +134,10 @@ public final class NameAllocator implements Cloneable {
           && Character.isJavaIdentifierPart(codePoint)) {
         result.append("_");
       }
-
-      int validCodePoint = Character.isJavaIdentifierPart(codePoint) ? codePoint : '_';
-      result.appendCodePoint(validCodePoint);
+      if(!Character.isIdentifierIgnorable(codePoint)) {
+        int validCodePoint = Character.isJavaIdentifierPart(codePoint) ? codePoint : '_';
+        result.appendCodePoint(validCodePoint);
+      }
       i += Character.charCount(codePoint);
     }
     return result.toString();

--- a/src/test/java/com/squareup/javapoet/NameAllocatorTest.java
+++ b/src/test/java/com/squareup/javapoet/NameAllocatorTest.java
@@ -108,4 +108,18 @@ public final class NameAllocatorTest {
     assertThat(innerAllocator2.newName("foo", 2)).isEqualTo("foo_");
     assertThat(innerAllocator2.newName("bar", 3)).isEqualTo("bar");
   }
+  //CS304 Issue link: https://github.com/square/javapoet/issues/774
+  @Test public void ignorableTestOne() throws Exception {
+    NameAllocator nameAllocator = new NameAllocator();
+    assertThat(nameAllocator.newName("ab")).isEqualTo("ab");
+    assertThat(nameAllocator.newName("a\u0008b")).isEqualTo("ab_");
+  }
+
+  //CS304 Issue link: https://github.com/square/javapoet/issues/774
+  @Test public void ignorableTestTwo() throws Exception {
+    NameAllocator nameAllocator = new NameAllocator();
+    assertThat(nameAllocator.newName("a\u007F\u0008c")).isEqualTo("ac");
+    assertThat(nameAllocator.newName("ac")).isEqualTo("ac_");
+  }
+
 }


### PR DESCRIPTION
Solving the problem of ignorable chars in Java identifier in NameAllocator. The linked problem is https://github.com/square/javapoet/issues/774