### PR TITLE
addModifiers method in FieldSpec and TypeSpec accepting Iterable

### DIFF
--- a/src/main/java/com/squareup/javapoet/FieldSpec.java
+++ b/src/main/java/com/squareup/javapoet/FieldSpec.java
@@ -158,6 +158,13 @@ public final class FieldSpec {
       return this;
     }
 
+    public Builder addModifiers(Iterable<Modifier> modifiers) {
+      for (Modifier modifier : modifiers) {
+        this.modifiers.add(modifier);
+      }
+      return this;
+    }
+
     public Builder initializer(String format, Object... args) {
       return initializer(CodeBlock.of(format, args));
     }

--- a/src/main/java/com/squareup/javapoet/TypeSpec.java
+++ b/src/main/java/com/squareup/javapoet/TypeSpec.java
@@ -474,6 +474,13 @@ public final class TypeSpec {
       return this;
     }
 
+    public Builder addModifiers(Iterable<Modifier> modifiers) {
+      for (Modifier modifier : modifiers) {
+        this.modifiers.add(modifier);
+      }
+      return this;
+    }
+
     public Builder addTypeVariables(Iterable<TypeVariableName> typeVariables) {
       checkArgument(typeVariables != null, "typeVariables == null");
       for (TypeVariableName typeVariable : typeVariables) {


### PR DESCRIPTION
Currently `FieldSpec` and `TypeSpec` both have `addModifiers` method that accepts a variable number of arguments of type `Modifier`:
```java
public Builder addModifiers(Modifier... modifiers) {
    Collections.addAll(this.modifiers, modifiers);
    return this;
}
```

In contrast, `MethodSpec` has an additional convenient signature for this method that accepts a `Iterable` type:
```java
public Builder addModifiers(Iterable<Modifier> modifiers) {
    checkNotNull(modifiers, "modifiers == null");
    for (Modifier modifier : modifiers) {
        this.modifiers.add(modifier);
    }
    return this;
}
```

I think it is appropriate to enhance `FieldSpec` and `TypeSpec` to also have such method signature.