### PR TITLE
Add value constant in AnnotationSpec

### DIFF
--- a/src/main/java/com/squareup/javapoet/AnnotationSpec.java
+++ b/src/main/java/com/squareup/javapoet/AnnotationSpec.java
@@ -43,7 +43,7 @@ import static com.squareup.javapoet.Util.checkNotNull;
 /** A generated annotation on a declaration. */
 public final class AnnotationSpec {
   public static final String VALUE = "value";
-  
+
   public final TypeName type;
   public final Map<String, List<CodeBlock>> members;
 

--- a/src/main/java/com/squareup/javapoet/AnnotationSpec.java
+++ b/src/main/java/com/squareup/javapoet/AnnotationSpec.java
@@ -42,6 +42,8 @@ import static com.squareup.javapoet.Util.checkNotNull;
 
 /** A generated annotation on a declaration. */
 public final class AnnotationSpec {
+  public static final String VALUE = "value";
+  
   public final TypeName type;
   public final Map<String, List<CodeBlock>> members;
 


### PR DESCRIPTION
I have "value" throughout my code in AnnotationSpecBuilders and it would be nice to replace them with a AnnotationSpec.Value