### PR TITLE
fix issue #541 AnnotationSpec.addMember support AnnotationSpec as member value

### DIFF
--- a/src/main/java/com/squareup/javapoet/AnnotationSpec.java
+++ b/src/main/java/com/squareup/javapoet/AnnotationSpec.java
@@ -19,14 +19,7 @@ import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Array;
 import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.AnnotationValue;
@@ -246,6 +239,52 @@ public final class AnnotationSpec {
       return new AnnotationSpec(this);
     }
   }
+
+  /**
+   *
+   * @param builder The AnnotationSpec.Builder that you want to add in;
+   * @param name The name of the AnnotationSpec;
+   * @param format The format of the @name;
+   * @param specs The AnnotationSpec that be added in;
+   * @return the AnnotationSpec.Builder that be added with @specs
+   */
+  public static AnnotationSpec.Builder addMembers(AnnotationSpec.Builder builder, String name, String format, AnnotationSpec... specs) {
+    final List<CodeBlock> codeBlocks = new ArrayList<>();
+    for (AnnotationSpec spec : specs) {
+      codeBlocks.add(CodeBlock.of(format, spec));
+    }
+    return addMembers(builder, name, codeBlocks);
+  }
+
+  /**
+   *
+   * @param builder The AnnotationSpec.Builder that you want to add in;
+   * @param name The name of the AnnotationSpec;
+   * @param format The format of the @name;
+   * @param specs The AnnotationSpec that be added in, speciticly, a Collection with AnnotationSpecs;
+   * @return the AnnotationSpec.Builder that be added with @specs
+   */
+  public static AnnotationSpec.Builder addMembers(AnnotationSpec.Builder builder, String name, String format, Collection<AnnotationSpec> specs) {
+    final List<CodeBlock> codeBlocks = new ArrayList<>();
+    for (AnnotationSpec spec : specs) {
+      codeBlocks.add(CodeBlock.of(format, spec));
+    }
+    return addMembers(builder, name, codeBlocks);
+  }
+
+  /**
+   *
+   * @param builder The AnnotationSpec.Builder that you want to add in;
+   * @param name The name of the AnnotationSpec;
+   * @param codeBlocks The CodeBlocks that be added in, speciticly, a Collection with AnnotationSpecs;
+   * @return the AnnotationSpec.Builder that be added with @codeBlocks
+   */
+  public static AnnotationSpec.Builder addMembers(AnnotationSpec.Builder builder, String name, Collection<CodeBlock> codeBlocks) {
+    final List<CodeBlock> values = builder.members.computeIfAbsent(name, k -> new ArrayList<>());
+    values.addAll(codeBlocks);
+    return builder;
+  }
+
 
   /**
    * Annotation value visitor adding members to the given builder instance.

--- a/src/test/java/com/squareup/javapoet/AnnotationSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/AnnotationSpecTest.java
@@ -383,6 +383,86 @@ public final class AnnotationSpecTest {
     assertThat(builder.build().toString()).isEqualTo("@java.lang.SuppressWarnings(\"Bar\")");
   }
 
+
+  @Test public void addMembersWithAnnotationSpec(){
+    String packageName = "package com.squareup.computerScience;";
+    ClassName java = ClassName.get(packageName, "Java");
+    ClassName language = ClassName.get(packageName, "Language");
+    ClassName computerScience = ClassName.get(packageName, "ComputerScience");
+
+    AnnotationSpec javaAnnotation = AnnotationSpec.builder(language)
+            .addMember("name", "$S", "function")
+            .addMember("language", "$T.class", java)
+            .build();
+
+    AnnotationSpec.Builder builder = AnnotationSpec.builder(computerScience);
+    AnnotationSpec computerScienceAnnotation = AnnotationSpec.addMembers(builder, "ComputerScience", "$L"
+            , javaAnnotation).build();
+    assertThat(computerScienceAnnotation.toString()).isEqualTo(
+            "@package com.squareup.computerScience;" +
+                    ".ComputerScience" +
+                    "(" +
+                    "ComputerScience = @package com.squareup.computerScience;" +
+                    ".Language" +
+                    "(" +
+                    "name = \"function\", language = package com.squareup.computerScience;" +
+                    ".Java.class" +
+                    ")" +
+                    ")");
+  }
+
+
+  @Test public void addMembersWithMoreAnnotationSpec(){
+    String packageName = "package com.squareup.computerScience;";
+    ClassName pytorch = ClassName.get(packageName, "Pytorch");
+    ClassName tensorflow = ClassName.get(packageName, "Tensorflow");
+    ClassName mxnet = ClassName.get(packageName, "MXNet");
+    ClassName dlFramework = ClassName.get(packageName, "DeepLearningFramework");
+    ClassName python = ClassName.get(packageName, "Python");
+
+    AnnotationSpec pytorchAnnotation = AnnotationSpec.builder(dlFramework)
+            .addMember("name", "$S", "function")
+            .addMember("DeepLearningFramework", "$T.class", pytorch)
+            .build();
+
+    AnnotationSpec tfAnnotation = AnnotationSpec.builder(dlFramework)
+            .addMember("name", "$S", "function")
+            .addMember("DeepLearningFramework", "$T.class", tensorflow)
+            .build();
+
+    AnnotationSpec mxnetAnnotation = AnnotationSpec.builder(dlFramework)
+            .addMember("name", "$S", "function")
+            .addMember("DeepLearningFramework", "$T.class", mxnet)
+            .build();
+
+    AnnotationSpec.Builder builder = AnnotationSpec.builder(python);
+    AnnotationSpec pythonAnnotation = AnnotationSpec.addMembers(builder, "DeepLearningFramework", "$L"
+            , pytorchAnnotation, tfAnnotation, mxnetAnnotation).build();
+    assertThat(pythonAnnotation.toString()).isEqualTo("" +
+            "@package com.squareup.computerScience;" +
+            ".Python" +
+            "(" +
+            "DeepLearningFramework = " +
+            "{" +
+            "@package com.squareup.computerScience;" +
+            ".DeepLearningFramework" +
+            "(" +
+            "name = \"function\", DeepLearningFramework = package com.squareup.computerScience;.Pytorch.class" +
+            "), " +
+            "@package com.squareup.computerScience;" +
+            ".DeepLearningFramework" +
+            "(" +
+            "name = \"function\", DeepLearningFramework = package com.squareup.computerScience;.Tensorflow.class" +
+            "), " +
+            "@package com.squareup.computerScience;" +
+            ".DeepLearningFramework" +
+            "(" +
+            "name = \"function\", DeepLearningFramework = package com.squareup.computerScience;.MXNet.class" +
+            ")" +
+            "}" +
+            ")\n");
+  }
+
   private String toString(TypeSpec typeSpec) {
     return JavaFile.builder("com.squareup.tacos", typeSpec).build().toString();
   }


### PR DESCRIPTION
based on the idea in the comment #541, I added these three static method to add members to AnnotationSpec.Builder in AnnotationSpec.java, two method for adding the AnnotationSpec and one method for adding the CodeBlock.