### PR TITLE
Add Method Spec API

### DIFF
--- a/src/main/java/com/squareup/javapoet/MethodSpec.java
+++ b/src/main/java/com/squareup/javapoet/MethodSpec.java
@@ -276,6 +276,34 @@ public final class MethodSpec {
     return builder;
   }
 
+  /**
+   * Returns a new method spec builder that overrides the method
+   * <p>This will copy its visibility modifiers, type parameters, return type, name, parameters, and
+   * throws declarations. An {@link Override} annotation will be added.
+   * @param method
+   * @param executableType
+   * @return
+   */
+  public static Builder overriding(
+          ExecutableElement method, ExecutableType executableType) {
+    List<? extends TypeMirror> resolvedParameterTypes = executableType.getParameterTypes();
+    List<? extends TypeMirror> resolvedThrownTypes = executableType.getThrownTypes();
+    TypeMirror resolvedReturnType = executableType.getReturnType();
+
+    Builder builder = overriding(method);
+    builder.returns(TypeName.get(resolvedReturnType));
+    for (int i = 0, size = builder.parameters.size(); i < size; i++) {
+      ParameterSpec parameter = builder.parameters.get(i);
+      TypeName type = TypeName.get(resolvedParameterTypes.get(i));
+      builder.parameters.set(i, parameter.toBuilder(type, parameter.name).build());
+    }
+    builder.exceptions.clear();
+    for (int i = 0, size = resolvedThrownTypes.size(); i < size; i++) {
+      builder.addException(TypeName.get(resolvedThrownTypes.get(i)));
+    }
+    return builder;
+  }
+
   public Builder toBuilder() {
     Builder builder = new Builder(name);
     builder.javadoc.add(javadoc);

--- a/src/test/java/com/squareup/javapoet/MethodSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/MethodSpecTest.java
@@ -31,6 +31,7 @@ import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.ExecutableType;
 import javax.lang.model.util.ElementFilter;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
@@ -179,6 +180,38 @@ public final class MethodSpecTest {
         + "@java.lang.Override\n"
         + "public java.lang.String toString() {\n"
         + "}\n");
+  }
+
+  @Test public void override1() {
+    TypeElement classElement = getElement(ExtendsIterableWithDefaultMethods.class);
+    DeclaredType classType = (DeclaredType) classElement.asType();
+    List<ExecutableElement> methods = methodsIn(elements.getAllMembers(classElement));
+    ExecutableElement exec = findFirst(methods, "spliterator");
+    ExecutableType executableType = (ExecutableType) types.asMemberOf(classType, exec);
+    MethodSpec method = MethodSpec.overriding(exec, executableType).build();
+    assertThat(method.toString()).isEqualTo(""
+            + "@java.lang.Override\n"
+            + "public java.util.Spliterator<java.lang.Object> spliterator() {\n"
+            + "}\n");
+  }
+
+  @Test public void override2() {
+    TypeElement classElement = getElement(ExtendsOthers.class);
+    DeclaredType classType = (DeclaredType) classElement.asType();
+    List<ExecutableElement> methods = methodsIn(elements.getAllMembers(classElement));
+    ExecutableElement exec = findFirst(methods, "call");
+    MethodSpec method = MethodSpec.overriding(exec, classType, types).build();
+    assertThat(method.toString()).isEqualTo(""
+            + "@java.lang.Override\n"
+            + "public java.lang.Integer call() throws java.lang.Exception {\n"
+            + "}\n");
+    exec = findFirst(methods, "compareTo");
+    ExecutableType executableType = (ExecutableType) types.asMemberOf(classType, exec);
+    method = MethodSpec.overriding(exec, executableType).build();
+    assertThat(method.toString()).isEqualTo(""
+            + "@java.lang.Override\n"
+            + "public int compareTo(" + ExtendsOthers.class.getCanonicalName() + " arg0) {\n"
+            + "}\n");
   }
 
   @Test public void overrideDoesNotCopyDefaultModifier() {


### PR DESCRIPTION
The following API exists to override a method as a member of the DeclaredType:

```
MethodSpec.Builder.overriding(ExecutableElement, DeclaredType, Types)
```
This is inconvenient in certain cases because it requires a Types instance. For instance, if your code generation layer only interacts with model objects and no longer has access to the ProcessingEnvironment the following API would be more convenient:

```
MethodSpec.Builder.overriding(ExecutableElement, ExecutableType)
```