### PR TITLE
Fix #841: addModifiers(Iterable) for TypeSpec.Builder

### DIFF
--- a/src/main/java/com/squareup/javapoet/TypeSpec.java
+++ b/src/main/java/com/squareup/javapoet/TypeSpec.java
@@ -473,6 +473,12 @@ public final class TypeSpec {
       Collections.addAll(this.modifiers, modifiers);
       return this;
     }
+    public Builder addModifiers(Iterable<Modifier> modifiers){
+      for (Modifier modifier : modifiers){
+        this.modifiers.add(modifier);
+      }
+      return this;
+    }
 
     public Builder addTypeVariables(Iterable<TypeVariableName> typeVariables) {
       checkArgument(typeVariables != null, "typeVariables == null");

--- a/src/test/java/com/squareup/javapoet/TypeSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/TypeSpecTest.java
@@ -2000,6 +2000,16 @@ public final class TypeSpecTest {
     }
   }
 
+  @Test public void nullModifiersListAdditions(){
+    try {
+      TypeSpec.classBuilder("Taco").addModifiers((Modifier[]) null).build();
+      fail();
+    } catch(IllegalArgumentException expected) {
+      assertThat(expected.getMessage())
+              .isEqualTo("modifiers contain null");
+    }
+  }
+
   @Test public void nullTypeVariablesAddition() {
     try {
       TypeSpec.classBuilder("Taco").addTypeVariables(null);


### PR DESCRIPTION
Easily add addModifiers(Iterable) function in TypeSpec.Builder. #841 

And add one corresponding test in TypeSpecTest with name of nullModifiersListAdditions()