### PR TITLE
Add ability to insert comment inside class scope

### DIFF
--- a/src/main/java/com/squareup/javapoet/TypeSpec.java
+++ b/src/main/java/com/squareup/javapoet/TypeSpec.java
@@ -626,6 +626,11 @@ public final class TypeSpec {
       return this;
     }
 
+    public Builder addRawInitializerBlock(CodeBlock block) {
+      initializerBlock.add(block).add("\n");
+      return this;
+    }
+
     public Builder addMethods(Iterable<MethodSpec> methodSpecs) {
       checkArgument(methodSpecs != null, "methodSpecs == null");
       for (MethodSpec methodSpec : methodSpecs) {

--- a/src/test/java/com/squareup/javapoet/TypeSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/TypeSpecTest.java
@@ -2307,6 +2307,7 @@ public final class TypeSpecTest {
         .addStaticBlock(CodeBlock.builder()
             .addStatement("FOO = $S", "FOO")
             .build())
+        .addRawInitializerBlock(CodeBlock.builder().add("// @@protoc_insertion_point(service_scope:)").build())
         .addMethod(MethodSpec.constructorBuilder().build())
         .addMethod(MethodSpec.methodBuilder("toString")
             .addAnnotation(Override.class)
@@ -2333,6 +2334,7 @@ public final class TypeSpecTest {
         + "\n"
         + "  private String foo;\n"
         + "\n"
+        + "  // @@protoc_insertion_point(service_scope:)\n"
         + "  {\n"
         + "    foo = \"FOO\";\n"
         + "  }\n"


### PR DESCRIPTION
Motivation:
When generating code it maybe useful to insert
comments as anchors for post processing and further
extension by other code generation tools. However
this is not easy to achieve with the existing API.

Modifications:
- Add a `TypeSpec.addRawInitializerBlock` method which
  is treated the same as `addInitializerBlock` without
  type restrictions and additional scope block.