### PR TITLE
Fix #604 Multiline Strings Forcefully Wrapping With Concatenation Causing Issues

### DIFF
--- a/src/main/java/com/squareup/javapoet/CodeBlock.java
+++ b/src/main/java/com/squareup/javapoet/CodeBlock.java
@@ -349,6 +349,33 @@ public final class CodeBlock {
     }
 
     private String argToString(Object o) {
+      if(o instanceof String){
+        int index = -1;
+        StringBuilder str= new StringBuilder();
+        char temp = '\\';
+        for(int i=0;i<((String) o).length();i++){
+          if(((String) o).charAt(i)==10){
+            if(i==0) {
+              str.append(temp).append("n");
+              index=i+1;
+            }else if(index==-1) {
+              str.append(((String) o).substring(0, i)).append(temp).append("n");
+              index=i+1;
+            }else {
+              str.append(((String) o).substring(index, i)).append(temp).append("n");
+              index=i+1;
+            }
+          }
+        }
+        if(index==-1){
+          return o != null ? String.valueOf(o) : null;
+        }
+        if(index!=((String) o).length() ){
+          str.append(((String) o).substring(index, ((String) o).length()));
+        }
+        return str.toString();
+
+      }
       return o != null ? String.valueOf(o) : null;
     }
 

--- a/src/main/java/com/squareup/javapoet/MethodSpec.java
+++ b/src/main/java/com/squareup/javapoet/MethodSpec.java
@@ -451,8 +451,17 @@ public final class MethodSpec {
     }
 
     public Builder addComment(String format, Object... args) {
-      code.add("// " + format + "\n", args);
-      return this;
+      String[] lines = format.split("\\R");
+      if(lines.length==1){
+        code.add("// " + format + "\n", args);
+        return this;
+      }else {
+        for (String line : lines) {
+          code.add("// " + line + "\n");
+        }
+        return this;
+      }
+//      return this;
     }
 
     public Builder defaultValue(String format, Object... args) {

--- a/src/main/java/com/squareup/javapoet/MethodSpec.java
+++ b/src/main/java/com/squareup/javapoet/MethodSpec.java
@@ -451,17 +451,8 @@ public final class MethodSpec {
     }
 
     public Builder addComment(String format, Object... args) {
-      String[] lines = format.split("\\R");
-      if(lines.length==1){
-        code.add("// " + format + "\n", args);
-        return this;
-      }else {
-        for (String line : lines) {
-          code.add("// " + line + "\n");
-        }
-        return this;
-      }
-//      return this;
+      code.add("// " + format + "\n", args);
+      return this;
     }
 
     public Builder defaultValue(String format, Object... args) {

--- a/src/main/java/com/squareup/javapoet/Util.java
+++ b/src/main/java/com/squareup/javapoet/Util.java
@@ -96,7 +96,7 @@ final class Util {
       case '\r': return "\\r"; /* \u000d: carriage return (CR) */
       case '\"': return "\"";  /* \u0022: double quote (") */
       case '\'': return "\\'"; /* \u0027: single quote (') */
-      case '\\': return "\\\\";  /* \u005c: backslash (\) */
+      case '\\': return "\\";  /* \u005c: backslash (\) */
       default:
         return isISOControl(c) ? String.format("\\u%04x", (int) c) : Character.toString(c);
     }

--- a/src/test/java/com/squareup/javapoet/MethodSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/MethodSpecTest.java
@@ -63,422 +63,441 @@ public final class MethodSpecTest {
     return elements.getTypeElement(clazz.getCanonicalName());
   }
 
-  @Test public void nullAnnotationsAddition() {
-    try {
-      MethodSpec.methodBuilder("doSomething").addAnnotations(null);
-      fail();
-    } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("annotationSpecs == null");
-    }
-  }
+//  @Test public void nullAnnotationsAddition() {
+//    try {
+//      MethodSpec.methodBuilder("doSomething").addAnnotations(null);
+//      fail();
+//    } catch (IllegalArgumentException expected) {
+//      assertThat(expected).hasMessageThat().isEqualTo("annotationSpecs == null");
+//    }
+//  }
+//
+//  @Test public void nullTypeVariablesAddition() {
+//    try {
+//      MethodSpec.methodBuilder("doSomething").addTypeVariables(null);
+//      fail();
+//    } catch (IllegalArgumentException expected) {
+//      assertThat(expected).hasMessageThat().isEqualTo("typeVariables == null");
+//    }
+//  }
+//
+//  @Test public void nullParametersAddition() {
+//    try {
+//      MethodSpec.methodBuilder("doSomething").addParameters(null);
+//      fail();
+//    } catch (IllegalArgumentException expected) {
+//      assertThat(expected).hasMessageThat().isEqualTo("parameterSpecs == null");
+//    }
+//  }
+//
+//  @Test public void nullExceptionsAddition() {
+//    try {
+//      MethodSpec.methodBuilder("doSomething").addExceptions(null);
+//      fail();
+//    } catch (IllegalArgumentException expected) {
+//      assertThat(expected).hasMessageThat().isEqualTo("exceptions == null");
+//    }
+//  }
+//
+//  @Target(ElementType.PARAMETER)
+//  @interface Nullable {
+//  }
+//
+//  abstract static class Everything {
+//    @Deprecated protected abstract <T extends Runnable & Closeable> Runnable everything(
+//        @Nullable String thing, List<? extends T> things) throws IOException, SecurityException;
+//  }
+//
+//  abstract static class Generics {
+//    <T, R, V extends Throwable> T run(R param) throws V {
+//      return null;
+//    }
+//  }
+//
+//  abstract static class HasAnnotation {
+//    @Override public abstract String toString();
+//  }
+//
+//  interface Throws<R extends RuntimeException> {
+//    void fail() throws R;
+//  }
+//
+//  interface ExtendsOthers extends Callable<Integer>, Comparable<ExtendsOthers>,
+//      Throws<IllegalStateException> {
+//  }
+//
+//  interface ExtendsIterableWithDefaultMethods extends Iterable<Object> {
+//  }
+//
+//  final class FinalClass {
+//    void method() {
+//    }
+//  }
+//
+//  abstract static class InvalidOverrideMethods {
+//    final void finalMethod() {
+//    }
+//
+//    private void privateMethod() {
+//    }
+//
+//    static void staticMethod() {
+//    }
+//  }
+//
+//  @Test public void overrideEverything() {
+//    TypeElement classElement = getElement(Everything.class);
+//    ExecutableElement methodElement = getOnlyElement(methodsIn(classElement.getEnclosedElements()));
+//    MethodSpec method = MethodSpec.overriding(methodElement).build();
+//    assertThat(method.toString()).isEqualTo(""
+//        + "@java.lang.Override\n"
+//        + "protected <T extends java.lang.Runnable & java.io.Closeable> java.lang.Runnable "
+//        + "everything(\n"
+//        + "    java.lang.String arg0, java.util.List<? extends T> arg1) throws java.io.IOException,\n"
+//        + "    java.lang.SecurityException {\n"
+//        + "}\n");
+//  }
+//
+//  @Test public void overrideGenerics() {
+//    TypeElement classElement = getElement(Generics.class);
+//    ExecutableElement methodElement = getOnlyElement(methodsIn(classElement.getEnclosedElements()));
+//    MethodSpec method = MethodSpec.overriding(methodElement)
+//        .addStatement("return null")
+//        .build();
+//    assertThat(method.toString()).isEqualTo(""
+//        + "@java.lang.Override\n"
+//        + "<T, R, V extends java.lang.Throwable> T run(R param) throws V {\n"
+//        + "  return null;\n"
+//        + "}\n");
+//  }
+//
+//  @Test public void overrideDoesNotCopyOverrideAnnotation() {
+//    TypeElement classElement = getElement(HasAnnotation.class);
+//    ExecutableElement exec = getOnlyElement(methodsIn(classElement.getEnclosedElements()));
+//    MethodSpec method = MethodSpec.overriding(exec).build();
+//    assertThat(method.toString()).isEqualTo(""
+//        + "@java.lang.Override\n"
+//        + "public java.lang.String toString() {\n"
+//        + "}\n");
+//  }
+//
+//  @Test public void overrideDoesNotCopyDefaultModifier() {
+//    TypeElement classElement = getElement(ExtendsIterableWithDefaultMethods.class);
+//    DeclaredType classType = (DeclaredType) classElement.asType();
+//    List<ExecutableElement> methods = methodsIn(elements.getAllMembers(classElement));
+//    ExecutableElement exec = findFirst(methods, "spliterator");
+//    MethodSpec method = MethodSpec.overriding(exec, classType, types).build();
+//    assertThat(method.toString()).isEqualTo(""
+//        + "@java.lang.Override\n"
+//        + "public java.util.Spliterator<java.lang.Object> spliterator() {\n"
+//        + "}\n");
+//  }
+//
+//  @Test public void overrideExtendsOthersWorksWithActualTypeParameters() {
+//    TypeElement classElement = getElement(ExtendsOthers.class);
+//    DeclaredType classType = (DeclaredType) classElement.asType();
+//    List<ExecutableElement> methods = methodsIn(elements.getAllMembers(classElement));
+//    ExecutableElement exec = findFirst(methods, "call");
+//    MethodSpec method = MethodSpec.overriding(exec, classType, types).build();
+//    assertThat(method.toString()).isEqualTo(""
+//        + "@java.lang.Override\n"
+//        + "public java.lang.Integer call() throws java.lang.Exception {\n"
+//        + "}\n");
+//    exec = findFirst(methods, "compareTo");
+//    method = MethodSpec.overriding(exec, classType, types).build();
+//    assertThat(method.toString()).isEqualTo(""
+//        + "@java.lang.Override\n"
+//        + "public int compareTo(" + ExtendsOthers.class.getCanonicalName() + " arg0) {\n"
+//        + "}\n");
+//    exec = findFirst(methods, "fail");
+//    method = MethodSpec.overriding(exec, classType, types).build();
+//    assertThat(method.toString()).isEqualTo(""
+//        + "@java.lang.Override\n"
+//        + "public void fail() throws java.lang.IllegalStateException {\n"
+//        + "}\n");
+//  }
+//
+//  @Test public void overrideFinalClassMethod() {
+//    TypeElement classElement = getElement(FinalClass.class);
+//    List<ExecutableElement> methods = methodsIn(elements.getAllMembers(classElement));
+//    try {
+//      MethodSpec.overriding(findFirst(methods, "method"));
+//      fail();
+//    } catch (IllegalArgumentException expected) {
+//      assertThat(expected).hasMessageThat().isEqualTo(
+//          "Cannot override method on final class com.squareup.javapoet.MethodSpecTest.FinalClass");
+//    }
+//  }
+//
+//  @Test public void overrideInvalidModifiers() {
+//    TypeElement classElement = getElement(InvalidOverrideMethods.class);
+//    List<ExecutableElement> methods = methodsIn(elements.getAllMembers(classElement));
+//    try {
+//      MethodSpec.overriding(findFirst(methods, "finalMethod"));
+//      fail();
+//    } catch (IllegalArgumentException expected) {
+//      assertThat(expected).hasMessageThat().isEqualTo("cannot override method with modifiers: [final]");
+//    }
+//    try {
+//      MethodSpec.overriding(findFirst(methods, "privateMethod"));
+//      fail();
+//    } catch (IllegalArgumentException expected) {
+//      assertThat(expected).hasMessageThat().isEqualTo("cannot override method with modifiers: [private]");
+//    }
+//    try {
+//      MethodSpec.overriding(findFirst(methods, "staticMethod"));
+//      fail();
+//    } catch (IllegalArgumentException expected) {
+//      assertThat(expected).hasMessageThat().isEqualTo("cannot override method with modifiers: [static]");
+//    }
+//  }
+//
+//  abstract static class AbstractClassWithPrivateAnnotation {
+//
+//    private @interface PrivateAnnotation{ }
+//
+//    abstract void foo(@PrivateAnnotation final String bar);
+//  }
+//
+//  @Test public void overrideDoesNotCopyParameterAnnotations() {
+//    TypeElement abstractTypeElement = getElement(AbstractClassWithPrivateAnnotation.class);
+//    ExecutableElement fooElement = ElementFilter.methodsIn(abstractTypeElement.getEnclosedElements()).get(0);
+//    ClassName implClassName = ClassName.get("com.squareup.javapoet", "Impl");
+//    TypeSpec type = TypeSpec.classBuilder(implClassName)
+//            .superclass(abstractTypeElement.asType())
+//            .addMethod(MethodSpec.overriding(fooElement).build())
+//            .build();
+//    JavaFileObject jfo = JavaFile.builder(implClassName.packageName, type).build().toJavaFileObject();
+//    Compilation compilation = javac().compile(jfo);
+//    assertThat(compilation).succeeded();
+//  }
+//
+//  @Test public void equalsAndHashCode() {
+//    MethodSpec a = MethodSpec.constructorBuilder().build();
+//    MethodSpec b = MethodSpec.constructorBuilder().build();
+//    assertThat(a.equals(b)).isTrue();
+//    assertThat(a.hashCode()).isEqualTo(b.hashCode());
+//    a = MethodSpec.methodBuilder("taco").build();
+//    b = MethodSpec.methodBuilder("taco").build();
+//    assertThat(a.equals(b)).isTrue();
+//    assertThat(a.hashCode()).isEqualTo(b.hashCode());
+//    TypeElement classElement = getElement(Everything.class);
+//    ExecutableElement methodElement = getOnlyElement(methodsIn(classElement.getEnclosedElements()));
+//    a = MethodSpec.overriding(methodElement).build();
+//    b = MethodSpec.overriding(methodElement).build();
+//    assertThat(a.equals(b)).isTrue();
+//    assertThat(a.hashCode()).isEqualTo(b.hashCode());
+//  }
+//
+//  @Test public void withoutParameterJavaDoc() {
+//    MethodSpec methodSpec = MethodSpec.methodBuilder("getTaco")
+//        .addModifiers(Modifier.PRIVATE)
+//        .addParameter(TypeName.DOUBLE, "money")
+//        .addJavadoc("Gets the best Taco\n")
+//        .build();
+//    assertThat(methodSpec.toString()).isEqualTo(""
+//        + "/**\n"
+//        + " * Gets the best Taco\n"
+//        + " */\n"
+//        + "private void getTaco(double money) {\n"
+//        + "}\n");
+//  }
+//
+//  @Test public void withParameterJavaDoc() {
+//    MethodSpec methodSpec = MethodSpec.methodBuilder("getTaco")
+//        .addParameter(ParameterSpec.builder(TypeName.DOUBLE, "money")
+//            .addJavadoc("the amount required to buy the taco.\n")
+//            .build())
+//        .addParameter(ParameterSpec.builder(TypeName.INT, "count")
+//            .addJavadoc("the number of Tacos to buy.\n")
+//            .build())
+//        .addJavadoc("Gets the best Taco money can buy.\n")
+//        .build();
+//    assertThat(methodSpec.toString()).isEqualTo(""
+//        + "/**\n"
+//        + " * Gets the best Taco money can buy.\n"
+//        + " *\n"
+//        + " * @param money the amount required to buy the taco.\n"
+//        + " * @param count the number of Tacos to buy.\n"
+//        + " */\n"
+//        + "void getTaco(double money, int count) {\n"
+//        + "}\n");
+//  }
+//
+//  @Test public void withParameterJavaDocAndWithoutMethodJavadoc() {
+//    MethodSpec methodSpec = MethodSpec.methodBuilder("getTaco")
+//        .addParameter(ParameterSpec.builder(TypeName.DOUBLE, "money")
+//            .addJavadoc("the amount required to buy the taco.\n")
+//            .build())
+//        .addParameter(ParameterSpec.builder(TypeName.INT, "count")
+//            .addJavadoc("the number of Tacos to buy.\n")
+//            .build())
+//        .build();
+//    assertThat(methodSpec.toString()).isEqualTo(""
+//        + "/**\n"
+//        + " * @param money the amount required to buy the taco.\n"
+//        + " * @param count the number of Tacos to buy.\n"
+//        + " */\n"
+//        + "void getTaco(double money, int count) {\n"
+//        + "}\n");
+//  }
+//
+//  @Test public void duplicateExceptionsIgnored() {
+//    ClassName ioException = ClassName.get(IOException.class);
+//    ClassName timeoutException = ClassName.get(TimeoutException.class);
+//    MethodSpec methodSpec = MethodSpec.methodBuilder("duplicateExceptions")
+//      .addException(ioException)
+//      .addException(timeoutException)
+//      .addException(timeoutException)
+//      .addException(ioException)
+//      .build();
+//    assertThat(methodSpec.exceptions).isEqualTo(Arrays.asList(ioException, timeoutException));
+//    assertThat(methodSpec.toBuilder().addException(ioException).build().exceptions)
+//      .isEqualTo(Arrays.asList(ioException, timeoutException));
+//  }
+//
+//  @Test public void nullIsNotAValidMethodName() {
+//    try {
+//      MethodSpec.methodBuilder(null);
+//      fail("NullPointerException expected");
+//    } catch (NullPointerException e) {
+//      assertThat(e.getMessage()).isEqualTo("name == null");
+//    }
+//  }
+//
+//  @Test public void addModifiersVarargsShouldNotBeNull() {
+//    try {
+//      MethodSpec.methodBuilder("taco")
+//              .addModifiers((Modifier[]) null);
+//      fail("NullPointerException expected");
+//    } catch (NullPointerException e) {
+//      assertThat(e.getMessage()).isEqualTo("modifiers == null");
+//    }
+//  }
+//
+//  @Test public void modifyMethodName() {
+//    MethodSpec methodSpec = MethodSpec.methodBuilder("initialMethod")
+//        .build()
+//        .toBuilder()
+//        .setName("revisedMethod")
+//        .build();
+//
+//    assertThat(methodSpec.toString()).isEqualTo("" + "void revisedMethod() {\n" + "}\n");
+//  }
+//
+//  @Test public void modifyAnnotations() {
+//    MethodSpec.Builder builder = MethodSpec.methodBuilder("foo")
+//            .addAnnotation(Override.class)
+//            .addAnnotation(SuppressWarnings.class);
+//
+//    builder.annotations.remove(1);
+//    assertThat(builder.build().annotations).hasSize(1);
+//  }
+//
+//  @Test public void modifyModifiers() {
+//    MethodSpec.Builder builder = MethodSpec.methodBuilder("foo")
+//            .addModifiers(Modifier.PUBLIC, Modifier.STATIC);
+//
+//    builder.modifiers.remove(1);
+//    assertThat(builder.build().modifiers).containsExactly(Modifier.PUBLIC);
+//  }
+//
+//  @Test public void modifyParameters() {
+//    MethodSpec.Builder builder = MethodSpec.methodBuilder("foo")
+//            .addParameter(int.class, "source");
+//
+//    builder.parameters.remove(0);
+//    assertThat(builder.build().parameters).isEmpty();
+//  }
+//
+//  @Test public void modifyTypeVariables() {
+//    TypeVariableName t = TypeVariableName.get("T");
+//    MethodSpec.Builder builder = MethodSpec.methodBuilder("foo")
+//            .addTypeVariable(t)
+//            .addTypeVariable(TypeVariableName.get("V"));
+//
+//    builder.typeVariables.remove(1);
+//    assertThat(builder.build().typeVariables).containsExactly(t);
+//  }
+//
+//  @Test public void ensureTrailingNewline() {
+//    MethodSpec methodSpec = MethodSpec.methodBuilder("method")
+//        .addCode("codeWithNoNewline();")
+//        .build();
+//
+//    assertThat(methodSpec.toString()).isEqualTo(""
+//        + "void method() {\n"
+//        + "  codeWithNoNewline();\n"
+//        + "}\n");
+//  }
+//
+//  /** Ensures that we don't add a duplicate newline if one is already present. */
+//  @Test public void ensureTrailingNewlineWithExistingNewline() {
+//    MethodSpec methodSpec = MethodSpec.methodBuilder("method")
+//        .addCode("codeWithNoNewline();\n") // Have a newline already, so ensure we're not adding one
+//        .build();
+//
+//    assertThat(methodSpec.toString()).isEqualTo(""
+//        + "void method() {\n"
+//        + "  codeWithNoNewline();\n"
+//        + "}\n");
+//  }
+//
+//  @Test public void controlFlowWithNamedCodeBlocks() {
+//    Map<String, Object> m = new HashMap<>();
+//    m.put("field", "valueField");
+//    m.put("threshold", "5");
+//
+//    MethodSpec methodSpec = MethodSpec.methodBuilder("method")
+//        .beginControlFlow(named("if ($field:N > $threshold:L)", m))
+//        .nextControlFlow(named("else if ($field:N == $threshold:L)", m))
+//        .endControlFlow()
+//        .build();
+//
+//    assertThat(methodSpec.toString()).isEqualTo(""
+//        + "void method() {\n"
+//        + "  if (valueField > 5) {\n"
+//        + "  } else if (valueField == 5) {\n"
+//        + "  }\n"
+//        + "}\n");
+//  }
+//
+//  @Test public void doWhileWithNamedCodeBlocks() {
+//    Map<String, Object> m = new HashMap<>();
+//    m.put("field", "valueField");
+//    m.put("threshold", "5");
+//
+//    MethodSpec methodSpec = MethodSpec.methodBuilder("method")
+//        .beginControlFlow("do")
+//        .addStatement(named("$field:N--", m))
+//        .endControlFlow(named("while ($field:N > $threshold:L)", m))
+//        .build();
+//
+//    assertThat(methodSpec.toString()).isEqualTo(""
+//        + "void method() {\n" +
+//        "  do {\n" +
+//        "    valueField--;\n" +
+//        "  } while (valueField > 5);\n" +
+//        "}\n");
+//  }
 
-  @Test public void nullTypeVariablesAddition() {
-    try {
-      MethodSpec.methodBuilder("doSomething").addTypeVariables(null);
-      fail();
-    } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("typeVariables == null");
-    }
-  }
+  @Test public void testnew() {
+    Map<String, Object> m = new HashMap<>();
+    m.put("field", "valueField");
+    m.put("threshold", "5");
 
-  @Test public void nullParametersAddition() {
-    try {
-      MethodSpec.methodBuilder("doSomething").addParameters(null);
-      fail();
-    } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("parameterSpecs == null");
-    }
-  }
-
-  @Test public void nullExceptionsAddition() {
-    try {
-      MethodSpec.methodBuilder("doSomething").addExceptions(null);
-      fail();
-    } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("exceptions == null");
-    }
-  }
-
-  @Target(ElementType.PARAMETER)
-  @interface Nullable {
-  }
-
-  abstract static class Everything {
-    @Deprecated protected abstract <T extends Runnable & Closeable> Runnable everything(
-        @Nullable String thing, List<? extends T> things) throws IOException, SecurityException;
-  }
-
-  abstract static class Generics {
-    <T, R, V extends Throwable> T run(R param) throws V {
-      return null;
-    }
-  }
-
-  abstract static class HasAnnotation {
-    @Override public abstract String toString();
-  }
-
-  interface Throws<R extends RuntimeException> {
-    void fail() throws R;
-  }
-
-  interface ExtendsOthers extends Callable<Integer>, Comparable<ExtendsOthers>,
-      Throws<IllegalStateException> {
-  }
-
-  interface ExtendsIterableWithDefaultMethods extends Iterable<Object> {
-  }
-
-  final class FinalClass {
-    void method() {
-    }
-  }
-
-  abstract static class InvalidOverrideMethods {
-    final void finalMethod() {
-    }
-
-    private void privateMethod() {
-    }
-
-    static void staticMethod() {
-    }
-  }
-
-  @Test public void overrideEverything() {
-    TypeElement classElement = getElement(Everything.class);
-    ExecutableElement methodElement = getOnlyElement(methodsIn(classElement.getEnclosedElements()));
-    MethodSpec method = MethodSpec.overriding(methodElement).build();
-    assertThat(method.toString()).isEqualTo(""
-        + "@java.lang.Override\n"
-        + "protected <T extends java.lang.Runnable & java.io.Closeable> java.lang.Runnable "
-        + "everything(\n"
-        + "    java.lang.String arg0, java.util.List<? extends T> arg1) throws java.io.IOException,\n"
-        + "    java.lang.SecurityException {\n"
-        + "}\n");
-  }
-
-  @Test public void overrideGenerics() {
-    TypeElement classElement = getElement(Generics.class);
-    ExecutableElement methodElement = getOnlyElement(methodsIn(classElement.getEnclosedElements()));
-    MethodSpec method = MethodSpec.overriding(methodElement)
-        .addStatement("return null")
-        .build();
-    assertThat(method.toString()).isEqualTo(""
-        + "@java.lang.Override\n"
-        + "<T, R, V extends java.lang.Throwable> T run(R param) throws V {\n"
-        + "  return null;\n"
-        + "}\n");
-  }
-
-  @Test public void overrideDoesNotCopyOverrideAnnotation() {
-    TypeElement classElement = getElement(HasAnnotation.class);
-    ExecutableElement exec = getOnlyElement(methodsIn(classElement.getEnclosedElements()));
-    MethodSpec method = MethodSpec.overriding(exec).build();
-    assertThat(method.toString()).isEqualTo(""
-        + "@java.lang.Override\n"
-        + "public java.lang.String toString() {\n"
-        + "}\n");
-  }
-
-  @Test public void overrideDoesNotCopyDefaultModifier() {
-    TypeElement classElement = getElement(ExtendsIterableWithDefaultMethods.class);
-    DeclaredType classType = (DeclaredType) classElement.asType();
-    List<ExecutableElement> methods = methodsIn(elements.getAllMembers(classElement));
-    ExecutableElement exec = findFirst(methods, "spliterator");
-    MethodSpec method = MethodSpec.overriding(exec, classType, types).build();
-    assertThat(method.toString()).isEqualTo(""
-        + "@java.lang.Override\n"
-        + "public java.util.Spliterator<java.lang.Object> spliterator() {\n"
-        + "}\n");
-  }
-
-  @Test public void overrideExtendsOthersWorksWithActualTypeParameters() {
-    TypeElement classElement = getElement(ExtendsOthers.class);
-    DeclaredType classType = (DeclaredType) classElement.asType();
-    List<ExecutableElement> methods = methodsIn(elements.getAllMembers(classElement));
-    ExecutableElement exec = findFirst(methods, "call");
-    MethodSpec method = MethodSpec.overriding(exec, classType, types).build();
-    assertThat(method.toString()).isEqualTo(""
-        + "@java.lang.Override\n"
-        + "public java.lang.Integer call() throws java.lang.Exception {\n"
-        + "}\n");
-    exec = findFirst(methods, "compareTo");
-    method = MethodSpec.overriding(exec, classType, types).build();
-    assertThat(method.toString()).isEqualTo(""
-        + "@java.lang.Override\n"
-        + "public int compareTo(" + ExtendsOthers.class.getCanonicalName() + " arg0) {\n"
-        + "}\n");
-    exec = findFirst(methods, "fail");
-    method = MethodSpec.overriding(exec, classType, types).build();
-    assertThat(method.toString()).isEqualTo(""
-        + "@java.lang.Override\n"
-        + "public void fail() throws java.lang.IllegalStateException {\n"
-        + "}\n");
-  }
-
-  @Test public void overrideFinalClassMethod() {
-    TypeElement classElement = getElement(FinalClass.class);
-    List<ExecutableElement> methods = methodsIn(elements.getAllMembers(classElement));
-    try {
-      MethodSpec.overriding(findFirst(methods, "method"));
-      fail();
-    } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo(
-          "Cannot override method on final class com.squareup.javapoet.MethodSpecTest.FinalClass");
-    }
-  }
-
-  @Test public void overrideInvalidModifiers() {
-    TypeElement classElement = getElement(InvalidOverrideMethods.class);
-    List<ExecutableElement> methods = methodsIn(elements.getAllMembers(classElement));
-    try {
-      MethodSpec.overriding(findFirst(methods, "finalMethod"));
-      fail();
-    } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("cannot override method with modifiers: [final]");
-    }
-    try {
-      MethodSpec.overriding(findFirst(methods, "privateMethod"));
-      fail();
-    } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("cannot override method with modifiers: [private]");
-    }
-    try {
-      MethodSpec.overriding(findFirst(methods, "staticMethod"));
-      fail();
-    } catch (IllegalArgumentException expected) {
-      assertThat(expected).hasMessageThat().isEqualTo("cannot override method with modifiers: [static]");
-    }
-  }
-
-  abstract static class AbstractClassWithPrivateAnnotation {
-
-    private @interface PrivateAnnotation{ }
-
-    abstract void foo(@PrivateAnnotation final String bar);
-  }
-
-  @Test public void overrideDoesNotCopyParameterAnnotations() {
-    TypeElement abstractTypeElement = getElement(AbstractClassWithPrivateAnnotation.class);
-    ExecutableElement fooElement = ElementFilter.methodsIn(abstractTypeElement.getEnclosedElements()).get(0);
-    ClassName implClassName = ClassName.get("com.squareup.javapoet", "Impl");
-    TypeSpec type = TypeSpec.classBuilder(implClassName)
-            .superclass(abstractTypeElement.asType())
-            .addMethod(MethodSpec.overriding(fooElement).build())
+    MethodSpec methodSpec = MethodSpec.methodBuilder("method")
+            .beginControlFlow("do")
+            .addStatement(named("$field:N--", m))
+            .endControlFlow(named("while ($field:N > $threshold:L)", m))
             .build();
-    JavaFileObject jfo = JavaFile.builder(implClassName.packageName, type).build().toJavaFileObject();
-    Compilation compilation = javac().compile(jfo);
-    assertThat(compilation).succeeded();
-  }
 
-  @Test public void equalsAndHashCode() {
-    MethodSpec a = MethodSpec.constructorBuilder().build();
-    MethodSpec b = MethodSpec.constructorBuilder().build();
-    assertThat(a.equals(b)).isTrue();
-    assertThat(a.hashCode()).isEqualTo(b.hashCode());
-    a = MethodSpec.methodBuilder("taco").build();
-    b = MethodSpec.methodBuilder("taco").build();
-    assertThat(a.equals(b)).isTrue();
-    assertThat(a.hashCode()).isEqualTo(b.hashCode());
-    TypeElement classElement = getElement(Everything.class);
-    ExecutableElement methodElement = getOnlyElement(methodsIn(classElement.getEnclosedElements()));
-    a = MethodSpec.overriding(methodElement).build();
-    b = MethodSpec.overriding(methodElement).build();
-    assertThat(a.equals(b)).isTrue();
-    assertThat(a.hashCode()).isEqualTo(b.hashCode());
-  }
-
-  @Test public void withoutParameterJavaDoc() {
-    MethodSpec methodSpec = MethodSpec.methodBuilder("getTaco")
-        .addModifiers(Modifier.PRIVATE)
-        .addParameter(TypeName.DOUBLE, "money")
-        .addJavadoc("Gets the best Taco\n")
-        .build();
-    assertThat(methodSpec.toString()).isEqualTo(""
-        + "/**\n"
-        + " * Gets the best Taco\n"
-        + " */\n"
-        + "private void getTaco(double money) {\n"
-        + "}\n");
-  }
-
-  @Test public void withParameterJavaDoc() {
-    MethodSpec methodSpec = MethodSpec.methodBuilder("getTaco")
-        .addParameter(ParameterSpec.builder(TypeName.DOUBLE, "money")
-            .addJavadoc("the amount required to buy the taco.\n")
-            .build())
-        .addParameter(ParameterSpec.builder(TypeName.INT, "count")
-            .addJavadoc("the number of Tacos to buy.\n")
-            .build())
-        .addJavadoc("Gets the best Taco money can buy.\n")
-        .build();
-    assertThat(methodSpec.toString()).isEqualTo(""
-        + "/**\n"
-        + " * Gets the best Taco money can buy.\n"
-        + " *\n"
-        + " * @param money the amount required to buy the taco.\n"
-        + " * @param count the number of Tacos to buy.\n"
-        + " */\n"
-        + "void getTaco(double money, int count) {\n"
-        + "}\n");
-  }
-
-  @Test public void withParameterJavaDocAndWithoutMethodJavadoc() {
-    MethodSpec methodSpec = MethodSpec.methodBuilder("getTaco")
-        .addParameter(ParameterSpec.builder(TypeName.DOUBLE, "money")
-            .addJavadoc("the amount required to buy the taco.\n")
-            .build())
-        .addParameter(ParameterSpec.builder(TypeName.INT, "count")
-            .addJavadoc("the number of Tacos to buy.\n")
-            .build())
-        .build();
-    assertThat(methodSpec.toString()).isEqualTo(""
-        + "/**\n"
-        + " * @param money the amount required to buy the taco.\n"
-        + " * @param count the number of Tacos to buy.\n"
-        + " */\n"
-        + "void getTaco(double money, int count) {\n"
-        + "}\n");
-  }
-
-  @Test public void duplicateExceptionsIgnored() {
-    ClassName ioException = ClassName.get(IOException.class);
-    ClassName timeoutException = ClassName.get(TimeoutException.class);
-    MethodSpec methodSpec = MethodSpec.methodBuilder("duplicateExceptions")
-      .addException(ioException)
-      .addException(timeoutException)
-      .addException(timeoutException)
-      .addException(ioException)
-      .build();
-    assertThat(methodSpec.exceptions).isEqualTo(Arrays.asList(ioException, timeoutException));
-    assertThat(methodSpec.toBuilder().addException(ioException).build().exceptions)
-      .isEqualTo(Arrays.asList(ioException, timeoutException));
-  }
-
-  @Test public void nullIsNotAValidMethodName() {
-    try {
-      MethodSpec.methodBuilder(null);
-      fail("NullPointerException expected");
-    } catch (NullPointerException e) {
-      assertThat(e.getMessage()).isEqualTo("name == null");
-    }
-  }
-
-  @Test public void addModifiersVarargsShouldNotBeNull() {
-    try {
-      MethodSpec.methodBuilder("taco")
-              .addModifiers((Modifier[]) null);
-      fail("NullPointerException expected");
-    } catch (NullPointerException e) {
-      assertThat(e.getMessage()).isEqualTo("modifiers == null");
-    }
-  }
-
-  @Test public void modifyMethodName() {
-    MethodSpec methodSpec = MethodSpec.methodBuilder("initialMethod")
-        .build()
-        .toBuilder()
-        .setName("revisedMethod")
-        .build();
-
-    assertThat(methodSpec.toString()).isEqualTo("" + "void revisedMethod() {\n" + "}\n");
-  }
-
-  @Test public void modifyAnnotations() {
-    MethodSpec.Builder builder = MethodSpec.methodBuilder("foo")
-            .addAnnotation(Override.class)
-            .addAnnotation(SuppressWarnings.class);
-
-    builder.annotations.remove(1);
-    assertThat(builder.build().annotations).hasSize(1);
-  }
-
-  @Test public void modifyModifiers() {
-    MethodSpec.Builder builder = MethodSpec.methodBuilder("foo")
-            .addModifiers(Modifier.PUBLIC, Modifier.STATIC);
-
-    builder.modifiers.remove(1);
-    assertThat(builder.build().modifiers).containsExactly(Modifier.PUBLIC);
-  }
-
-  @Test public void modifyParameters() {
-    MethodSpec.Builder builder = MethodSpec.methodBuilder("foo")
-            .addParameter(int.class, "source");
-
-    builder.parameters.remove(0);
-    assertThat(builder.build().parameters).isEmpty();
-  }
-
-  @Test public void modifyTypeVariables() {
-    TypeVariableName t = TypeVariableName.get("T");
-    MethodSpec.Builder builder = MethodSpec.methodBuilder("foo")
-            .addTypeVariable(t)
-            .addTypeVariable(TypeVariableName.get("V"));
-
-    builder.typeVariables.remove(1);
-    assertThat(builder.build().typeVariables).containsExactly(t);
-  }
-
-  @Test public void ensureTrailingNewline() {
-    MethodSpec methodSpec = MethodSpec.methodBuilder("method")
-        .addCode("codeWithNoNewline();")
-        .build();
-
-    assertThat(methodSpec.toString()).isEqualTo(""
-        + "void method() {\n"
-        + "  codeWithNoNewline();\n"
-        + "}\n");
-  }
-
-  /** Ensures that we don't add a duplicate newline if one is already present. */
-  @Test public void ensureTrailingNewlineWithExistingNewline() {
-    MethodSpec methodSpec = MethodSpec.methodBuilder("method")
-        .addCode("codeWithNoNewline();\n") // Have a newline already, so ensure we're not adding one
-        .build();
-
-    assertThat(methodSpec.toString()).isEqualTo(""
-        + "void method() {\n"
-        + "  codeWithNoNewline();\n"
-        + "}\n");
-  }
-
-  @Test public void controlFlowWithNamedCodeBlocks() {
-    Map<String, Object> m = new HashMap<>();
-    m.put("field", "valueField");
-    m.put("threshold", "5");
-
-    MethodSpec methodSpec = MethodSpec.methodBuilder("method")
-        .beginControlFlow(named("if ($field:N > $threshold:L)", m))
-        .nextControlFlow(named("else if ($field:N == $threshold:L)", m))
-        .endControlFlow()
-        .build();
-
-    assertThat(methodSpec.toString()).isEqualTo(""
-        + "void method() {\n"
-        + "  if (valueField > 5) {\n"
-        + "  } else if (valueField == 5) {\n"
-        + "  }\n"
-        + "}\n");
-  }
-
-  @Test public void doWhileWithNamedCodeBlocks() {
-    Map<String, Object> m = new HashMap<>();
-    m.put("field", "valueField");
-    m.put("threshold", "5");
-
-    MethodSpec methodSpec = MethodSpec.methodBuilder("method")
-        .beginControlFlow("do")
-        .addStatement(named("$field:N--", m))
-        .endControlFlow(named("while ($field:N > $threshold:L)", m))
-        .build();
-
-    assertThat(methodSpec.toString()).isEqualTo(""
-        + "void method() {\n" +
-        "  do {\n" +
-        "    valueField--;\n" +
-        "  } while (valueField > 5);\n" +
-        "}\n");
+    assertThat(MethodSpec.constructorBuilder().addComment("Test: $S", "foo\nbar").build().toString()).isEqualTo(""
+            + "void method() {\n" +
+            "  do {\n" +
+            "    valueField--;\n" +
+            "  } while (valueField > 5);\n" +
+            "}\n");
   }
 
   private static CodeBlock named(String format, Map<String, ?> args){

--- a/src/test/java/com/squareup/javapoet/MethodSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/MethodSpecTest.java
@@ -481,6 +481,40 @@ public final class MethodSpecTest {
 //        "}\n");
 //  }
 
+//  @Test public void multilineComments() {
+//    MethodSpec main = MethodSpec.methodBuilder("main")
+//            .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+//            .returns(void.class)
+//            .addParameter(String[].class, "args")
+//            .addComment("Hello\nmultiline\ncomments!")
+//            .addStatement("$T.out.println($S)", System.class, "Hello, JavaPoet!")
+//            .build();
+//
+//    assertThat(main.toString()).isEqualTo("" +
+//            "public static void main(java.lang.String[] args) {\n" +
+//            "  // Hello\n" +
+//            "  // multiline\n" +
+//            "  // comments!\n" +
+//            "  java.lang.System.out.println(\"Hello, JavaPoet!\");\n" +
+//            "}\n");
+//  }
+//
+//  @Test public void singleLineComments() {
+//    MethodSpec main = MethodSpec.methodBuilder("main")
+//            .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+//            .returns(void.class)
+//            .addParameter(String[].class, "args")
+//            .addComment("Hello single line comments!")
+//            .addStatement("$T.out.println($S)", System.class, "Hello, JavaPoet!")
+//            .build();
+//
+//    assertThat(main.toString()).isEqualTo("" +
+//            "public static void main(java.lang.String[] args) {\n" +
+//            "  // Hello single line comments!\n" +
+//            "  java.lang.System.out.println(\"Hello, JavaPoet!\");\n" +
+//            "}\n");
+//  }
+
   @Test public void testnew() {
     Map<String, Object> m = new HashMap<>();
     m.put("field", "valueField");
@@ -491,8 +525,8 @@ public final class MethodSpecTest {
             .addStatement(named("$field:N--", m))
             .endControlFlow(named("while ($field:N > $threshold:L)", m))
             .build();
-
-    assertThat(MethodSpec.constructorBuilder().addComment("Test: $S", "foo\nbar").build().toString()).isEqualTo(""
+//    assertThat(MethodSpec.constructorBuilder().addComment("Test: $L", "foo\nbar").build().toString()).isEqualTo(""
+    assertThat(MethodSpec.constructorBuilder().addComment("Test: $L", "foo\nbar").build().toString()).isEqualTo(""
             + "void method() {\n" +
             "  do {\n" +
             "    valueField--;\n" +

--- a/src/test/java/com/squareup/javapoet/MethodSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/MethodSpecTest.java
@@ -63,459 +63,406 @@ public final class MethodSpecTest {
     return elements.getTypeElement(clazz.getCanonicalName());
   }
 
-//  @Test public void nullAnnotationsAddition() {
-//    try {
-//      MethodSpec.methodBuilder("doSomething").addAnnotations(null);
-//      fail();
-//    } catch (IllegalArgumentException expected) {
-//      assertThat(expected).hasMessageThat().isEqualTo("annotationSpecs == null");
-//    }
-//  }
-//
-//  @Test public void nullTypeVariablesAddition() {
-//    try {
-//      MethodSpec.methodBuilder("doSomething").addTypeVariables(null);
-//      fail();
-//    } catch (IllegalArgumentException expected) {
-//      assertThat(expected).hasMessageThat().isEqualTo("typeVariables == null");
-//    }
-//  }
-//
-//  @Test public void nullParametersAddition() {
-//    try {
-//      MethodSpec.methodBuilder("doSomething").addParameters(null);
-//      fail();
-//    } catch (IllegalArgumentException expected) {
-//      assertThat(expected).hasMessageThat().isEqualTo("parameterSpecs == null");
-//    }
-//  }
-//
-//  @Test public void nullExceptionsAddition() {
-//    try {
-//      MethodSpec.methodBuilder("doSomething").addExceptions(null);
-//      fail();
-//    } catch (IllegalArgumentException expected) {
-//      assertThat(expected).hasMessageThat().isEqualTo("exceptions == null");
-//    }
-//  }
-//
-//  @Target(ElementType.PARAMETER)
-//  @interface Nullable {
-//  }
-//
-//  abstract static class Everything {
-//    @Deprecated protected abstract <T extends Runnable & Closeable> Runnable everything(
-//        @Nullable String thing, List<? extends T> things) throws IOException, SecurityException;
-//  }
-//
-//  abstract static class Generics {
-//    <T, R, V extends Throwable> T run(R param) throws V {
-//      return null;
-//    }
-//  }
-//
-//  abstract static class HasAnnotation {
-//    @Override public abstract String toString();
-//  }
-//
-//  interface Throws<R extends RuntimeException> {
-//    void fail() throws R;
-//  }
-//
-//  interface ExtendsOthers extends Callable<Integer>, Comparable<ExtendsOthers>,
-//      Throws<IllegalStateException> {
-//  }
-//
-//  interface ExtendsIterableWithDefaultMethods extends Iterable<Object> {
-//  }
-//
-//  final class FinalClass {
-//    void method() {
-//    }
-//  }
-//
-//  abstract static class InvalidOverrideMethods {
-//    final void finalMethod() {
-//    }
-//
-//    private void privateMethod() {
-//    }
-//
-//    static void staticMethod() {
-//    }
-//  }
-//
-//  @Test public void overrideEverything() {
-//    TypeElement classElement = getElement(Everything.class);
-//    ExecutableElement methodElement = getOnlyElement(methodsIn(classElement.getEnclosedElements()));
-//    MethodSpec method = MethodSpec.overriding(methodElement).build();
-//    assertThat(method.toString()).isEqualTo(""
-//        + "@java.lang.Override\n"
-//        + "protected <T extends java.lang.Runnable & java.io.Closeable> java.lang.Runnable "
-//        + "everything(\n"
-//        + "    java.lang.String arg0, java.util.List<? extends T> arg1) throws java.io.IOException,\n"
-//        + "    java.lang.SecurityException {\n"
-//        + "}\n");
-//  }
-//
-//  @Test public void overrideGenerics() {
-//    TypeElement classElement = getElement(Generics.class);
-//    ExecutableElement methodElement = getOnlyElement(methodsIn(classElement.getEnclosedElements()));
-//    MethodSpec method = MethodSpec.overriding(methodElement)
-//        .addStatement("return null")
-//        .build();
-//    assertThat(method.toString()).isEqualTo(""
-//        + "@java.lang.Override\n"
-//        + "<T, R, V extends java.lang.Throwable> T run(R param) throws V {\n"
-//        + "  return null;\n"
-//        + "}\n");
-//  }
-//
-//  @Test public void overrideDoesNotCopyOverrideAnnotation() {
-//    TypeElement classElement = getElement(HasAnnotation.class);
-//    ExecutableElement exec = getOnlyElement(methodsIn(classElement.getEnclosedElements()));
-//    MethodSpec method = MethodSpec.overriding(exec).build();
-//    assertThat(method.toString()).isEqualTo(""
-//        + "@java.lang.Override\n"
-//        + "public java.lang.String toString() {\n"
-//        + "}\n");
-//  }
-//
-//  @Test public void overrideDoesNotCopyDefaultModifier() {
-//    TypeElement classElement = getElement(ExtendsIterableWithDefaultMethods.class);
-//    DeclaredType classType = (DeclaredType) classElement.asType();
-//    List<ExecutableElement> methods = methodsIn(elements.getAllMembers(classElement));
-//    ExecutableElement exec = findFirst(methods, "spliterator");
-//    MethodSpec method = MethodSpec.overriding(exec, classType, types).build();
-//    assertThat(method.toString()).isEqualTo(""
-//        + "@java.lang.Override\n"
-//        + "public java.util.Spliterator<java.lang.Object> spliterator() {\n"
-//        + "}\n");
-//  }
-//
-//  @Test public void overrideExtendsOthersWorksWithActualTypeParameters() {
-//    TypeElement classElement = getElement(ExtendsOthers.class);
-//    DeclaredType classType = (DeclaredType) classElement.asType();
-//    List<ExecutableElement> methods = methodsIn(elements.getAllMembers(classElement));
-//    ExecutableElement exec = findFirst(methods, "call");
-//    MethodSpec method = MethodSpec.overriding(exec, classType, types).build();
-//    assertThat(method.toString()).isEqualTo(""
-//        + "@java.lang.Override\n"
-//        + "public java.lang.Integer call() throws java.lang.Exception {\n"
-//        + "}\n");
-//    exec = findFirst(methods, "compareTo");
-//    method = MethodSpec.overriding(exec, classType, types).build();
-//    assertThat(method.toString()).isEqualTo(""
-//        + "@java.lang.Override\n"
-//        + "public int compareTo(" + ExtendsOthers.class.getCanonicalName() + " arg0) {\n"
-//        + "}\n");
-//    exec = findFirst(methods, "fail");
-//    method = MethodSpec.overriding(exec, classType, types).build();
-//    assertThat(method.toString()).isEqualTo(""
-//        + "@java.lang.Override\n"
-//        + "public void fail() throws java.lang.IllegalStateException {\n"
-//        + "}\n");
-//  }
-//
-//  @Test public void overrideFinalClassMethod() {
-//    TypeElement classElement = getElement(FinalClass.class);
-//    List<ExecutableElement> methods = methodsIn(elements.getAllMembers(classElement));
-//    try {
-//      MethodSpec.overriding(findFirst(methods, "method"));
-//      fail();
-//    } catch (IllegalArgumentException expected) {
-//      assertThat(expected).hasMessageThat().isEqualTo(
-//          "Cannot override method on final class com.squareup.javapoet.MethodSpecTest.FinalClass");
-//    }
-//  }
-//
-//  @Test public void overrideInvalidModifiers() {
-//    TypeElement classElement = getElement(InvalidOverrideMethods.class);
-//    List<ExecutableElement> methods = methodsIn(elements.getAllMembers(classElement));
-//    try {
-//      MethodSpec.overriding(findFirst(methods, "finalMethod"));
-//      fail();
-//    } catch (IllegalArgumentException expected) {
-//      assertThat(expected).hasMessageThat().isEqualTo("cannot override method with modifiers: [final]");
-//    }
-//    try {
-//      MethodSpec.overriding(findFirst(methods, "privateMethod"));
-//      fail();
-//    } catch (IllegalArgumentException expected) {
-//      assertThat(expected).hasMessageThat().isEqualTo("cannot override method with modifiers: [private]");
-//    }
-//    try {
-//      MethodSpec.overriding(findFirst(methods, "staticMethod"));
-//      fail();
-//    } catch (IllegalArgumentException expected) {
-//      assertThat(expected).hasMessageThat().isEqualTo("cannot override method with modifiers: [static]");
-//    }
-//  }
-//
-//  abstract static class AbstractClassWithPrivateAnnotation {
-//
-//    private @interface PrivateAnnotation{ }
-//
-//    abstract void foo(@PrivateAnnotation final String bar);
-//  }
-//
-//  @Test public void overrideDoesNotCopyParameterAnnotations() {
-//    TypeElement abstractTypeElement = getElement(AbstractClassWithPrivateAnnotation.class);
-//    ExecutableElement fooElement = ElementFilter.methodsIn(abstractTypeElement.getEnclosedElements()).get(0);
-//    ClassName implClassName = ClassName.get("com.squareup.javapoet", "Impl");
-//    TypeSpec type = TypeSpec.classBuilder(implClassName)
-//            .superclass(abstractTypeElement.asType())
-//            .addMethod(MethodSpec.overriding(fooElement).build())
-//            .build();
-//    JavaFileObject jfo = JavaFile.builder(implClassName.packageName, type).build().toJavaFileObject();
-//    Compilation compilation = javac().compile(jfo);
-//    assertThat(compilation).succeeded();
-//  }
-//
-//  @Test public void equalsAndHashCode() {
-//    MethodSpec a = MethodSpec.constructorBuilder().build();
-//    MethodSpec b = MethodSpec.constructorBuilder().build();
-//    assertThat(a.equals(b)).isTrue();
-//    assertThat(a.hashCode()).isEqualTo(b.hashCode());
-//    a = MethodSpec.methodBuilder("taco").build();
-//    b = MethodSpec.methodBuilder("taco").build();
-//    assertThat(a.equals(b)).isTrue();
-//    assertThat(a.hashCode()).isEqualTo(b.hashCode());
-//    TypeElement classElement = getElement(Everything.class);
-//    ExecutableElement methodElement = getOnlyElement(methodsIn(classElement.getEnclosedElements()));
-//    a = MethodSpec.overriding(methodElement).build();
-//    b = MethodSpec.overriding(methodElement).build();
-//    assertThat(a.equals(b)).isTrue();
-//    assertThat(a.hashCode()).isEqualTo(b.hashCode());
-//  }
-//
-//  @Test public void withoutParameterJavaDoc() {
-//    MethodSpec methodSpec = MethodSpec.methodBuilder("getTaco")
-//        .addModifiers(Modifier.PRIVATE)
-//        .addParameter(TypeName.DOUBLE, "money")
-//        .addJavadoc("Gets the best Taco\n")
-//        .build();
-//    assertThat(methodSpec.toString()).isEqualTo(""
-//        + "/**\n"
-//        + " * Gets the best Taco\n"
-//        + " */\n"
-//        + "private void getTaco(double money) {\n"
-//        + "}\n");
-//  }
-//
-//  @Test public void withParameterJavaDoc() {
-//    MethodSpec methodSpec = MethodSpec.methodBuilder("getTaco")
-//        .addParameter(ParameterSpec.builder(TypeName.DOUBLE, "money")
-//            .addJavadoc("the amount required to buy the taco.\n")
-//            .build())
-//        .addParameter(ParameterSpec.builder(TypeName.INT, "count")
-//            .addJavadoc("the number of Tacos to buy.\n")
-//            .build())
-//        .addJavadoc("Gets the best Taco money can buy.\n")
-//        .build();
-//    assertThat(methodSpec.toString()).isEqualTo(""
-//        + "/**\n"
-//        + " * Gets the best Taco money can buy.\n"
-//        + " *\n"
-//        + " * @param money the amount required to buy the taco.\n"
-//        + " * @param count the number of Tacos to buy.\n"
-//        + " */\n"
-//        + "void getTaco(double money, int count) {\n"
-//        + "}\n");
-//  }
-//
-//  @Test public void withParameterJavaDocAndWithoutMethodJavadoc() {
-//    MethodSpec methodSpec = MethodSpec.methodBuilder("getTaco")
-//        .addParameter(ParameterSpec.builder(TypeName.DOUBLE, "money")
-//            .addJavadoc("the amount required to buy the taco.\n")
-//            .build())
-//        .addParameter(ParameterSpec.builder(TypeName.INT, "count")
-//            .addJavadoc("the number of Tacos to buy.\n")
-//            .build())
-//        .build();
-//    assertThat(methodSpec.toString()).isEqualTo(""
-//        + "/**\n"
-//        + " * @param money the amount required to buy the taco.\n"
-//        + " * @param count the number of Tacos to buy.\n"
-//        + " */\n"
-//        + "void getTaco(double money, int count) {\n"
-//        + "}\n");
-//  }
-//
-//  @Test public void duplicateExceptionsIgnored() {
-//    ClassName ioException = ClassName.get(IOException.class);
-//    ClassName timeoutException = ClassName.get(TimeoutException.class);
-//    MethodSpec methodSpec = MethodSpec.methodBuilder("duplicateExceptions")
-//      .addException(ioException)
-//      .addException(timeoutException)
-//      .addException(timeoutException)
-//      .addException(ioException)
-//      .build();
-//    assertThat(methodSpec.exceptions).isEqualTo(Arrays.asList(ioException, timeoutException));
-//    assertThat(methodSpec.toBuilder().addException(ioException).build().exceptions)
-//      .isEqualTo(Arrays.asList(ioException, timeoutException));
-//  }
-//
-//  @Test public void nullIsNotAValidMethodName() {
-//    try {
-//      MethodSpec.methodBuilder(null);
-//      fail("NullPointerException expected");
-//    } catch (NullPointerException e) {
-//      assertThat(e.getMessage()).isEqualTo("name == null");
-//    }
-//  }
-//
-//  @Test public void addModifiersVarargsShouldNotBeNull() {
-//    try {
-//      MethodSpec.methodBuilder("taco")
-//              .addModifiers((Modifier[]) null);
-//      fail("NullPointerException expected");
-//    } catch (NullPointerException e) {
-//      assertThat(e.getMessage()).isEqualTo("modifiers == null");
-//    }
-//  }
-//
-//  @Test public void modifyMethodName() {
-//    MethodSpec methodSpec = MethodSpec.methodBuilder("initialMethod")
-//        .build()
-//        .toBuilder()
-//        .setName("revisedMethod")
-//        .build();
-//
-//    assertThat(methodSpec.toString()).isEqualTo("" + "void revisedMethod() {\n" + "}\n");
-//  }
-//
-//  @Test public void modifyAnnotations() {
-//    MethodSpec.Builder builder = MethodSpec.methodBuilder("foo")
-//            .addAnnotation(Override.class)
-//            .addAnnotation(SuppressWarnings.class);
-//
-//    builder.annotations.remove(1);
-//    assertThat(builder.build().annotations).hasSize(1);
-//  }
-//
-//  @Test public void modifyModifiers() {
-//    MethodSpec.Builder builder = MethodSpec.methodBuilder("foo")
-//            .addModifiers(Modifier.PUBLIC, Modifier.STATIC);
-//
-//    builder.modifiers.remove(1);
-//    assertThat(builder.build().modifiers).containsExactly(Modifier.PUBLIC);
-//  }
-//
-//  @Test public void modifyParameters() {
-//    MethodSpec.Builder builder = MethodSpec.methodBuilder("foo")
-//            .addParameter(int.class, "source");
-//
-//    builder.parameters.remove(0);
-//    assertThat(builder.build().parameters).isEmpty();
-//  }
-//
-//  @Test public void modifyTypeVariables() {
-//    TypeVariableName t = TypeVariableName.get("T");
-//    MethodSpec.Builder builder = MethodSpec.methodBuilder("foo")
-//            .addTypeVariable(t)
-//            .addTypeVariable(TypeVariableName.get("V"));
-//
-//    builder.typeVariables.remove(1);
-//    assertThat(builder.build().typeVariables).containsExactly(t);
-//  }
-//
-//  @Test public void ensureTrailingNewline() {
-//    MethodSpec methodSpec = MethodSpec.methodBuilder("method")
-//        .addCode("codeWithNoNewline();")
-//        .build();
-//
-//    assertThat(methodSpec.toString()).isEqualTo(""
-//        + "void method() {\n"
-//        + "  codeWithNoNewline();\n"
-//        + "}\n");
-//  }
-//
-//  /** Ensures that we don't add a duplicate newline if one is already present. */
-//  @Test public void ensureTrailingNewlineWithExistingNewline() {
-//    MethodSpec methodSpec = MethodSpec.methodBuilder("method")
-//        .addCode("codeWithNoNewline();\n") // Have a newline already, so ensure we're not adding one
-//        .build();
-//
-//    assertThat(methodSpec.toString()).isEqualTo(""
-//        + "void method() {\n"
-//        + "  codeWithNoNewline();\n"
-//        + "}\n");
-//  }
-//
-//  @Test public void controlFlowWithNamedCodeBlocks() {
-//    Map<String, Object> m = new HashMap<>();
-//    m.put("field", "valueField");
-//    m.put("threshold", "5");
-//
-//    MethodSpec methodSpec = MethodSpec.methodBuilder("method")
-//        .beginControlFlow(named("if ($field:N > $threshold:L)", m))
-//        .nextControlFlow(named("else if ($field:N == $threshold:L)", m))
-//        .endControlFlow()
-//        .build();
-//
-//    assertThat(methodSpec.toString()).isEqualTo(""
-//        + "void method() {\n"
-//        + "  if (valueField > 5) {\n"
-//        + "  } else if (valueField == 5) {\n"
-//        + "  }\n"
-//        + "}\n");
-//  }
-//
-//  @Test public void doWhileWithNamedCodeBlocks() {
-//    Map<String, Object> m = new HashMap<>();
-//    m.put("field", "valueField");
-//    m.put("threshold", "5");
-//
-//    MethodSpec methodSpec = MethodSpec.methodBuilder("method")
-//        .beginControlFlow("do")
-//        .addStatement(named("$field:N--", m))
-//        .endControlFlow(named("while ($field:N > $threshold:L)", m))
-//        .build();
-//
-//    assertThat(methodSpec.toString()).isEqualTo(""
-//        + "void method() {\n" +
-//        "  do {\n" +
-//        "    valueField--;\n" +
-//        "  } while (valueField > 5);\n" +
-//        "}\n");
-//  }
+  @Test public void nullAnnotationsAddition() {
+    try {
+      MethodSpec.methodBuilder("doSomething").addAnnotations(null);
+      fail();
+    } catch (IllegalArgumentException expected) {
+      assertThat(expected).hasMessageThat().isEqualTo("annotationSpecs == null");
+    }
+  }
 
-//  @Test public void multilineComments() {
-//    MethodSpec main = MethodSpec.methodBuilder("main")
-//            .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-//            .returns(void.class)
-//            .addParameter(String[].class, "args")
-//            .addComment("Hello\nmultiline\ncomments!")
-//            .addStatement("$T.out.println($S)", System.class, "Hello, JavaPoet!")
-//            .build();
-//
-//    assertThat(main.toString()).isEqualTo("" +
-//            "public static void main(java.lang.String[] args) {\n" +
-//            "  // Hello\n" +
-//            "  // multiline\n" +
-//            "  // comments!\n" +
-//            "  java.lang.System.out.println(\"Hello, JavaPoet!\");\n" +
-//            "}\n");
-//  }
-//
-//  @Test public void singleLineComments() {
-//    MethodSpec main = MethodSpec.methodBuilder("main")
-//            .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-//            .returns(void.class)
-//            .addParameter(String[].class, "args")
-//            .addComment("Hello single line comments!")
-//            .addStatement("$T.out.println($S)", System.class, "Hello, JavaPoet!")
-//            .build();
-//
-//    assertThat(main.toString()).isEqualTo("" +
-//            "public static void main(java.lang.String[] args) {\n" +
-//            "  // Hello single line comments!\n" +
-//            "  java.lang.System.out.println(\"Hello, JavaPoet!\");\n" +
-//            "}\n");
-//  }
+  @Test public void nullTypeVariablesAddition() {
+    try {
+      MethodSpec.methodBuilder("doSomething").addTypeVariables(null);
+      fail();
+    } catch (IllegalArgumentException expected) {
+      assertThat(expected).hasMessageThat().isEqualTo("typeVariables == null");
+    }
+  }
 
-  @Test public void testnew() {
+  @Test public void nullParametersAddition() {
+    try {
+      MethodSpec.methodBuilder("doSomething").addParameters(null);
+      fail();
+    } catch (IllegalArgumentException expected) {
+      assertThat(expected).hasMessageThat().isEqualTo("parameterSpecs == null");
+    }
+  }
+
+  @Test public void nullExceptionsAddition() {
+    try {
+      MethodSpec.methodBuilder("doSomething").addExceptions(null);
+      fail();
+    } catch (IllegalArgumentException expected) {
+      assertThat(expected).hasMessageThat().isEqualTo("exceptions == null");
+    }
+  }
+
+  @Target(ElementType.PARAMETER)
+  @interface Nullable {
+  }
+
+  abstract static class Everything {
+    @Deprecated protected abstract <T extends Runnable & Closeable> Runnable everything(
+            @Nullable String thing, List<? extends T> things) throws IOException, SecurityException;
+  }
+
+  abstract static class Generics {
+    <T, R, V extends Throwable> T run(R param) throws V {
+      return null;
+    }
+  }
+
+  abstract static class HasAnnotation {
+    @Override public abstract String toString();
+  }
+
+  interface Throws<R extends RuntimeException> {
+    void fail() throws R;
+  }
+
+  interface ExtendsOthers extends Callable<Integer>, Comparable<ExtendsOthers>,
+          Throws<IllegalStateException> {
+  }
+
+  interface ExtendsIterableWithDefaultMethods extends Iterable<Object> {
+  }
+
+  final class FinalClass {
+    void method() {
+    }
+  }
+
+  abstract static class InvalidOverrideMethods {
+    final void finalMethod() {
+    }
+
+    private void privateMethod() {
+    }
+
+    static void staticMethod() {
+    }
+  }
+
+  @Test public void overrideEverything() {
+    TypeElement classElement = getElement(Everything.class);
+    ExecutableElement methodElement = getOnlyElement(methodsIn(classElement.getEnclosedElements()));
+    MethodSpec method = MethodSpec.overriding(methodElement).build();
+    assertThat(method.toString()).isEqualTo(""
+            + "@java.lang.Override\n"
+            + "protected <T extends java.lang.Runnable & java.io.Closeable> java.lang.Runnable "
+            + "everything(\n"
+            + "    java.lang.String arg0, java.util.List<? extends T> arg1) throws java.io.IOException,\n"
+            + "    java.lang.SecurityException {\n"
+            + "}\n");
+  }
+
+  @Test public void overrideGenerics() {
+    TypeElement classElement = getElement(Generics.class);
+    ExecutableElement methodElement = getOnlyElement(methodsIn(classElement.getEnclosedElements()));
+    MethodSpec method = MethodSpec.overriding(methodElement)
+            .addStatement("return null")
+            .build();
+    assertThat(method.toString()).isEqualTo(""
+            + "@java.lang.Override\n"
+            + "<T, R, V extends java.lang.Throwable> T run(R param) throws V {\n"
+            + "  return null;\n"
+            + "}\n");
+  }
+
+  @Test public void overrideDoesNotCopyOverrideAnnotation() {
+    TypeElement classElement = getElement(HasAnnotation.class);
+    ExecutableElement exec = getOnlyElement(methodsIn(classElement.getEnclosedElements()));
+    MethodSpec method = MethodSpec.overriding(exec).build();
+    assertThat(method.toString()).isEqualTo(""
+            + "@java.lang.Override\n"
+            + "public java.lang.String toString() {\n"
+            + "}\n");
+  }
+
+  @Test public void overrideDoesNotCopyDefaultModifier() {
+    TypeElement classElement = getElement(ExtendsIterableWithDefaultMethods.class);
+    DeclaredType classType = (DeclaredType) classElement.asType();
+    List<ExecutableElement> methods = methodsIn(elements.getAllMembers(classElement));
+    ExecutableElement exec = findFirst(methods, "spliterator");
+    MethodSpec method = MethodSpec.overriding(exec, classType, types).build();
+    assertThat(method.toString()).isEqualTo(""
+            + "@java.lang.Override\n"
+            + "public java.util.Spliterator<java.lang.Object> spliterator() {\n"
+            + "}\n");
+  }
+
+  @Test public void overrideExtendsOthersWorksWithActualTypeParameters() {
+    TypeElement classElement = getElement(ExtendsOthers.class);
+    DeclaredType classType = (DeclaredType) classElement.asType();
+    List<ExecutableElement> methods = methodsIn(elements.getAllMembers(classElement));
+    ExecutableElement exec = findFirst(methods, "call");
+    MethodSpec method = MethodSpec.overriding(exec, classType, types).build();
+    assertThat(method.toString()).isEqualTo(""
+            + "@java.lang.Override\n"
+            + "public java.lang.Integer call() throws java.lang.Exception {\n"
+            + "}\n");
+    exec = findFirst(methods, "compareTo");
+    method = MethodSpec.overriding(exec, classType, types).build();
+    assertThat(method.toString()).isEqualTo(""
+            + "@java.lang.Override\n"
+            + "public int compareTo(" + ExtendsOthers.class.getCanonicalName() + " arg0) {\n"
+            + "}\n");
+    exec = findFirst(methods, "fail");
+    method = MethodSpec.overriding(exec, classType, types).build();
+    assertThat(method.toString()).isEqualTo(""
+            + "@java.lang.Override\n"
+            + "public void fail() throws java.lang.IllegalStateException {\n"
+            + "}\n");
+  }
+
+  @Test public void overrideFinalClassMethod() {
+    TypeElement classElement = getElement(FinalClass.class);
+    List<ExecutableElement> methods = methodsIn(elements.getAllMembers(classElement));
+    try {
+      MethodSpec.overriding(findFirst(methods, "method"));
+      fail();
+    } catch (IllegalArgumentException expected) {
+      assertThat(expected).hasMessageThat().isEqualTo(
+              "Cannot override method on final class com.squareup.javapoet.MethodSpecTest.FinalClass");
+    }
+  }
+
+  @Test public void overrideInvalidModifiers() {
+    TypeElement classElement = getElement(InvalidOverrideMethods.class);
+    List<ExecutableElement> methods = methodsIn(elements.getAllMembers(classElement));
+    try {
+      MethodSpec.overriding(findFirst(methods, "finalMethod"));
+      fail();
+    } catch (IllegalArgumentException expected) {
+      assertThat(expected).hasMessageThat().isEqualTo("cannot override method with modifiers: [final]");
+    }
+    try {
+      MethodSpec.overriding(findFirst(methods, "privateMethod"));
+      fail();
+    } catch (IllegalArgumentException expected) {
+      assertThat(expected).hasMessageThat().isEqualTo("cannot override method with modifiers: [private]");
+    }
+    try {
+      MethodSpec.overriding(findFirst(methods, "staticMethod"));
+      fail();
+    } catch (IllegalArgumentException expected) {
+      assertThat(expected).hasMessageThat().isEqualTo("cannot override method with modifiers: [static]");
+    }
+  }
+
+  abstract static class AbstractClassWithPrivateAnnotation {
+
+    private @interface PrivateAnnotation{ }
+
+    abstract void foo(@PrivateAnnotation final String bar);
+  }
+
+  @Test public void overrideDoesNotCopyParameterAnnotations() {
+    TypeElement abstractTypeElement = getElement(AbstractClassWithPrivateAnnotation.class);
+    ExecutableElement fooElement = ElementFilter.methodsIn(abstractTypeElement.getEnclosedElements()).get(0);
+    ClassName implClassName = ClassName.get("com.squareup.javapoet", "Impl");
+    TypeSpec type = TypeSpec.classBuilder(implClassName)
+            .superclass(abstractTypeElement.asType())
+            .addMethod(MethodSpec.overriding(fooElement).build())
+            .build();
+    JavaFileObject jfo = JavaFile.builder(implClassName.packageName, type).build().toJavaFileObject();
+    Compilation compilation = javac().compile(jfo);
+    assertThat(compilation).succeeded();
+  }
+
+  @Test public void equalsAndHashCode() {
+    MethodSpec a = MethodSpec.constructorBuilder().build();
+    MethodSpec b = MethodSpec.constructorBuilder().build();
+    assertThat(a.equals(b)).isTrue();
+    assertThat(a.hashCode()).isEqualTo(b.hashCode());
+    a = MethodSpec.methodBuilder("taco").build();
+    b = MethodSpec.methodBuilder("taco").build();
+    assertThat(a.equals(b)).isTrue();
+    assertThat(a.hashCode()).isEqualTo(b.hashCode());
+    TypeElement classElement = getElement(Everything.class);
+    ExecutableElement methodElement = getOnlyElement(methodsIn(classElement.getEnclosedElements()));
+    a = MethodSpec.overriding(methodElement).build();
+    b = MethodSpec.overriding(methodElement).build();
+    assertThat(a.equals(b)).isTrue();
+    assertThat(a.hashCode()).isEqualTo(b.hashCode());
+  }
+
+  @Test public void withoutParameterJavaDoc() {
+    MethodSpec methodSpec = MethodSpec.methodBuilder("getTaco")
+            .addModifiers(Modifier.PRIVATE)
+            .addParameter(TypeName.DOUBLE, "money")
+            .addJavadoc("Gets the best Taco\n")
+            .build();
+    assertThat(methodSpec.toString()).isEqualTo(""
+            + "/**\n"
+            + " * Gets the best Taco\n"
+            + " */\n"
+            + "private void getTaco(double money) {\n"
+            + "}\n");
+  }
+
+  @Test public void withParameterJavaDoc() {
+    MethodSpec methodSpec = MethodSpec.methodBuilder("getTaco")
+            .addParameter(ParameterSpec.builder(TypeName.DOUBLE, "money")
+                    .addJavadoc("the amount required to buy the taco.\n")
+                    .build())
+            .addParameter(ParameterSpec.builder(TypeName.INT, "count")
+                    .addJavadoc("the number of Tacos to buy.\n")
+                    .build())
+            .addJavadoc("Gets the best Taco money can buy.\n")
+            .build();
+    assertThat(methodSpec.toString()).isEqualTo(""
+            + "/**\n"
+            + " * Gets the best Taco money can buy.\n"
+            + " *\n"
+            + " * @param money the amount required to buy the taco.\n"
+            + " * @param count the number of Tacos to buy.\n"
+            + " */\n"
+            + "void getTaco(double money, int count) {\n"
+            + "}\n");
+  }
+
+  @Test public void withParameterJavaDocAndWithoutMethodJavadoc() {
+    MethodSpec methodSpec = MethodSpec.methodBuilder("getTaco")
+            .addParameter(ParameterSpec.builder(TypeName.DOUBLE, "money")
+                    .addJavadoc("the amount required to buy the taco.\n")
+                    .build())
+            .addParameter(ParameterSpec.builder(TypeName.INT, "count")
+                    .addJavadoc("the number of Tacos to buy.\n")
+                    .build())
+            .build();
+    assertThat(methodSpec.toString()).isEqualTo(""
+            + "/**\n"
+            + " * @param money the amount required to buy the taco.\n"
+            + " * @param count the number of Tacos to buy.\n"
+            + " */\n"
+            + "void getTaco(double money, int count) {\n"
+            + "}\n");
+  }
+
+  @Test public void duplicateExceptionsIgnored() {
+    ClassName ioException = ClassName.get(IOException.class);
+    ClassName timeoutException = ClassName.get(TimeoutException.class);
+    MethodSpec methodSpec = MethodSpec.methodBuilder("duplicateExceptions")
+            .addException(ioException)
+            .addException(timeoutException)
+            .addException(timeoutException)
+            .addException(ioException)
+            .build();
+    assertThat(methodSpec.exceptions).isEqualTo(Arrays.asList(ioException, timeoutException));
+    assertThat(methodSpec.toBuilder().addException(ioException).build().exceptions)
+            .isEqualTo(Arrays.asList(ioException, timeoutException));
+  }
+
+  @Test public void nullIsNotAValidMethodName() {
+    try {
+      MethodSpec.methodBuilder(null);
+      fail("NullPointerException expected");
+    } catch (NullPointerException e) {
+      assertThat(e.getMessage()).isEqualTo("name == null");
+    }
+  }
+
+  @Test public void addModifiersVarargsShouldNotBeNull() {
+    try {
+      MethodSpec.methodBuilder("taco")
+              .addModifiers((Modifier[]) null);
+      fail("NullPointerException expected");
+    } catch (NullPointerException e) {
+      assertThat(e.getMessage()).isEqualTo("modifiers == null");
+    }
+  }
+
+  @Test public void modifyMethodName() {
+    MethodSpec methodSpec = MethodSpec.methodBuilder("initialMethod")
+            .build()
+            .toBuilder()
+            .setName("revisedMethod")
+            .build();
+
+    assertThat(methodSpec.toString()).isEqualTo("" + "void revisedMethod() {\n" + "}\n");
+  }
+
+  @Test public void modifyAnnotations() {
+    MethodSpec.Builder builder = MethodSpec.methodBuilder("foo")
+            .addAnnotation(Override.class)
+            .addAnnotation(SuppressWarnings.class);
+
+    builder.annotations.remove(1);
+    assertThat(builder.build().annotations).hasSize(1);
+  }
+
+  @Test public void modifyModifiers() {
+    MethodSpec.Builder builder = MethodSpec.methodBuilder("foo")
+            .addModifiers(Modifier.PUBLIC, Modifier.STATIC);
+
+    builder.modifiers.remove(1);
+    assertThat(builder.build().modifiers).containsExactly(Modifier.PUBLIC);
+  }
+
+  @Test public void modifyParameters() {
+    MethodSpec.Builder builder = MethodSpec.methodBuilder("foo")
+            .addParameter(int.class, "source");
+
+    builder.parameters.remove(0);
+    assertThat(builder.build().parameters).isEmpty();
+  }
+
+  @Test public void modifyTypeVariables() {
+    TypeVariableName t = TypeVariableName.get("T");
+    MethodSpec.Builder builder = MethodSpec.methodBuilder("foo")
+            .addTypeVariable(t)
+            .addTypeVariable(TypeVariableName.get("V"));
+
+    builder.typeVariables.remove(1);
+    assertThat(builder.build().typeVariables).containsExactly(t);
+  }
+
+  @Test public void ensureTrailingNewline() {
+    MethodSpec methodSpec = MethodSpec.methodBuilder("method")
+            .addCode("codeWithNoNewline();")
+            .build();
+
+    assertThat(methodSpec.toString()).isEqualTo(""
+            + "void method() {\n"
+            + "  codeWithNoNewline();\n"
+            + "}\n");
+  }
+
+  /** Ensures that we don't add a duplicate newline if one is already present. */
+  @Test public void ensureTrailingNewlineWithExistingNewline() {
+    MethodSpec methodSpec = MethodSpec.methodBuilder("method")
+            .addCode("codeWithNoNewline();\n") // Have a newline already, so ensure we're not adding one
+            .build();
+
+    assertThat(methodSpec.toString()).isEqualTo(""
+            + "void method() {\n"
+            + "  codeWithNoNewline();\n"
+            + "}\n");
+  }
+
+  @Test public void controlFlowWithNamedCodeBlocks() {
+    Map<String, Object> m = new HashMap<>();
+    m.put("field", "valueField");
+    m.put("threshold", "5");
+
+    MethodSpec methodSpec = MethodSpec.methodBuilder("method")
+            .beginControlFlow(named("if ($field:N > $threshold:L)", m))
+            .nextControlFlow(named("else if ($field:N == $threshold:L)", m))
+            .endControlFlow()
+            .build();
+
+    assertThat(methodSpec.toString()).isEqualTo(""
+            + "void method() {\n"
+            + "  if (valueField > 5) {\n"
+            + "  } else if (valueField == 5) {\n"
+            + "  }\n"
+            + "}\n");
+  }
+
+  @Test public void doWhileWithNamedCodeBlocks() {
     Map<String, Object> m = new HashMap<>();
     m.put("field", "valueField");
     m.put("threshold", "5");
@@ -525,14 +472,40 @@ public final class MethodSpecTest {
             .addStatement(named("$field:N--", m))
             .endControlFlow(named("while ($field:N > $threshold:L)", m))
             .build();
-//    assertThat(MethodSpec.constructorBuilder().addComment("Test: $L", "foo\nbar").build().toString()).isEqualTo(""
-    assertThat(MethodSpec.constructorBuilder().addComment("Test: $L", "foo\nbar").build().toString()).isEqualTo(""
+
+    assertThat(methodSpec.toString()).isEqualTo(""
             + "void method() {\n" +
             "  do {\n" +
             "    valueField--;\n" +
             "  } while (valueField > 5);\n" +
             "}\n");
   }
+
+  @Test public void newLineAsStringCommentWithout$S() {
+    MethodSpec methodSpec = MethodSpec.methodBuilder("method")
+            .returns(void.class)
+            .addComment("The result of\\nissue \\\\n#604!")
+            .build();
+
+    assertThat(methodSpec.toString()).isEqualTo(""
+            + "void method() {\n"
+            + "  // The result of\\nissue \\\\n#604!\n"
+            + "}\n");
+  }
+
+  @Test public void newLineAsStringCommentWith$S() {
+    MethodSpec methodSpec = MethodSpec.methodBuilder("method")
+            .returns(void.class)
+            .addComment("The result is: $S", "fixed \n issue \n #604!")
+            .build();
+
+    assertThat(methodSpec.toString()).isEqualTo(""
+            + "void method() {\n"
+            + "  // The result is: \"fixed \\n issue \\n #604!\"\n"
+            + "}\n");
+  }
+
+
 
   private static CodeBlock named(String format, Map<String, ?> args){
     return CodeBlock.builder().addNamed(format, args).build();


### PR DESCRIPTION
In this issue, for example,  We use the code bellow
```
MethodSpec.methodBuilder().addComment("Test: $S", "foo\nbar");
```

the output in the past is that:

```
// Test: "foo\n"
    "bar"
```
now after my pull request, the outputs are like this:
```
// Test: "foo\nbar"
```
As you can see, I solve this issue.