### PR TITLE
Fix boxing and unboxing of annotated primitives

### DIFF
--- a/src/main/java/com/squareup/javapoet/TypeName.java
+++ b/src/main/java/com/squareup/javapoet/TypeName.java
@@ -189,15 +189,15 @@ public class TypeName {
     TypeName thisWithoutAnnotations = withoutAnnotations();
     TypeName unboxed = null;
     if (thisWithoutAnnotations.equals(BOXED_VOID)) unboxed = VOID;
-    if (thisWithoutAnnotations.equals(BOXED_BOOLEAN)) unboxed = BOOLEAN;
-    if (thisWithoutAnnotations.equals(BOXED_BYTE)) unboxed = BYTE;
-    if (thisWithoutAnnotations.equals(BOXED_SHORT)) unboxed = SHORT;
-    if (thisWithoutAnnotations.equals(BOXED_INT)) unboxed = INT;
-    if (thisWithoutAnnotations.equals(BOXED_LONG)) unboxed = LONG;
-    if (thisWithoutAnnotations.equals(BOXED_CHAR)) unboxed = CHAR;
-    if (thisWithoutAnnotations.equals(BOXED_FLOAT)) unboxed = FLOAT;
-    if (thisWithoutAnnotations.equals(BOXED_DOUBLE)) unboxed = DOUBLE;
-    if (unboxed == null) throw new UnsupportedOperationException("cannot unbox " + this);
+    else if (thisWithoutAnnotations.equals(BOXED_BOOLEAN)) unboxed = BOOLEAN;
+    else if (thisWithoutAnnotations.equals(BOXED_BYTE)) unboxed = BYTE;
+    else if (thisWithoutAnnotations.equals(BOXED_SHORT)) unboxed = SHORT;
+    else if (thisWithoutAnnotations.equals(BOXED_INT)) unboxed = INT;
+    else if (thisWithoutAnnotations.equals(BOXED_LONG)) unboxed = LONG;
+    else if (thisWithoutAnnotations.equals(BOXED_CHAR)) unboxed = CHAR;
+    else if (thisWithoutAnnotations.equals(BOXED_FLOAT)) unboxed = FLOAT;
+    else if (thisWithoutAnnotations.equals(BOXED_DOUBLE)) unboxed = DOUBLE;
+    else throw new UnsupportedOperationException("cannot unbox " + this);
     return annotations.isEmpty() ? unboxed : unboxed.annotated(annotations);
   }
 

--- a/src/main/java/com/squareup/javapoet/TypeName.java
+++ b/src/main/java/com/squareup/javapoet/TypeName.java
@@ -118,6 +118,9 @@ public class TypeName {
   }
 
   public TypeName withoutAnnotations() {
+    if (annotations.isEmpty()) {
+      return this;
+    }
     return new TypeName(keyword);
   }
 
@@ -144,14 +147,15 @@ public class TypeName {
    * other types types including unboxed primitives and {@code java.lang.Void}.
    */
   public boolean isBoxedPrimitive() {
-    return this.equals(BOXED_BOOLEAN)
-        || this.equals(BOXED_BYTE)
-        || this.equals(BOXED_SHORT)
-        || this.equals(BOXED_INT)
-        || this.equals(BOXED_LONG)
-        || this.equals(BOXED_CHAR)
-        || this.equals(BOXED_FLOAT)
-        || this.equals(BOXED_DOUBLE);
+    TypeName thisWithoutAnnotations = withoutAnnotations();
+    return thisWithoutAnnotations.equals(BOXED_BOOLEAN)
+        || thisWithoutAnnotations.equals(BOXED_BYTE)
+        || thisWithoutAnnotations.equals(BOXED_SHORT)
+        || thisWithoutAnnotations.equals(BOXED_INT)
+        || thisWithoutAnnotations.equals(BOXED_LONG)
+        || thisWithoutAnnotations.equals(BOXED_CHAR)
+        || thisWithoutAnnotations.equals(BOXED_FLOAT)
+        || thisWithoutAnnotations.equals(BOXED_DOUBLE);
   }
 
   /**
@@ -160,16 +164,18 @@ public class TypeName {
    */
   public TypeName box() {
     if (keyword == null) return this; // Doesn't need boxing.
-    if (this == VOID) return BOXED_VOID;
-    if (this == BOOLEAN) return BOXED_BOOLEAN;
-    if (this == BYTE) return BOXED_BYTE;
-    if (this == SHORT) return BOXED_SHORT;
-    if (this == INT) return BOXED_INT;
-    if (this == LONG) return BOXED_LONG;
-    if (this == CHAR) return BOXED_CHAR;
-    if (this == FLOAT) return BOXED_FLOAT;
-    if (this == DOUBLE) return BOXED_DOUBLE;
-    throw new AssertionError(keyword);
+    TypeName boxed = null;
+    if (keyword.equals(VOID.keyword)) boxed = BOXED_VOID;
+    if (keyword.equals(BOOLEAN.keyword)) boxed = BOXED_BOOLEAN;
+    if (keyword.equals(BYTE.keyword)) boxed = BOXED_BYTE;
+    if (keyword.equals(SHORT.keyword)) boxed = BOXED_SHORT;
+    if (keyword.equals(INT.keyword)) boxed = BOXED_INT;
+    if (keyword.equals(LONG.keyword)) boxed = BOXED_LONG;
+    if (keyword.equals(CHAR.keyword)) boxed = BOXED_CHAR;
+    if (keyword.equals(FLOAT.keyword)) boxed = BOXED_FLOAT;
+    if (keyword.equals(DOUBLE.keyword)) boxed = BOXED_DOUBLE;
+    if (boxed == null) throw new AssertionError("cannot box " + keyword);
+    return annotations.isEmpty() ? boxed : boxed.annotated(annotations);
   }
 
   /**
@@ -180,16 +186,19 @@ public class TypeName {
    */
   public TypeName unbox() {
     if (keyword != null) return this; // Already unboxed.
-    if (this.equals(BOXED_VOID)) return VOID;
-    if (this.equals(BOXED_BOOLEAN)) return BOOLEAN;
-    if (this.equals(BOXED_BYTE)) return BYTE;
-    if (this.equals(BOXED_SHORT)) return SHORT;
-    if (this.equals(BOXED_INT)) return INT;
-    if (this.equals(BOXED_LONG)) return LONG;
-    if (this.equals(BOXED_CHAR)) return CHAR;
-    if (this.equals(BOXED_FLOAT)) return FLOAT;
-    if (this.equals(BOXED_DOUBLE)) return DOUBLE;
-    throw new UnsupportedOperationException("cannot unbox " + this);
+    TypeName thisWithoutAnnotations = withoutAnnotations();
+    TypeName unboxed = null;
+    if (thisWithoutAnnotations.equals(BOXED_VOID)) unboxed = VOID;
+    if (thisWithoutAnnotations.equals(BOXED_BOOLEAN)) unboxed = BOOLEAN;
+    if (thisWithoutAnnotations.equals(BOXED_BYTE)) unboxed = BYTE;
+    if (thisWithoutAnnotations.equals(BOXED_SHORT)) unboxed = SHORT;
+    if (thisWithoutAnnotations.equals(BOXED_INT)) unboxed = INT;
+    if (thisWithoutAnnotations.equals(BOXED_LONG)) unboxed = LONG;
+    if (thisWithoutAnnotations.equals(BOXED_CHAR)) unboxed = CHAR;
+    if (thisWithoutAnnotations.equals(BOXED_FLOAT)) unboxed = FLOAT;
+    if (thisWithoutAnnotations.equals(BOXED_DOUBLE)) unboxed = DOUBLE;
+    if (unboxed == null) throw new UnsupportedOperationException("cannot unbox " + this);
+    return annotations.isEmpty() ? unboxed : unboxed.annotated(annotations);
   }
 
   @Override public final boolean equals(Object o) {

--- a/src/main/java/com/squareup/javapoet/TypeName.java
+++ b/src/main/java/com/squareup/javapoet/TypeName.java
@@ -166,15 +166,15 @@ public class TypeName {
     if (keyword == null) return this; // Doesn't need boxing.
     TypeName boxed = null;
     if (keyword.equals(VOID.keyword)) boxed = BOXED_VOID;
-    if (keyword.equals(BOOLEAN.keyword)) boxed = BOXED_BOOLEAN;
-    if (keyword.equals(BYTE.keyword)) boxed = BOXED_BYTE;
-    if (keyword.equals(SHORT.keyword)) boxed = BOXED_SHORT;
-    if (keyword.equals(INT.keyword)) boxed = BOXED_INT;
-    if (keyword.equals(LONG.keyword)) boxed = BOXED_LONG;
-    if (keyword.equals(CHAR.keyword)) boxed = BOXED_CHAR;
-    if (keyword.equals(FLOAT.keyword)) boxed = BOXED_FLOAT;
-    if (keyword.equals(DOUBLE.keyword)) boxed = BOXED_DOUBLE;
-    if (boxed == null) throw new AssertionError("cannot box " + keyword);
+    else if (keyword.equals(BOOLEAN.keyword)) boxed = BOXED_BOOLEAN;
+    else if (keyword.equals(BYTE.keyword)) boxed = BOXED_BYTE;
+    else if (keyword.equals(SHORT.keyword)) boxed = BOXED_SHORT;
+    else if (keyword.equals(INT.keyword)) boxed = BOXED_INT;
+    else if (keyword.equals(LONG.keyword)) boxed = BOXED_LONG;
+    else if (keyword.equals(CHAR.keyword)) boxed = BOXED_CHAR;
+    else if (keyword.equals(FLOAT.keyword)) boxed = BOXED_FLOAT;
+    else if (keyword.equals(DOUBLE.keyword)) boxed = BOXED_DOUBLE;
+    else throw new AssertionError(keyword);
     return annotations.isEmpty() ? boxed : boxed.annotated(annotations);
   }
 

--- a/src/test/java/com/squareup/javapoet/TypeNameTest.java
+++ b/src/test/java/com/squareup/javapoet/TypeNameTest.java
@@ -17,6 +17,7 @@ package com.squareup.javapoet;
 
 import java.io.Serializable;
 import java.lang.reflect.Method;
+import java.lang.reflect.Type;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
@@ -29,6 +30,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 
 public class TypeNameTest {
+
+  private static final AnnotationSpec ANNOTATION_SPEC = AnnotationSpec.builder(ClassName.OBJECT).build();
 
   protected <E extends Enum<E>> E generic(E[] values) {
     return values[0];
@@ -173,6 +176,18 @@ public class TypeNameTest {
     assertThat(ClassName.get("java.lang", "String").isBoxedPrimitive()).isFalse();
     assertThat(TypeName.VOID.isBoxedPrimitive()).isFalse();
     assertThat(ClassName.get("java.lang", "Void").isBoxedPrimitive()).isFalse();
+    assertThat(ClassName.get("java.lang", "Integer")
+            .annotated(ANNOTATION_SPEC).isBoxedPrimitive()).isTrue();
+  }
+
+  @Test public void canBoxAnnotatedPrimitive() throws Exception {
+    assertThat(TypeName.BOOLEAN.annotated(ANNOTATION_SPEC).box()).isEqualTo(
+            ClassName.get("java.lang", "Boolean").annotated(ANNOTATION_SPEC));
+  }
+
+  @Test public void canUnboxAnnotatedPrimitive() throws Exception {
+    assertThat(ClassName.get("java.lang", "Boolean").annotated(ANNOTATION_SPEC)
+            .unbox()).isEqualTo(TypeName.BOOLEAN.annotated(ANNOTATION_SPEC));
   }
 
   private void assertEqualsHashCodeAndToString(TypeName a, TypeName b) {


### PR DESCRIPTION
TypeName#box currently relies on identity comparisons between `this` and one of the primitive TypeName constants. However, it is possible to have an instance of a primitive that isn't any of those constants by calling TypeName#annotated or TypeName#withoutAnnotations. The returned TypeName instance can no longer be boxed.

TypeName#unbox and TypeName#isBoxedPrimitive have a similar issue. `this` is compared using `equals` instead of identity, but annotations are part of the compared string, so a boxed primitive with annotations is not found to be any of the existing constants. Annotated boxed TypeName instances can no longer be unboxed.

This PR changes behavior of all 3 methods to do a more appropriate comparison when trying to find the (un)boxed version of `this`. After (un)boxing, the annotations from `this` are copied onto the returned value. That way, boxing and unboxing works on both unannotated and annotated TypeNames, preserving any annotations. When no annotations are present, identity is preserved.
I added unit tests to test both boxing and unboxing. Those tests fail without the code changes in TypeName.