### PR TITLE
issue #582, API for changing the modifer when overriding 

### DIFF
--- a/src/main/java/com/squareup/javapoet/MethodSpec.java
+++ b/src/main/java/com/squareup/javapoet/MethodSpec.java
@@ -276,6 +276,36 @@ public final class MethodSpec {
     return builder;
   }
 
+  public static Builder overridingWithModifier(ExecutableElement method, List<Integer> locations, Modifier modifier) {
+    Builder builder = overriding(method);
+    int size = method.getParameters().size();
+
+    for (int i : locations) {
+      if (0 <= i && i < size) {
+        ParameterSpec parameter = builder.parameters.get(i);
+        builder.parameters.set(i, parameter.toBuilder().addModifiers(modifier).build());
+      }
+    }
+
+    return builder;
+  }
+
+  public static Builder overriding(
+          ExecutableElement method, DeclaredType enclosing, Types types,
+          List<Integer> locations, Modifier modifier) {
+    Builder builder = overriding(method, enclosing, types);
+    int size = method.getParameters().size();
+
+    for (int i: locations) {
+      if (0 <= i && i < size) {
+        ParameterSpec parameter = builder.parameters.get(i);
+        builder.parameters.set(i, parameter.toBuilder().addModifiers(modifier).build());
+      }
+    }
+
+    return builder;
+  }
+
   public Builder toBuilder() {
     Builder builder = new Builder(name);
     builder.javadoc.add(javadoc);

--- a/src/test/java/com/squareup/javapoet/MethodSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/MethodSpecTest.java
@@ -158,6 +158,19 @@ public final class MethodSpecTest {
         + "}\n");
   }
 
+  @Test public void overrideEverythingWithFinal() {
+    TypeElement classElement = getElement(Everything.class);
+    ExecutableElement methodElement = getOnlyElement(methodsIn(classElement.getEnclosedElements()));
+    MethodSpec method = MethodSpec.overridingWithModifier(methodElement, Arrays.asList(0, 1),Modifier.FINAL).build();
+    assertThat(method.toString()).isEqualTo(""
+            + "@java.lang.Override\n"
+            + "protected <T extends java.lang.Runnable & java.io.Closeable> java.lang.Runnable "
+            + "everything(\n"
+            + "    final java.lang.String arg0, final java.util.List<? extends T> arg1) throws java.io.IOException,\n"
+            + "    java.lang.SecurityException {\n"
+            + "}\n");
+  }
+
   @Test public void overrideGenerics() {
     TypeElement classElement = getElement(Generics.class);
     ExecutableElement methodElement = getOnlyElement(methodsIn(classElement.getEnclosedElements()));


### PR DESCRIPTION
As mentioned in #582, I add an API for changing the parameter's  modifier when overriding. The solution mentioned in #576 inspires me a lot.

The method is `overridingWithModifier(ExecutableElement method, List<Integer> locations, Modifier modifier)`. `locations` is the index of parameters(of course start from 0) you wanna add modifiers to, and `modifier` is the modifier you wanna add. One thing worth mentioning is that the index can be illegal, and the illegal index will be ignored by the method automatically.

I also add a test in `MethoSpecTest.java`.