### PR TITLE
Fix #860: Nested Type name clashes within same package

### DIFF
--- a/src/main/java/com/squareup/javapoet/CodeWriter.java
+++ b/src/main/java/com/squareup/javapoet/CodeWriter.java
@@ -401,8 +401,16 @@ final class CodeWriter {
 
     // If the class is in the same package, we're done.
     if (Objects.equals(packageName, className.packageName())) {
-      referencedNames.add(topLevelSimpleName);
-      return join(".", className.simpleNames());
+      String conflictClassName = packageName+"."+className.simpleName;//From same package (Nest)
+      //For nested conflict situation, the simpleName should be in QualifyList
+      //But its full name dont contains its super name
+      if(alwaysQualify.contains(className.simpleName)
+              &&Objects.equals(conflictClassName,className.canonicalName)){
+
+      }else{//If not, do regular trim
+        referencedNames.add(topLevelSimpleName);
+        return join(".", className.simpleNames());
+      }
     }
 
     // We'll have to use the fully-qualified name. Mark the type as importable for a future pass.

--- a/src/test/java/com/squareup/javapoet/FooInterface.java
+++ b/src/test/java/com/squareup/javapoet/FooInterface.java
@@ -1,0 +1,5 @@
+package com.squareup.javapoet;
+
+public interface FooInterface {
+    public class Nest{};
+}

--- a/src/test/java/com/squareup/javapoet/JavaFileTest.java
+++ b/src/test/java/com/squareup/javapoet/JavaFileTest.java
@@ -757,6 +757,50 @@ public final class JavaFileTest {
         + "}\n");
   }
 
+  @Test public void avoidClashesWithNestedClasses_SamePackageTest() {
+    String source = JavaFile.builder("com.squareup.javapoet",
+            TypeSpec.classBuilder("Taco")
+                    // The external Name should be full
+                    .addField(ClassName.get(com.squareup.javapoet.Nest.class), "external_Nest")
+                    // The internal Name would be better with super name
+                    .addField(ClassName.get(com.squareup.javapoet.FooInterface.Nest.class), "interface_Nest")
+                    .addSuperinterface(com.squareup.javapoet.FooInterface.class)
+                    .build())
+            .build()
+            .toString();
+    assertThat(source).isEqualTo("package com.squareup.javapoet;\n" +
+            "\n" +
+            "class Taco implements FooInterface {\n" +
+            "  com.squareup.javapoet.Nest external_Nest;\n" +
+            "\n" +
+            "  FooInterface.Nest interface_Nest;\n" +
+            "}"+"\n");
+  }
+
+  @Test public void avoidClashesWithNestedClasses_InterExterPackageTest() {
+    String source = JavaFile.builder("com.squareup.javapoet",
+            TypeSpec.classBuilder("Taco")
+                    // The external Name should be full
+                    .addField(ClassName.get(com.squareup.javapoet.Nest.class), "external_Nest")
+                    // The internal Name would be better with super name
+                    .addField(ClassName.get(com.squareup.javapoet.FooInterface.Nest.class), "interface_Nest")
+                    // The external Name from external package
+                    .addField(ClassName.get("other","Nest"), "interface_Nest")
+                    .addSuperinterface(com.squareup.javapoet.FooInterface.class)
+                    .build())
+            .build()
+            .toString();
+    assertThat(source).isEqualTo("package com.squareup.javapoet;\n" +
+            "\n" +
+            "class Taco implements FooInterface {\n" +
+            "  com.squareup.javapoet.Nest external_Nest;\n" +
+            "\n" +
+            "  FooInterface.Nest interface_Nest;\n" +
+            "\n" +
+            "  other.Nest interface_Nest;\n" +
+            "}"+"\n");
+  }
+
   @Test public void avoidClashesWithNestedClasses_viaClass() {
     String source = JavaFile.builder("com.squareup.tacos",
         TypeSpec.classBuilder("Taco")
@@ -874,6 +918,10 @@ public final class JavaFileTest {
     class NestedTypeB {
 
     }
+  }
+
+  static class NestedTypeA{
+
   }
 
   private TypeSpec.Builder childTypeBuilder() {

--- a/src/test/java/com/squareup/javapoet/Nest.java
+++ b/src/test/java/com/squareup/javapoet/Nest.java
@@ -1,0 +1,4 @@
+package com.squareup.javapoet;
+
+public class Nest {
+}


### PR DESCRIPTION
As mentioned in #860 , when we are using a class with name both appearing in the inner declaration of current super class, and a individual class in current package, the later one's name would be the simplest form (e.g. `Nest`). However, it should be `com.squareup.javapoet.Nest` and the `Nest` should be the name of inner class.

Therefore, an judgement is added in the trim step in `lookupname`. With that, the name of external class in same package would not be trim any longer and will be write as its full name.

By the way, in order to test this situation, two other class is added in `test`. They don't look good, but that's the only way I know to get the bug's situation. 