### PR TITLE
Add Java literal support for $L literal for issue #488

### DIFF
--- a/src/main/java/com/squareup/javapoet/AnnotationSpec.java
+++ b/src/main/java/com/squareup/javapoet/AnnotationSpec.java
@@ -229,9 +229,6 @@ public final class AnnotationSpec {
       if (value instanceof String) {
         return addMember(memberName, "$S", value);
       }
-      if (value instanceof Float) {
-        return addMember(memberName, "$Lf", value);
-      }
       if (value instanceof Character) {
         return addMember(memberName, "'$L'", characterLiteralWithoutSingleQuotes((char) value));
       }

--- a/src/main/java/com/squareup/javapoet/CodeWriter.java
+++ b/src/main/java/com/squareup/javapoet/CodeWriter.java
@@ -363,6 +363,10 @@ final class CodeWriter {
     } else if (o instanceof CodeBlock) {
       CodeBlock codeBlock = (CodeBlock) o;
       emit(codeBlock);
+    } else if (o instanceof Long) {
+      emitAndIndent(String.valueOf(o) + "L");
+    } else if (o instanceof Float) {
+      emitAndIndent(String.valueOf(o) + "f");
     } else {
       emitAndIndent(String.valueOf(o));
     }

--- a/src/test/java/com/squareup/javapoet/AnnotationSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/AnnotationSpecTest.java
@@ -313,7 +313,7 @@ public final class AnnotationSpecTest {
         + "    a = 5,\n"
         + "    b = 6,\n"
         + "    c = 7,\n"
-        + "    d = 8,\n"
+        + "    d = 8L,\n"
         + "    e = 9.0f,\n"
         + "    f = 11.1,\n"
         + "    g = {\n"

--- a/src/test/java/com/squareup/javapoet/CodeWriterTest.java
+++ b/src/test/java/com/squareup/javapoet/CodeWriterTest.java
@@ -2,6 +2,7 @@ package com.squareup.javapoet;
 
 import org.junit.Test;
 
+import javax.lang.model.element.Modifier;
 import java.io.IOException;
 
 import static com.google.common.truth.Truth.assertThat;
@@ -20,4 +21,31 @@ public class CodeWriterTest {
                         " * B\n" +
                         " */\n");
     }
+
+    @Test
+    public void floatLiteralInInitializer() throws IOException {
+        float a = 7.0f;
+        float b = 8.0f;
+        FieldSpec fieldSpec = FieldSpec.builder(Float[].class, "floatArray", Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL).
+                initializer("new Float[] { $L, $L }", a, b).build();
+
+        System.out.print(fieldSpec.toString());
+        assertThat(fieldSpec.toString()).isEqualTo(
+                "public static final java.lang.Float[] floatArray = new Float[] { 7.0f, 8.0f };\n"
+        );
+    }
+
+    @Test
+    public void LongLiteralInInitializer() throws IOException {
+        Long a = 11111111111L;
+        Long b = 22222222222L;
+        FieldSpec fieldSpec = FieldSpec.builder(Long[].class, "longArray", Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL).
+                initializer("new Long[] { $L, $L }", a, b).build();
+
+        System.out.print(fieldSpec.toString());
+        assertThat(fieldSpec.toString()).isEqualTo(
+                "public static final java.lang.Long[] longArray = new Long[] { 11111111111L, 22222222222L };\n"
+        );
+    }
+
 }


### PR DESCRIPTION
emitLiteral() is modified.
And consider it add support for float literal, the addMemberForValue() method in AnnotationSpec can delete the case for float type.
Some test added.