### PR TITLE
Add L to long values to prevent them from being interpreted as int

### DIFF
--- a/src/main/java/com/squareup/javapoet/AnnotationSpec.java
+++ b/src/main/java/com/squareup/javapoet/AnnotationSpec.java
@@ -232,6 +232,9 @@ public final class AnnotationSpec {
       if (value instanceof Float) {
         return addMember(memberName, "$Lf", value);
       }
+      if (value instanceof Long) {
+        return addMember(memberName, "$LL", value);
+      }
       if (value instanceof Character) {
         return addMember(memberName, "'$L'", characterLiteralWithoutSingleQuotes((char) value));
       }

--- a/src/test/java/com/squareup/javapoet/AnnotationSpecTest.java
+++ b/src/test/java/com/squareup/javapoet/AnnotationSpecTest.java
@@ -59,7 +59,7 @@ public final class AnnotationSpecTest {
 
     int c() default 7;
 
-    long d() default 8;
+    long d() default 12345678910L;
 
     float e() default 9.0f;
 
@@ -313,7 +313,7 @@ public final class AnnotationSpecTest {
         + "    a = 5,\n"
         + "    b = 6,\n"
         + "    c = 7,\n"
-        + "    d = 8,\n"
+        + "    d = 12345678910L,\n"
         + "    e = 9.0f,\n"
         + "    f = 11.1,\n"
         + "    g = {\n"


### PR DESCRIPTION
Fixes #993 