### PR TITLE
Only build on Java 8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,33 +3,17 @@ name: build
 on: [push, pull_request]
 
 jobs:
-  jvm:
+  build:
     runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
-      matrix:
-        java-version:
-          - 8
-          - 9
-          - 10
-          # TODO:
-          #- 11
-          #- 12
-          #- 13
-          #- 14
-          #- 15
-          #- 16
-
     steps:
       - uses: actions/checkout@v3
 
       - uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: ${{ matrix.java-version }}
+          java-version: 8
 
       - run: mvn --no-transfer-progress verify source:jar javadoc:jar
 
       - run: mvn --no-transfer-progress deploy --settings=".github/workflows/settings.xml" -Dmaven.test.skip=true
-        if: ${{ github.ref == 'refs/heads/master' && github.repository == 'square/javapoet' && matrix.java-version == '8' }}
+        if: ${{ github.ref == 'refs/heads/master' && github.repository == 'square/javapoet' }}


### PR DESCRIPTION
Running a build on different JDKs is pointless. Our users consume the artifact in binary form. We may want to run the tests on multiple JDKs. The way to do that is to migrate to Gradle, duplicate the test task, and use the toolchain feature. That is out of scope of this change, which is only to stop pointless CI builds.