### PR TITLE
`ParameterizedTypeName` and `TypeVariableName` collection input

### DIFF
--- a/src/main/java/com/squareup/javapoet/ParameterizedTypeName.java
+++ b/src/main/java/com/squareup/javapoet/ParameterizedTypeName.java
@@ -119,6 +119,16 @@ public final class ParameterizedTypeName extends TypeName {
     return new ParameterizedTypeName(null, ClassName.get(rawType), list(typeArguments));
   }
 
+  /** Returns a parameterized type, applying {@code typeArguments} to {@code rawType}. */
+  public static ParameterizedTypeName get(ClassName rawType, List<TypeName> typeArguments) {
+    return new ParameterizedTypeName(null, rawType, typeArguments);
+  }
+
+  /** Returns a parameterized type, applying {@code typeArguments} to {@code rawType}. */
+  public static ParameterizedTypeName get(Class<?> rawType, Iterable<Type> typeArguments) {
+    return new ParameterizedTypeName(null, ClassName.get(rawType), list(typeArguments));
+  }
+
   /** Returns a parameterized type equivalent to {@code type}. */
   public static ParameterizedTypeName get(ParameterizedType type) {
     return get(type, new LinkedHashMap<>());

--- a/src/main/java/com/squareup/javapoet/TypeName.java
+++ b/src/main/java/com/squareup/javapoet/TypeName.java
@@ -368,6 +368,16 @@ public class TypeName {
     return result;
   }
 
+  /** Converts an iterable of types to a list of type names. */
+  static List<TypeName> list(Iterable<Type> types) {
+    Map<Type, TypeVariableName> map = new LinkedHashMap<>();
+    List<TypeName> result = new ArrayList<>();
+    for (Type type : types) {
+      result.add(get(type, map));
+    }
+    return result;
+  }
+
   /** Returns the array component of {@code type}, or null if {@code type} is not an array. */
   static TypeName arrayComponent(TypeName type) {
     return type instanceof ArrayTypeName

--- a/src/main/java/com/squareup/javapoet/TypeVariableName.java
+++ b/src/main/java/com/squareup/javapoet/TypeVariableName.java
@@ -96,7 +96,17 @@ public final class TypeVariableName extends TypeName {
 
   /** Returns type variable named {@code name} with {@code bounds}. */
   public static TypeVariableName get(String name, Type... bounds) {
-    return TypeVariableName.of(name, TypeName.list(bounds));
+    return TypeVariableName.of(name, list(bounds));
+  }
+
+  /** Returns type variable named {@code name} with {@code bounds}. */
+  public static TypeVariableName get(String name, List<TypeName> bounds) {
+    return TypeVariableName.of(name, bounds);
+  }
+
+  /** Returns type variable named {@code name} with {@code bounds}. */
+  public static TypeVariableName get(String name, Iterable<Type> bounds) {
+    return TypeVariableName.of(name, list(bounds));
   }
 
   /** Returns type variable equivalent to {@code mirror}. */

--- a/src/test/java/com/squareup/javapoet/TypeNameTest.java
+++ b/src/test/java/com/squareup/javapoet/TypeNameTest.java
@@ -137,7 +137,7 @@ public class TypeNameTest {
     assertEqualsHashCodeAndToString(ParameterizedTypeName.get(Object.class),
         ParameterizedTypeName.get(Object.class));
     assertEqualsHashCodeAndToString(ParameterizedTypeName.get(Set.class, UUID.class),
-        ParameterizedTypeName.get(Set.class, UUID.class));
+        ParameterizedTypeName.get(Set.class, Collections.singletonList(UUID.class)));
     assertNotEquals(ClassName.get(List.class), ParameterizedTypeName.get(List.class,
         String.class));
   }
@@ -146,7 +146,8 @@ public class TypeNameTest {
     assertEqualsHashCodeAndToString(TypeVariableName.get(Object.class),
         TypeVariableName.get(Object.class));
     TypeVariableName typeVar1 = TypeVariableName.get("T", Comparator.class, Serializable.class);
-    TypeVariableName typeVar2 = TypeVariableName.get("T", Comparator.class, Serializable.class);
+    TypeVariableName typeVar2 = TypeVariableName.get("T", Arrays.asList(Comparator.class,
+        Serializable.class));
     assertEqualsHashCodeAndToString(typeVar1, typeVar2);
   }
 


### PR DESCRIPTION
Just like kotlinpoet, javapoet should accept collection when creating an instance of `ParameterizedTypeName` and `TypeVariableName`.